### PR TITLE
Add Codex CLI agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Run AI coding agents in secure containers. They make commits, you pull them back
 | Agent | Flag | Status |
 |-------|------|--------|
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | `--agent claude` (default) | Supported |
+| [Codex CLI](https://github.com/openai/codex) | `--agent codex` | Supported |
 | [Cursor CLI](https://docs.cursor.com/cli) | `--agent cursor` | Supported |
 | [Gas City](https://github.com/gastownhall/gascity) | `--agent gascity` | Supported |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `--agent gemini` | Supported |
@@ -74,7 +75,7 @@ paude create --agent openclaw --provider anthropic ...
 </details>
 
 <details>
-<summary><strong>OpenAI API key</strong> (OpenClaw)</summary>
+<summary><strong>OpenAI API key</strong> (Codex CLI, OpenClaw)</summary>
 
 ```bash
 export OPENAI_API_KEY=your-api-key
@@ -111,6 +112,9 @@ paude create --agent openclaw --allowed-domains "default openclaw" my-project
 # Claude Code (default)
 cd your-project
 paude create --yolo --git my-project
+
+# Codex CLI
+paude create --agent codex --yolo --git my-project
 
 # Cursor CLI
 paude create --agent cursor --yolo --git my-project

--- a/src/paude/agents/__init__.py
+++ b/src/paude/agents/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from paude.agents.base import Agent, AgentConfig
 from paude.agents.claude import ClaudeAgent
+from paude.agents.codex import CodexAgent
 from paude.agents.cursor import CursorAgent
 from paude.agents.gascity import GascityAgent
 from paude.agents.gemini import GeminiAgent
@@ -13,6 +14,7 @@ __all__ = [
     "Agent",
     "AgentConfig",
     "ClaudeAgent",
+    "CodexAgent",
     "CursorAgent",
     "GascityAgent",
     "GeminiAgent",
@@ -23,6 +25,7 @@ __all__ = [
 
 _REGISTRY: dict[str, type] = {
     "claude": ClaudeAgent,
+    "codex": CodexAgent,
     "cursor": CursorAgent,
     "gascity": GascityAgent,
     "gemini": GeminiAgent,

--- a/src/paude/agents/codex.py
+++ b/src/paude/agents/codex.py
@@ -1,0 +1,87 @@
+"""Codex CLI agent implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from paude.agents.base import (
+    AgentConfig,
+    build_environment_from_config,
+    build_provider_credentials,
+    pipefail_install_lines,
+)
+
+CODEX_VERSION = "0.132.0"
+
+_INSTALL_SCRIPT = (
+    'mkdir -p "$HOME/.local/bin" && '
+    "ARCH=$(uname -m) && "
+    'case "$ARCH" in '
+    'x86_64) CODEX_ARCH="x86_64-unknown-linux-musl" ;; '
+    'aarch64) CODEX_ARCH="aarch64-unknown-linux-musl" ;; '
+    '*) echo "Unsupported architecture: $ARCH" && exit 1 ;; '
+    "esac && "
+    "curl -fsSL "
+    '"https://github.com/openai/codex/releases/download/'
+    f"rust-v{CODEX_VERSION}"
+    '/codex-${CODEX_ARCH}.tar.gz"'
+    ' | tar xz -C "$HOME/.local/bin" "codex-${CODEX_ARCH}" && '
+    'mv "$HOME/.local/bin/codex-${CODEX_ARCH}" "$HOME/.local/bin/codex"'
+)
+
+
+class CodexAgent:
+    """Codex CLI agent implementation."""
+
+    def __init__(self, provider: str | None = None) -> None:
+        creds = build_provider_credentials("codex", provider)
+        self._config = AgentConfig(
+            name="codex",
+            display_name="Codex CLI",
+            process_name="codex",
+            session_name="codex",
+            install_script=_INSTALL_SCRIPT,
+            install_dir=".local/bin",
+            env_vars=creds.extra_env_vars,
+            passthrough_env_vars=creds.passthrough_env_vars,
+            secret_env_vars=creds.secret_env_vars,
+            passthrough_env_prefixes=creds.passthrough_env_prefixes,
+            config_dir_name=".codex",
+            config_file_name=None,
+            activity_files=[],
+            yolo_flag="--dangerously-bypass-approvals-and-sandbox",
+            clear_command=None,
+            extra_domain_aliases=["codex"],
+            provider=creds.resolved_provider_name,
+        )
+
+    @property
+    def config(self) -> AgentConfig:
+        return self._config
+
+    def dockerfile_install_lines(self, container_home: str) -> list[str]:
+        return [
+            "",
+            "# Install Codex CLI",
+            "USER paude",
+            f"WORKDIR {container_home}",
+            *pipefail_install_lines(self._config, container_home),
+            "",
+            f'ENV PATH="{container_home}/{self._config.install_dir}:$PATH"',
+        ]
+
+    def apply_sandbox_config(
+        self, home: str, workspace: str, args: str, *, yolo: bool = False
+    ) -> str:
+        return f'#!/bin/bash\nmkdir -p "{home}/.codex" 2>/dev/null || true\n'
+
+    def launch_command(self, args: str) -> str:
+        if args:
+            return f"codex {args}"
+        return "codex"
+
+    def host_config_mounts(self, home: Path) -> list[str]:
+        return []
+
+    def build_environment(self) -> dict[str, str]:
+        return build_environment_from_config(self._config)

--- a/src/paude/cli/help.py
+++ b/src/paude/cli/help.py
@@ -157,6 +157,7 @@ _SECTIONS: tuple[HelpSection, ...] = (
         title="Agents & Providers",
         rows=(
             ("--agent claude", "Claude Code (default)"),
+            ("--agent codex", "Codex CLI"),
             ("--agent cursor", "Cursor CLI"),
             ("--agent gascity", "Gas City (multi-agent orchestration)"),
             ("--agent gemini", "Gemini CLI"),

--- a/src/paude/providers/agent_providers.py
+++ b/src/paude/providers/agent_providers.py
@@ -32,6 +32,9 @@ AGENT_PROVIDERS: dict[str, dict[str, AgentProviderConfig]] = {
         ),
         "anthropic": AgentProviderConfig(),
     },
+    "codex": {
+        "openai": AgentProviderConfig(),
+    },
     "openclaw": {
         "vertex": AgentProviderConfig(
             model_config={"primary": "anthropic-vertex/claude-sonnet-4-6"},
@@ -59,6 +62,7 @@ AGENT_PROVIDERS: dict[str, dict[str, AgentProviderConfig]] = {
 # Default provider for each agent (used when --provider is not specified).
 DEFAULT_PROVIDER: dict[str, str] = {
     "claude": "vertex",
+    "codex": "openai",
     "gascity": "vertex",
     "openclaw": "vertex",
     "cursor": "cursor",

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -15,6 +15,7 @@ from paude.agents.base import (
     pipefail_install_lines,
 )
 from paude.agents.claude import ClaudeAgent
+from paude.agents.codex import CODEX_VERSION, CodexAgent
 from paude.agents.cursor import CursorAgent
 from paude.agents.gascity import GascityAgent
 from paude.agents.gemini import GeminiAgent
@@ -37,6 +38,10 @@ class TestRegistry:
         with pytest.raises(ValueError, match="Unknown agent 'nonexistent'"):
             get_agent("nonexistent")
 
+    def test_get_agent_codex(self) -> None:
+        agent = get_agent("codex")
+        assert isinstance(agent, CodexAgent)
+
     def test_get_agent_cursor(self) -> None:
         agent = get_agent("cursor")
         assert isinstance(agent, CursorAgent)
@@ -55,13 +60,15 @@ class TestRegistry:
 
     def test_get_agent_error_lists_available(self) -> None:
         with pytest.raises(
-            ValueError, match="Available: claude, cursor, gascity, gemini, openclaw"
+            ValueError,
+            match="Available: claude, codex, cursor, gascity, gemini, openclaw",
         ):
             get_agent("bad")
 
     def test_list_agents(self) -> None:
         agents = list_agents()
         assert "claude" in agents
+        assert "codex" in agents
         assert "cursor" in agents
         assert "gascity" in agents
         assert "gemini" in agents
@@ -281,6 +288,215 @@ class TestClaudeAgentSandboxConfig:
             "/home/paude", "/workspace", "--dangerously-skip-permissions"
         )
         assert "skipDangerousModePermissionPrompt" not in script
+
+
+class TestCodexAgentConfig:
+    """Tests for CodexAgent configuration values."""
+
+    def test_name(self) -> None:
+        assert CodexAgent().config.name == "codex"
+
+    def test_display_name(self) -> None:
+        assert CodexAgent().config.display_name == "Codex CLI"
+
+    def test_process_name(self) -> None:
+        assert CodexAgent().config.process_name == "codex"
+
+    def test_session_name(self) -> None:
+        assert CodexAgent().config.session_name == "codex"
+
+    def test_install_script(self) -> None:
+        cfg = CodexAgent().config
+        assert "openai/codex" in cfg.install_script
+
+    def test_install_script_contains_version(self) -> None:
+        cfg = CodexAgent().config
+        assert CODEX_VERSION in cfg.install_script
+
+    def test_config_dir_name(self) -> None:
+        assert CodexAgent().config.config_dir_name == ".codex"
+
+    def test_config_file_name_is_none(self) -> None:
+        assert CodexAgent().config.config_file_name is None
+
+    def test_yolo_flag(self) -> None:
+        assert (
+            CodexAgent().config.yolo_flag
+            == "--dangerously-bypass-approvals-and-sandbox"
+        )
+
+    def test_clear_command_is_none(self) -> None:
+        assert CodexAgent().config.clear_command is None
+
+    def test_secret_env_vars(self) -> None:
+        cfg = CodexAgent().config
+        assert "OPENAI_API_KEY" in cfg.secret_env_vars
+
+    def test_passthrough_vars_empty(self) -> None:
+        assert CodexAgent().config.passthrough_env_vars == []
+
+    def test_passthrough_prefixes_empty(self) -> None:
+        assert CodexAgent().config.passthrough_env_prefixes == []
+
+    def test_extra_domain_aliases(self) -> None:
+        assert CodexAgent().config.extra_domain_aliases == ["codex"]
+
+    def test_env_vars_empty(self) -> None:
+        assert CodexAgent().config.env_vars == {}
+
+    def test_activity_files_empty(self) -> None:
+        assert CodexAgent().config.activity_files == []
+
+    def test_exposed_ports_empty(self) -> None:
+        assert CodexAgent().config.exposed_ports == []
+
+    def test_default_base_image_is_none(self) -> None:
+        assert CodexAgent().config.default_base_image is None
+
+
+class TestCodexAgentDockerfile:
+    """Tests for CodexAgent.dockerfile_install_lines."""
+
+    def test_returns_list(self) -> None:
+        lines = CodexAgent().dockerfile_install_lines("/home/paude")
+        assert isinstance(lines, list)
+        assert len(lines) > 0
+
+    def test_contains_install_url(self) -> None:
+        lines = CodexAgent().dockerfile_install_lines("/home/paude")
+        text = "\n".join(lines)
+        assert "openai/codex" in text
+
+    def test_contains_version(self) -> None:
+        lines = CodexAgent().dockerfile_install_lines("/home/paude")
+        text = "\n".join(lines)
+        assert CODEX_VERSION in text
+
+    def test_contains_arch_detection(self) -> None:
+        lines = CodexAgent().dockerfile_install_lines("/home/paude")
+        text = "\n".join(lines)
+        assert "uname -m" in text
+
+    def test_contains_x86_64_arch(self) -> None:
+        lines = CodexAgent().dockerfile_install_lines("/home/paude")
+        text = "\n".join(lines)
+        assert "x86_64-unknown-linux-musl" in text
+
+    def test_contains_aarch64_arch(self) -> None:
+        lines = CodexAgent().dockerfile_install_lines("/home/paude")
+        text = "\n".join(lines)
+        assert "aarch64-unknown-linux-musl" in text
+
+    def test_sets_path(self) -> None:
+        lines = CodexAgent().dockerfile_install_lines("/home/paude")
+        text = "\n".join(lines)
+        assert "/home/paude/.local/bin" in text
+
+    def test_uses_container_home(self) -> None:
+        lines = CodexAgent().dockerfile_install_lines("/custom/home")
+        text = "\n".join(lines)
+        assert "/custom/home" in text
+
+    def test_pipefail_shell(self) -> None:
+        lines = CodexAgent().dockerfile_install_lines("/home/paude")
+        text = "\n".join(lines)
+        assert "pipefail" in text
+
+    def test_binary_verification(self) -> None:
+        lines = CodexAgent().dockerfile_install_lines("/home/paude")
+        text = "\n".join(lines)
+        assert "test -x /home/paude/.local/bin/codex" in text
+
+    def test_shell_reset(self) -> None:
+        lines = CodexAgent().dockerfile_install_lines("/home/paude")
+        assert 'SHELL ["/bin/sh", "-c"]' in lines
+
+    def test_error_message(self) -> None:
+        lines = CodexAgent().dockerfile_install_lines("/home/paude")
+        text = "\n".join(lines)
+        assert "ERROR" in text
+        assert "installation failed" in text
+
+    def test_contains_umask(self) -> None:
+        lines = CodexAgent().dockerfile_install_lines("/home/paude")
+        text = "\n".join(lines)
+        assert "umask 0002" in text
+
+
+class TestCodexAgentLaunchCommand:
+    """Tests for CodexAgent.launch_command."""
+
+    def test_no_args(self) -> None:
+        assert CodexAgent().launch_command("") == "codex"
+
+    def test_with_args(self) -> None:
+        assert CodexAgent().launch_command("--flag") == "codex --flag"
+
+
+class TestCodexAgentHostConfigMounts:
+    """Tests for CodexAgent.host_config_mounts."""
+
+    def test_empty_when_no_config(self, tmp_path: Path) -> None:
+        mounts = CodexAgent().host_config_mounts(tmp_path)
+        assert mounts == []
+
+    def test_empty_when_dir_exists(self, tmp_path: Path) -> None:
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        mounts = CodexAgent().host_config_mounts(tmp_path)
+        assert mounts == []
+
+
+class TestCodexAgentBuildEnvironment:
+    """Tests for CodexAgent.build_environment."""
+
+    def test_empty_when_no_vars_set(self) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            env = CodexAgent().build_environment()
+            assert env == {}
+
+    def test_does_not_include_secret_vars(self) -> None:
+        with patch.dict(
+            "os.environ",
+            {"OPENAI_API_KEY": "sk-test", "UNRELATED": "x"},
+            clear=True,
+        ):
+            env = CodexAgent().build_environment()
+            assert "OPENAI_API_KEY" not in env
+
+    def test_secret_env_collects_openai_key(self) -> None:
+        with patch.dict(
+            "os.environ",
+            {"OPENAI_API_KEY": "sk-test", "UNRELATED": "x"},
+            clear=True,
+        ):
+            env = build_secret_environment_from_config(CodexAgent().config)
+            assert env == {"OPENAI_API_KEY": "sk-test"}
+
+
+class TestCodexAgentSandboxConfig:
+    """Tests for CodexAgent.apply_sandbox_config."""
+
+    def test_returns_bash_script(self) -> None:
+        script = CodexAgent().apply_sandbox_config("/home/paude", "/workspace", "")
+        assert script.startswith("#!/bin/bash")
+
+    def test_creates_config_dir(self) -> None:
+        script = CodexAgent().apply_sandbox_config("/home/paude", "/workspace", "")
+        assert ".codex" in script
+
+    def test_home_path_parameterized(self) -> None:
+        script = CodexAgent().apply_sandbox_config("/custom/home", "/workspace", "")
+        assert "/custom/home/.codex" in script
+
+    def test_yolo_does_not_change_config(self) -> None:
+        script_normal = CodexAgent().apply_sandbox_config(
+            "/home/paude", "/workspace", ""
+        )
+        script_yolo = CodexAgent().apply_sandbox_config(
+            "/home/paude", "/workspace", "", yolo=True
+        )
+        assert script_normal == script_yolo
 
 
 class TestGeminiAgentConfig:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -98,6 +98,15 @@ class TestAgentProviderResolution:
         _, agent_cfg = resolve_agent_provider("openclaw", "anthropic")
         assert agent_cfg.model_config["primary"] == "anthropic/claude-opus-4-6"
 
+    def test_resolve_codex_openai(self) -> None:
+        provider, agent_cfg = resolve_agent_provider("codex", "openai")
+        assert provider.name == "openai"
+        assert isinstance(agent_cfg, AgentProviderConfig)
+
+    def test_resolve_codex_default(self) -> None:
+        provider, _ = resolve_agent_provider("codex")
+        assert provider.name == "openai"
+
     def test_resolve_cursor_cursor(self) -> None:
         provider, _ = resolve_agent_provider("cursor", "cursor")
         assert provider.name == "cursor"
@@ -147,6 +156,9 @@ class TestDefaultProviders:
     def test_gascity_default_is_vertex(self) -> None:
         assert DEFAULT_PROVIDER["gascity"] == "vertex"
 
+    def test_codex_default_is_openai(self) -> None:
+        assert DEFAULT_PROVIDER["codex"] == "openai"
+
     def test_gemini_default_is_google(self) -> None:
         assert DEFAULT_PROVIDER["gemini"] == "google"
 
@@ -173,6 +185,10 @@ class TestSupportedProviders:
         assert "vertex" in providers
         assert "openai" in providers
         assert "anthropic" in providers
+
+    def test_codex_providers(self) -> None:
+        providers = supported_providers("codex")
+        assert providers == ["openai"]
 
     def test_gascity_providers(self) -> None:
         providers = supported_providers("gascity")


### PR DESCRIPTION
Add the OpenAI Codex CLI as a supported agent, installing v0.132.0
from GitHub releases as a static musl binary with architecture
detection for x86_64 and aarch64. Uses the existing OpenAI provider
for OPENAI_API_KEY authentication and supports YOLO mode via
--dangerously-bypass-approvals-and-sandbox.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
