### PR TITLE
use Podman secrets for gcloud ADC credentials

### DIFF
--- a/src/paude/mounts.py
+++ b/src/paude/mounts.py
@@ -31,12 +31,13 @@ def build_mounts(workspace: Path, home: Path) -> list[str]:
     Note: Workspace is NOT mounted here - it uses a named volume at /pvc/workspace.
     Users sync code via git remote (paude remote add + git push/pull).
 
+    Note: gcloud ADC credentials are injected via Podman secrets, not bind mounts.
+
     Mounts (in order):
-    1. gcloud config (ro, if exists)
-    2. Claude seed directory (ro, if exists)
-    3. Plugins at original host path (ro, if exists)
-    4. gitconfig (ro, if exists)
-    5. claude.json seed (ro, if exists)
+    1. Claude seed directory (ro, if exists)
+    2. Plugins at original host path (ro, if exists)
+    3. gitconfig (ro, if exists)
+    4. claude.json seed (ro, if exists)
 
     Args:
         workspace: Path to the workspace directory (for reference, not mounted).
@@ -46,12 +47,6 @@ def build_mounts(workspace: Path, home: Path) -> list[str]:
         List of mount argument strings (e.g., ["-v", "/path:/path:rw", ...]).
     """
     mounts: list[str] = []
-
-    # gcloud config (ro)
-    gcloud_dir = home / ".config" / "gcloud"
-    resolved_gcloud = resolve_path(gcloud_dir)
-    if resolved_gcloud and resolved_gcloud.is_dir():
-        mounts.extend(["-v", f"{resolved_gcloud}:/home/paude/.config/gcloud:ro"])
 
     # Claude seed directory (ro)
     claude_dir = home / ".claude"

--- a/tests/test_mounts.py
+++ b/tests/test_mounts.py
@@ -25,8 +25,8 @@ class TestBuildMounts:
         # Workspace should NOT be in mounts - it uses a named volume at /pvc
         assert str(workspace) not in mount_str
 
-    def test_gcloud_mount_read_only(self, tmp_path: Path):
-        """gcloud mount is read-only when .config/gcloud exists."""
+    def test_gcloud_not_bind_mounted(self, tmp_path: Path):
+        """gcloud directory is not bind mounted (uses Podman secrets instead)."""
         workspace = tmp_path / "workspace"
         workspace.mkdir()
         home = tmp_path / "home"
@@ -37,20 +37,6 @@ class TestBuildMounts:
         mounts = build_mounts(workspace, home)
         mount_str = " ".join(mounts)
 
-        assert "/home/paude/.config/gcloud:ro" in mount_str
-
-    def test_gcloud_mount_skipped_when_missing(self, tmp_path: Path):
-        """gcloud mount skipped when directory missing."""
-        workspace = tmp_path / "workspace"
-        workspace.mkdir()
-        home = tmp_path / "home"
-        home.mkdir()
-        # Don't create gcloud dir
-
-        mounts = build_mounts(workspace, home)
-        mount_str = " ".join(mounts)
-
-        # Check that .config/gcloud mount is not present (not just "gcloud" substring)
         assert ".config/gcloud" not in mount_str
 
     def test_claude_seed_mount_read_only(self, tmp_path: Path):


### PR DESCRIPTION
The gcloud bind mount fails silently when SELinux is in enforcing mode.

Even without SELinux, the container cannot read the file with rootless UID mapping.

Use Podman secrets to inject the credentials with tmpfs. This is a best-practice for secrets handling, and it bypasses the SELinux problem.

Fixes: #2 