### PR TITLE
Double proxy pod memory to fix OOMKills during uv install

### DIFF
--- a/src/paude/backends/openshift/proxy.py
+++ b/src/paude/backends/openshift/proxy.py
@@ -339,8 +339,8 @@ class ProxyManager:
                                     {"secretRef": {"name": creds_secret}},
                                 ],
                                 "resources": {
-                                    "requests": {"cpu": "100m", "memory": "128Mi"},
-                                    "limits": {"cpu": "500m", "memory": "256Mi"},
+                                    "requests": {"cpu": "100m", "memory": "256Mi"},
+                                    "limits": {"cpu": "500m", "memory": "512Mi"},
                                 },
                                 "volumeMounts": [
                                     {


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
