### PR TITLE
Fix inject_file leaving newly created parent directories root-owned

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -80,6 +80,18 @@ Deferred items from the network egress security audit (2026-03-06).
 
 GitHub's GraphQL API uses POST for ALL operations, including reads (`gh pr list`, `gh issue list`). Blocking POST/PUT at the proxy level would break read-only `gh` CLI usage. The correct mitigation is using a read-only Personal Access Token (PAT) rather than proxy-level HTTP method filtering.
 
+## Runtime Hardening Backlog
+
+### RUNTIME-001: persist_config_dir failures are invisible to the user
+
+**Status**: Open
+**Priority**: Low
+**Discovered**: 2026-07-30 while diagnosing a Codex sqlite "database is damaged" bug (root cause fixed for the current call sites: `ContainerRunner.inject_file()` now also chowns the immediate parent directory it creates, not just the leaf file — but only one level deep, so a future caller whose `mkdir -p` creates more than one new directory level would reproduce this bug)
+
+`persist_config_dir()` in `containers/paude/entrypoint-lib-config.sh` swallows every failure from `mkdir`, `chmod`, `chcon`, and `rm -rf` via `2>/dev/null || true`. Its only diagnostic — `"persist_config_dir: cannot replace $home_dir with symlink; using PVC copy at $pvc_dir"` — is printed to the exec session's stderr, but `entrypoint-session.sh` runs `clear` immediately before launching the agent, wiping that line from the terminal before the user ever sees it. When the self-heal fails (e.g. a pre-existing directory under `$HOME` that `paude` can't write into), the user only sees an opaque downstream error from the agent itself (in the Codex case, a cryptic sqlite `CANTOPEN` error), with zero indication that paude's own volume-persistence step failed first.
+
+Consider making this diagnostic durable — e.g. write it to a log file under `$HOME` that survives `clear`, or print it after `clear` runs, or fail loudly instead of silently falling back — so any future recurrence of this class of bug is diagnosable from the user's own terminal instead of requiring a live `podman exec` investigation.
+
 ## Documentation Gaps
 
 Found during a 2026-07-22 audit to add OpenCode support to README/docs/CLI help.

--- a/src/paude/container/runner.py
+++ b/src/paude/container/runner.py
@@ -291,7 +291,7 @@ class ContainerRunner:
         quoted_target = shlex.quote(target)
         parts = [f"mkdir -p {parent}", f"cat > {quoted_target}"]
         if owner:
-            parts.append(f"chown {shlex.quote(owner)} {quoted_target}")
+            parts.append(f"chown {shlex.quote(owner)} {parent} {quoted_target}")
         parts.append(f"chmod {shlex.quote(mode)} {quoted_target}")
         self._engine.run(
             "exec",

--- a/tests/test_docker_compat.py
+++ b/tests/test_docker_compat.py
@@ -375,7 +375,7 @@ class TestDockerCredentialInjection:
 
     @patch("subprocess.run")
     def test_inject_file_chowns_when_owner_specified(self, mock_run: MagicMock) -> None:
-        """inject_file should chown the file when owner is specified."""
+        """inject_file should chown the parent directory and the file."""
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         engine = ContainerEngine("docker")
         runner = ContainerRunner(engine)
@@ -385,7 +385,7 @@ class TestDockerCredentialInjection:
 
         cmd = mock_run.call_args[0][0]
         shell_cmd = cmd[-1]
-        assert "chown paude" in shell_cmd
+        assert "chown paude:0 /home/paude/.config/gcloud" in shell_cmd
         assert "chmod 600" in shell_cmd
 
     @patch("subprocess.run")


### PR DESCRIPTION
mkdir -p inside inject_file runs as root, so a freshly created parent directory was left root-owned while only the leaf file got chowned. This broke Codex's ~/.codex persistence symlink, since paude couldn't write into the root-owned directory to relocate it onto the PVC volume, causing sqlite/PATH-alias permission errors on fresh sessions.