### PR TITLE
fix uv install to fail properly on download errors

### DIFF
--- a/containers/paude/Dockerfile
+++ b/containers/paude/Dockerfile
@@ -45,10 +45,10 @@ ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
 # Install uv package manager system-wide (available to root for pip_install builds)
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/local/bin sh \
+RUN curl -LsSf https://astral.sh/uv/install.sh -o /tmp/uv-install.sh \
+    && UV_INSTALL_DIR=/usr/local/bin sh /tmp/uv-install.sh \
+    && rm /tmp/uv-install.sh \
     && uv --version
-SHELL ["/bin/sh", "-c"]
 
 # Install tini init process for zombie reaping (not available in EPEL 10)
 ARG TINI_VERSION=v0.19.0


### PR DESCRIPTION
- Podman and Buildah default to OCI image format, which does not support the `SHELL` Dockerfile instruction (https://github.com/containers/buildah/issues/6460). Podman was ignoring `SHELL`, so `pipefail` was never active. A failed `curl` piped into `sh` could exit zero and produce a broken image.
- Replace the piped `curl | sh` with a download-then-execute pattern. Each step in the `&&` chain fails the build independently.

Claude and I have run the following steps

- [x] `make clean && make build` completes without the `SHELL is not supported for OCI image format` warning
- [x] `uv --version` works in the built image
- [x] `/tmp/uv-install.sh` temp file is cleaned up
- [x] Changing the URL to a bogus path fails the build at the `curl` step (exit status 22)