### PR TITLE
recommend uv over pip for installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ source .venv/bin/activate
 
 # Install in development mode with all dev dependencies
 make install
-# or: pip install -e ".[dev]"
+# or: uv pip install -e ".[dev]"
 ```
 
 ### Dev Mode
@@ -144,7 +144,7 @@ Releases are published to:
 
 3. **Build Tools**: Install Python build and upload tools:
    ```bash
-   pip install build twine
+   uv tool install build twine
    ```
 
 ### Release Process
@@ -203,11 +203,11 @@ After publishing, test the installed experience in a fresh environment:
 
 ```bash
 # Create a fresh test environment
-python -m venv /tmp/test-paude
+uv venv /tmp/test-paude
 source /tmp/test-paude/bin/activate
 
 # Install from PyPI
-pip install paude
+uv pip install paude
 
 # Test basic commands
 paude --version

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ _Video walkthrough coming soon. Follow the Quick Start below to try it yourself.
 ### Install
 
 ```bash
-pip install paude
+uv tool install paude
 ```
 
 > **First run**: Paude pulls container images on first use. This takes a few minutes; subsequent runs start immediately.
@@ -117,15 +117,7 @@ Your Machine                    Container
 - **`--yolo` is safe** because network filtering blocks Claude from sending data to arbitrary URLs
 - Claude can only reach Vertex AI (for the API) and PyPI (for packages) by default
 
-## Installation
-
-### Using pip
-
-```bash
-pip install paude
-```
-
-### From source
+## Install from source
 
 ```bash
 git clone https://github.com/bbrowning/paude


### PR DESCRIPTION
`uv` is a modern replacement for `pip` and `venv`.

`uv tool install` automatically places `paude` into its own virtualenv that does not conflict with anything else. It makes it easier to upgrade and isolate `paude` automatically.
