### PR TITLE
Bind-mount host workspace for local podman sessions

### DIFF
--- a/src/paude/backends/podman/backend.py
+++ b/src/paude/backends/podman/backend.py
@@ -320,6 +320,11 @@ class PodmanBackend:
         mounts = list(config.mounts)
         mounts.extend(["-v", f"{vname}:/pvc"])
 
+        # Bind-mount host workspace directly for local sessions (avoids
+        # the git-remote sync step, which is slow for large repos).
+        if not self._engine.is_remote:
+            mounts.extend(["-v", f"{config.workspace}:{CONTAINER_WORKSPACE}:z"])
+
         proxy_name_for_env = (
             (proxy_ip or proxy_container_name(session_name))
             if config.proxy_image


### PR DESCRIPTION
For local podman sessions, bind-mount the host workspace directory directly to /pvc/workspace instead of requiring git remote setup. This makes code immediately available in the container, which is especially important for large repos where git push is slow.

SSH remote sessions continue to use the named volume + git remote flow.