### PR TITLE
Fix Docker rejecting Podman-style network:ip= syntax on agent container

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -20,6 +20,7 @@ Technical debt identified during codebase analysis. Address these before adding 
 **Still open — files exceeding 400-line limit:**
 - `cli/commands.py` — 580 lines
 - `workflow.py` — 467 lines
+- `container/runner.py` — 442 lines
 
 **Still open — methods exceeding 50-line limit:**
 - `workflow.py` — `harvest_session()` (~102 lines), `status_sessions()` (~84), `reset_session()` (~72)

--- a/src/paude/container/engine.py
+++ b/src/paude/container/engine.py
@@ -118,6 +118,17 @@ class ContainerEngine:
             return ["--gpus", gpu_value]
         return ["--device", f"nvidia.com/gpu={gpu_value}"]
 
+    def network_args(self, network: str, network_ip: str | None = None) -> list[str]:
+        """Build ``--network`` arguments, embedding a static IP if given.
+
+        Podman embeds the IP in the ``--network`` value (``net:ip=...``);
+        Docker requires the IP as a separate ``--ip`` flag.
+        """
+        if network_ip and not self.is_podman:
+            return ["--network", network, "--ip", network_ip]
+        net_spec = f"{network}:ip={network_ip}" if network_ip else network
+        return ["--network", net_spec]
+
     @property
     def image_name_format(self) -> str:
         """Go template for extracting image name from container inspect.

--- a/src/paude/container/runner.py
+++ b/src/paude/container/runner.py
@@ -137,8 +137,7 @@ class ContainerRunner:
             args.extend(self._engine.gpu_args(gpu))
 
         if network:
-            net_spec = f"{network}:ip={network_ip}" if network_ip else network
-            args.extend(["--network", net_spec])
+            args.extend(self._engine.network_args(network, network_ip))
 
         if dns:
             for server in dns:

--- a/tests/test_docker_compat.py
+++ b/tests/test_docker_compat.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from paude.agents.codex import (
     CODEX_CHATGPT_PROFILE_TARGET,
     SYNTHETIC_CODEX_PROFILE_TOML,
@@ -100,6 +102,73 @@ class TestDockerMultiNetwork:
         proxy = ProxyRunner(runner)
         # Should be a no-op, no subprocess call
         proxy._connect_bridge_if_needed("my-proxy")
+
+
+class TestDockerAgentContainerNetworkIp:
+    """Tests for Docker vs Podman static-IP handling on the agent container."""
+
+    @patch("subprocess.run")
+    def test_podman_embeds_ip_in_network(self, mock_run: MagicMock) -> None:
+        """Podman embeds the static IP directly in --network."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="cid\n")
+        engine = ContainerEngine("podman")
+        runner = ContainerRunner(engine)
+        runner.create_container(
+            name="paude-test",
+            image="paude-workspace:latest",
+            mounts=[],
+            env={},
+            workdir="/pvc",
+            network="net",
+            network_ip="10.0.0.5",
+        )
+        cmd = mock_run.call_args[0][0]
+        assert "--ip" not in cmd
+        net_idx = cmd.index("--network")
+        assert cmd[net_idx + 1] == "net:ip=10.0.0.5"
+
+    @patch("subprocess.run")
+    def test_docker_passes_ip_flag_separately(self, mock_run: MagicMock) -> None:
+        """Docker cannot embed the IP in --network; it needs a separate --ip."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="cid\n")
+        engine = ContainerEngine("docker")
+        runner = ContainerRunner(engine)
+        runner.create_container(
+            name="paude-test",
+            image="paude-workspace:latest",
+            mounts=[],
+            env={},
+            workdir="/pvc",
+            network="net",
+            network_ip="10.0.0.5",
+        )
+        cmd = mock_run.call_args[0][0]
+        net_idx = cmd.index("--network")
+        assert cmd[net_idx + 1] == "net"
+        ip_idx = cmd.index("--ip")
+        assert cmd[ip_idx + 1] == "10.0.0.5"
+
+    @pytest.mark.parametrize("binary", ["podman", "docker"])
+    @patch("subprocess.run")
+    def test_network_without_ip_unaffected(
+        self, mock_run: MagicMock, binary: str
+    ) -> None:
+        """With no static IP, --network is unchanged for either engine."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="cid\n")
+        engine = ContainerEngine(binary)
+        runner = ContainerRunner(engine)
+        runner.create_container(
+            name="paude-test",
+            image="paude-workspace:latest",
+            mounts=[],
+            env={},
+            workdir="/pvc",
+            network="net",
+        )
+        cmd = mock_run.call_args[0][0]
+        assert "--ip" not in cmd
+        net_idx = cmd.index("--network")
+        assert cmd[net_idx + 1] == "net"
 
 
 class TestDockerContainerImage:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -226,6 +226,30 @@ class TestContainerEngineGpuArgs:
         assert engine.gpu_args("all") == ["--device", "nvidia.com/gpu=all"]
 
 
+class TestContainerEngineNetworkArgs:
+    """Tests for ContainerEngine.network_args method."""
+
+    def test_podman_embeds_ip_in_network(self) -> None:
+        engine = ContainerEngine("podman")
+        assert engine.network_args("net", "10.0.0.5") == [
+            "--network",
+            "net:ip=10.0.0.5",
+        ]
+
+    def test_docker_passes_ip_as_separate_flag(self) -> None:
+        engine = ContainerEngine("docker")
+        assert engine.network_args("net", "10.0.0.5") == [
+            "--network",
+            "net",
+            "--ip",
+            "10.0.0.5",
+        ]
+
+    def test_network_without_ip(self) -> None:
+        assert ContainerEngine("podman").network_args("net") == ["--network", "net"]
+        assert ContainerEngine("docker").network_args("net") == ["--network", "net"]
+
+
 class TestContainerEngineImageNameFormat:
     """Tests for ContainerEngine.image_name_format property."""
 


### PR DESCRIPTION
ContainerRunner.create_container() always embedded a static IP into --network as "name:ip=x.x.x.x", which only Podman understands. Docker needs the IP passed via a separate --ip flag, causing session creation to fail with the docker backend whenever the agent container is given a fixed IP. Extracted the engine-specific branching into a new ContainerEngine.network_args() helper (mirroring the existing gpu_args()), since the same Docker/Podman distinction already existed in ProxyRunner and was starting to duplicate.