### PR TITLE
Add chatgpt.com domain support for Codex CLI agent

### DIFF
--- a/containers/proxy/Dockerfile
+++ b/containers/proxy/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage — compile paude-proxy from source
 FROM golang:1.23 AS builder
 WORKDIR /app
-ARG PAUDE_PROXY_VERSION=cd70cedb8ccfeee9728c9b070d667c32ad8c6608
+ARG PAUDE_PROXY_VERSION=47eb7703c1663ee61cc0622e0bd604ff472c3449
 RUN git init . && \
     git fetch --depth 1 https://github.com/bbrowning/paude-proxy.git ${PAUDE_PROXY_VERSION} && \
     git checkout FETCH_HEAD && \

--- a/src/paude/domains.py
+++ b/src/paude/domains.py
@@ -24,6 +24,9 @@ DOMAIN_ALIASES: dict[str, list[str]] = {
         ".claude.ai",
         ".anthropic.com",
     ],
+    "codex": [
+        ".chatgpt.com",
+    ],
     "gemini": [
         "cloudcode-pa.googleapis.com",
         "play.googleapis.com",

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -454,6 +454,34 @@ class TestClaudeAlias:
         assert len(result) == len(set(result))
 
 
+class TestCodexAlias:
+    """Tests for the 'codex' domain alias."""
+
+    def test_codex_alias_exists(self):
+        """'codex' alias exists in DOMAIN_ALIASES."""
+        assert "codex" in DOMAIN_ALIASES
+
+    def test_codex_not_in_defaults(self):
+        """'codex' is NOT in DEFAULT_ALIASES (opt-in only via extra_domain_aliases)."""
+        assert "codex" not in DEFAULT_ALIASES
+
+    def test_codex_has_chatgpt(self):
+        """'codex' expands to include .chatgpt.com."""
+        result = expand_domains(["codex"])
+        assert ".chatgpt.com" in result
+
+    def test_codex_does_not_include_openai(self):
+        """'codex' alias does NOT include .openai.com (covered by 'openai' alias)."""
+        result = expand_domains(["codex"])
+        assert ".openai.com" not in result
+
+    def test_codex_in_format_display(self):
+        """format_domains_for_display recognizes codex alias."""
+        domains = expand_domains(["codex"])
+        result = format_domains_for_display(domains)
+        assert "codex" in result
+
+
 class TestGithubAlias:
     """Tests for the 'github' domain alias."""
 


### PR DESCRIPTION
The Codex agent declared extra_domain_aliases=["codex"] but no "codex"
entry existed in DOMAIN_ALIASES, so chatgpt.com traffic was blocked.
Add the alias with .chatgpt.com and bump paude-proxy to include
credential injection for chatgpt.com domains.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
