### PR TITLE
Add missing click dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Topic :: Software Development :: Build Tools",
 ]
 dependencies = [
+    "click>=8.0.0",
     "typer>=0.9.0",
     "rich>=13.0.0",
 ]


### PR DESCRIPTION
## Summary
- Add `click>=8.0.0` as an explicit dependency — the code imports `click` directly (e.g. `paude/cli/help.py`), but it was only available as a transitive dependency of `typer`
- Typer 0.26.x dropped its hard dependency on `click`, causing `ModuleNotFoundError: No module named 'click'` when installed via `uv tool install`

## Test plan
- `uv tool install .` and verify `paude --help` runs without import errors