### PR TITLE
Remove dead --github-token flag and fix harvest SSH remote resolution

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -41,6 +41,20 @@ The static `containers/paude/Dockerfile` and the programmatic Dockerfile generat
 
 This caused a bug where the new OpenClaw helper script was added to the static Dockerfile but not to generated images. Consider having a single source of truth for the list of container scripts (e.g., a constant in `build_context.py`) that all four locations reference, or generating the static Dockerfile from the same code path.
 
+### REFACTOR-005: SSH transport construction (`ssh_host` string → `SshTransport`) duplicated in three places
+
+**Status**: Open
+**Priority**: Low (small duplication, but drift-prone since all three must stay in sync)
+**Discovered**: 2026-07-30 while fixing SEC-003 (`harvest` SSH remote resolution)
+
+The same "parse a `user@host[:port]` string with `parse_ssh_host()`, then construct a matching `SshTransport`" logic is independently implemented in three places:
+
+1. `_build_transport()` in `src/paude/cli/remote_git_setup.py:57-66`
+2. Inline in `build_ssh_backend()` in `src/paude/backends/ssh.py:31-36`
+3. Inline in `resolve_session_remote()` in `src/paude/git_remote/utils.py:60-63`
+
+The third occurrence was added while fixing SEC-003 rather than reusing `_build_transport()`, because `_build_transport()` lives in `src/paude/cli/` and importing it from `src/paude/git_remote/` (a lower-level package) would invert the existing dependency direction. Consolidating all three requires first giving this logic a home that both `cli/` and `git_remote/`/`backends/` can depend on without a layering inversion (e.g. a small helper in `src/paude/transport/ssh.py` itself, alongside `parse_ssh_host()`). Until then, any change to `SshTransport`'s constructor or `parse_ssh_host()`'s contract needs to be checked against all three call sites.
+
 ## Agent Limitations
 
 Issues caused by upstream agent behavior, not paude bugs.
@@ -79,22 +93,6 @@ Deferred items from the network egress security audit (2026-03-06).
 **Discovered**: 2026-03-06 during network egress security audit
 
 GitHub's GraphQL API uses POST for ALL operations, including reads (`gh pr list`, `gh issue list`). Blocking POST/PUT at the proxy level would break read-only `gh` CLI usage. The correct mitigation is using a read-only Personal Access Token (PAT) rather than proxy-level HTTP method filtering.
-
-### SEC-002: `--github-token` CLI flag is dead code
-
-**Status**: Open
-**Severity**: Medium (documented feature has no effect)
-**Discovered**: 2026-07-30 during docs audit
-
-`paude start --github-token ...` and `paude connect --github-token ...` resolve the flag (or `PAUDE_GITHUB_TOKEN`) into `resolved_token` in `src/paude/cli/commands/lifecycle.py` and `src/paude/cli/commands/connect.py`, then pass it as `backend_obj.start_session(name, github_token=resolved_token)` / `connect_session(name, github_token=resolved_token)`. However, `PodmanBackend.start_session()` and `.connect_session()` (`src/paude/backends/podman/backend.py:225,281`) accept the `github_token` parameter but never reference it anywhere in their bodies — grepping the class turns up no other use. The only code path that actually delivers a GitHub token into a session is independent of this flag: `gather_proxy_credentials()` (`src/paude/backends/proxy_config.py:138-140`) reads `PAUDE_GITHUB_TOKEN` directly from the host environment and forwards it to the proxy sidecar as `GH_TOKEN`, at `create`/`start`/`connect` time. So `--github-token` alone (without also setting `PAUDE_GITHUB_TOKEN`) currently does nothing. Either wire the CLI-resolved value into the proxy credential path, or remove the flag.
-
-### SEC-003: `harvest` doesn't set up git remotes correctly for `--host` sessions
-
-**Status**: Open
-**Severity**: Low
-**Discovered**: 2026-07-30 during docs audit
-
-`_ensure_remote_exists()` in `src/paude/workflow.py:67-108` (used only by `paude harvest`) auto-creates a paude git remote using `build_podman_remote_url(cname, engine=engine)` unconditionally when one doesn't already exist — it never checks whether the session is SSH/`--host`-backed. Compare `_remote_add_local()` in `src/paude/cli/remote.py:266-322` (used by `paude remote add`), which correctly branches on `registry_entry.ssh_host` and calls `build_ssh_remote_url(...)` for remote-host sessions. A user who creates a `--host` session without `--git` and then runs `paude harvest` directly (without first running `paude remote add`) will get an auto-added remote pointing at a container that doesn't exist on the local machine, which fails silently downstream. Fix `_ensure_remote_exists` to mirror `_remote_add_local`'s ssh_host branching.
 
 ## Runtime Hardening Backlog
 

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -38,7 +38,7 @@ paude harvest my-project -b feature/auth-refactor
 
 This creates a local `feature/auth-refactor` branch with all of the agent's commits. Review the diff, run tests, and iterate as needed.
 
-Protected branches (`main`, `master`, `release`, `release-*`, `release/*`) cannot be used as harvest targets. For `--host` remote sessions, see the [Limitations](REMOTE.md#limitations) note on `harvest` — set up the git remote with `--git` at create time or `paude remote add` first.
+Protected branches (`main`, `master`, `release`, `release-*`, `release/*`) cannot be used as harvest targets.
 
 ## Open a PR
 

--- a/docs/REMOTE.md
+++ b/docs/REMOTE.md
@@ -52,7 +52,6 @@ paude create my-project --host user@hostname:2222
 ### Limitations
 
 - `--host` and `--ssh-key` are CLI-only flags (not stored in user defaults)
-- [`paude harvest`](ORCHESTRATION.md#harvest-changes) assumes a local session when auto-adding its git remote; for `--host` sessions, use `--git` at create time or run `paude remote add` first
 
 ## Combining Remote Hosts with GPU
 

--- a/src/paude/backends/base.py
+++ b/src/paude/backends/base.py
@@ -129,14 +129,13 @@ class Backend(Protocol):
         """
         ...
 
-    def start_session(self, name: str, github_token: str | None = None) -> int:
+    def start_session(self, name: str) -> int:
         """Start a session and connect to it.
 
         Starts the container/scales to 1 and connects.
 
         Args:
             name: Session name.
-            github_token: Optional GitHub token to inject into the session.
 
         Returns:
             Exit code from the connected session.
@@ -153,12 +152,11 @@ class Backend(Protocol):
         """
         ...
 
-    def connect_session(self, name: str, github_token: str | None = None) -> int:
+    def connect_session(self, name: str) -> int:
         """Attach to a running session.
 
         Args:
             name: Session name.
-            github_token: Optional GitHub token to inject into the session.
 
         Returns:
             Exit code from the attached session.

--- a/src/paude/backends/podman/backend.py
+++ b/src/paude/backends/podman/backend.py
@@ -222,7 +222,7 @@ class PodmanBackend:
         self._volume_manager.remove_volume_verified(vname)
         self._runner.remove_secret(GCP_ADC_SECRET_NAME)
 
-    def start_session(self, name: str, github_token: str | None = None) -> int:
+    def start_session(self, name: str) -> int:
         """Start a session and connect to it."""
         cname = require_session(self._runner, name)
 
@@ -278,7 +278,7 @@ class PodmanBackend:
 
         print(f"Session '{name}' stopped.", file=sys.stderr)
 
-    def connect_session(self, name: str, github_token: str | None = None) -> int:
+    def connect_session(self, name: str) -> int:
         """Attach to a running session."""
         cname = container_name(name)
 

--- a/src/paude/cli/commands/connect.py
+++ b/src/paude/cli/commands/connect.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from typing import Annotated
 
 import typer
@@ -29,29 +28,14 @@ def session_connect(
             help="Container backend (auto-detected from session if not specified).",
         ),
     ] = None,
-    github_token: Annotated[
-        str | None,
-        typer.Option(
-            "--github-token",
-            help=(
-                "GitHub personal access token for gh CLI. "
-                "Use a fine-grained read-only PAT. "
-                "Also reads PAUDE_GITHUB_TOKEN env var (this flag takes priority). "
-                "Token is injected at connect time only, never stored."
-            ),
-        ),
-    ] = None,
 ) -> None:
     """Attach to a running session."""
-    # Resolve token: explicit flag takes priority over env var
-    resolved_token = github_token or os.environ.get("PAUDE_GITHUB_TOKEN")
-
     # Auto-detect backend if name is provided but backend is not
     if name and backend is None:
         result = find_session_backend(name)
         if result:
             backend, backend_obj = result
-            exit_code = backend_obj.connect_session(name, github_token=resolved_token)
+            exit_code = backend_obj.connect_session(name)
             raise typer.Exit(exit_code)
         else:
             typer.echo(f"Session '{name}' not found.", err=True)
@@ -73,9 +57,7 @@ def session_connect(
             multi_hint_format="  paude connect {name}  # {backend_type}, {workspace}",
         )
         typer.echo(f"Connecting to '{session.name}' ({session.backend_type})...")
-        exit_code = backend_obj.connect_session(
-            session.name, github_token=resolved_token
-        )
+        exit_code = backend_obj.connect_session(session.name)
         raise typer.Exit(exit_code)
 
     # Backend specified explicitly
@@ -85,5 +67,5 @@ def session_connect(
         if not name:
             raise typer.Exit(1)
 
-    exit_code = backend_instance.connect_session(name, github_token=resolved_token)
+    exit_code = backend_instance.connect_session(name)
     raise typer.Exit(exit_code)

--- a/src/paude/cli/commands/lifecycle.py
+++ b/src/paude/cli/commands/lifecycle.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from typing import Annotated
 
 import typer
@@ -30,30 +29,15 @@ def session_start(
             help="Container backend (auto-detected from session if not specified).",
         ),
     ] = None,
-    github_token: Annotated[
-        str | None,
-        typer.Option(
-            "--github-token",
-            help=(
-                "GitHub personal access token for gh CLI. "
-                "Use a fine-grained read-only PAT. "
-                "Also reads PAUDE_GITHUB_TOKEN env var (this flag takes priority). "
-                "Token is injected at connect time only, never stored."
-            ),
-        ),
-    ] = None,
 ) -> None:
     """Start a session and connect to it."""
-    # Resolve token: explicit flag takes priority over env var
-    resolved_token = github_token or os.environ.get("PAUDE_GITHUB_TOKEN")
-
     # Auto-detect backend if name is provided but backend is not
     if name and backend is None:
         result = find_session_backend(name)
         if result:
             backend, backend_obj = result
             try:
-                exit_code = backend_obj.start_session(name, github_token=resolved_token)
+                exit_code = backend_obj.start_session(name)
                 raise typer.Exit(exit_code)
             except Exception as e:
                 typer.echo(f"Error starting session: {e}", err=True)
@@ -74,7 +58,7 @@ def session_start(
             multi_hint_format="  paude start {name}  # {backend_type}, {status}",
         )
         typer.echo(f"Starting '{session.name}' ({session.backend_type})...")
-        exit_code = backend_obj.start_session(session.name, github_token=resolved_token)
+        exit_code = backend_obj.start_session(session.name)
         raise typer.Exit(exit_code)
 
     # Backend specified explicitly
@@ -85,7 +69,7 @@ def session_start(
             raise typer.Exit(1)
 
     try:
-        exit_code = backend_instance.start_session(name, github_token=resolved_token)
+        exit_code = backend_instance.start_session(name)
         raise typer.Exit(exit_code)
     except SessionNotFoundError as e:
         typer.echo(f"Error: {e}", err=True)

--- a/src/paude/cli/remote.py
+++ b/src/paude/cli/remote.py
@@ -270,53 +270,11 @@ def _remote_add_local(
     transport: Transport | None,
 ) -> tuple[str, Transport | None]:
     """Handle local backend remote add: check container, init workspace, build URL."""
-    from paude.cli.remote_git_setup import _build_transport
-    from paude.git_remote import (
-        build_podman_remote_url,
-        build_ssh_remote_url,
-        initialize_container_workspace,
-        is_container_running_podman,
-        podman_exec_builder,
-    )
-    from paude.registry import SessionRegistry
+    from paude.cli.remote_git_setup import _prepare_session_git_remote
 
     cname = resource_name(session.name)
     engine = engine_binary_for_backend(session.backend_type)
 
-    registry_entry = SessionRegistry().get(session.name)
-    effective_transport = transport
-    if effective_transport is None and registry_entry and registry_entry.ssh_host:
-        effective_transport = _build_transport(
-            registry_entry.ssh_host, registry_entry.ssh_key
-        )
-
-    if not is_container_running_podman(
-        cname, engine=engine, transport=effective_transport
-    ):
-        typer.echo("Error: Container not running.", err=True)
-        typer.echo("Start it first:", err=True)
-        typer.echo(f"  paude start {session.name}", err=True)
-        raise typer.Exit(1)
-
-    typer.echo("Initializing git repository in container...")
-    exec_builder = podman_exec_builder(cname, engine)
-    if not initialize_container_workspace(
-        exec_builder, branch=branch, transport=effective_transport
-    ):
-        raise typer.Exit(1)
-
-    if registry_entry and registry_entry.ssh_host:
-        from paude.transport.ssh import parse_ssh_host
-
-        ssh_host_parsed, ssh_port = parse_ssh_host(registry_entry.ssh_host)
-        remote_url = build_ssh_remote_url(
-            container_name=cname,
-            ssh_host=ssh_host_parsed,
-            engine=engine,
-            ssh_key=registry_entry.ssh_key,
-            ssh_port=ssh_port,
-        )
-    else:
-        remote_url = build_podman_remote_url(container_name=cname, engine=engine)
-
-    return remote_url, effective_transport
+    return _prepare_session_git_remote(
+        session.name, cname, engine, branch=branch, transport=transport
+    )

--- a/src/paude/cli/remote_git_setup.py
+++ b/src/paude/cli/remote_git_setup.py
@@ -66,6 +66,49 @@ def _build_transport(
     return SshTransport(host, key=ssh_key, port=port)
 
 
+def _prepare_session_git_remote(
+    session_name: str,
+    container_name: str,
+    engine: str,
+    *,
+    branch: str = "main",
+    transport: Transport | None = None,
+) -> tuple[str, Transport | None]:
+    """Resolve a session's remote URL/transport and prepare its container workspace.
+
+    Used by both `paude remote add` and `paude harvest` to auto-add a remote.
+    Raises typer.Exit(1) if the container isn't running or workspace init fails.
+    """
+    from paude.git_remote import (
+        initialize_container_workspace,
+        is_container_running_podman,
+        podman_exec_builder,
+        resolve_session_remote,
+    )
+
+    remote_url, resolved_transport = resolve_session_remote(
+        session_name, container_name, engine
+    )
+    effective_transport = transport if transport is not None else resolved_transport
+
+    if not is_container_running_podman(
+        container_name, engine=engine, transport=effective_transport
+    ):
+        typer.echo("Error: Container not running.", err=True)
+        typer.echo("Start it first:", err=True)
+        typer.echo(f"  paude start {session_name}", err=True)
+        raise typer.Exit(1)
+
+    typer.echo("Initializing git repository in container...")
+    exec_builder = podman_exec_builder(container_name, engine)
+    if not initialize_container_workspace(
+        exec_builder, branch=branch, transport=effective_transport
+    ):
+        raise typer.Exit(1)
+
+    return remote_url, effective_transport
+
+
 def _setup_git_after_create(
     session_name: str,
     backend_type: str,

--- a/src/paude/git_remote/__init__.py
+++ b/src/paude/git_remote/__init__.py
@@ -40,6 +40,7 @@ from paude.git_remote.utils import (
     is_git_repository,
     list_paude_remotes,
     resolve_origin_cmd,
+    resolve_session_remote,
     ssh_url_to_https,
 )
 
@@ -72,6 +73,7 @@ __all__ = [
     "list_paude_remotes",
     "podman_exec_builder",
     "resolve_origin_cmd",
+    "resolve_session_remote",
     "set_base_ref_in_container",
     "set_origin_in_container",
     "setup_precommit_in_container",

--- a/src/paude/git_remote/utils.py
+++ b/src/paude/git_remote/utils.py
@@ -1,4 +1,4 @@
-"""Pure git utility functions that don't exec into containers."""
+"""Git remote URL construction and related utility functions."""
 
 from __future__ import annotations
 
@@ -41,6 +41,36 @@ def build_ssh_remote_url(
 
     ssh_cmd = " ".join(ssh_parts)
     return f"ext::{ssh_cmd} {engine} exec -i {container_name} %S {workspace_path}"
+
+
+def resolve_session_remote(
+    session_name: str, container_name: str, engine: str
+) -> tuple[str, Transport | None]:
+    """Resolve the git remote URL and transport for a session's container.
+
+    SSH-host (--host) sessions get an ext::ssh-wrapped URL and a matching
+    transport; local sessions get a plain ext::<engine> exec URL and no transport.
+    """
+    from paude.registry import SessionRegistry
+
+    registry_entry = SessionRegistry().get(session_name)
+    if registry_entry and registry_entry.ssh_host:
+        from paude.transport.ssh import SshTransport, parse_ssh_host
+
+        ssh_host, ssh_port = parse_ssh_host(registry_entry.ssh_host)
+        transport: Transport | None = SshTransport(
+            ssh_host, key=registry_entry.ssh_key, port=ssh_port
+        )
+        remote_url = build_ssh_remote_url(
+            container_name=container_name,
+            ssh_host=ssh_host,
+            engine=engine,
+            ssh_key=registry_entry.ssh_key,
+            ssh_port=ssh_port,
+        )
+        return remote_url, transport
+
+    return build_podman_remote_url(container_name=container_name, engine=engine), None
 
 
 def is_ext_protocol_allowed() -> bool:

--- a/src/paude/workflow.py
+++ b/src/paude/workflow.py
@@ -7,7 +7,6 @@ import shlex
 import shutil
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
-from pathlib import Path
 
 import typer
 
@@ -64,21 +63,14 @@ def _find_backend_and_session(
     return backend_type, backend, session
 
 
-def _ensure_remote_exists(
-    session_name: str,
-    backend_type: str,
-    backend: Backend,
-    workspace: Path,
-) -> str:
+def _ensure_remote_exists(session_name: str, backend_type: str) -> str:
     """Ensure a paude git remote exists, auto-adding if needed."""
+    from paude.cli.remote_git_setup import _prepare_session_git_remote
     from paude.git_remote import (
-        build_podman_remote_url,
         enable_ext_protocol,
         git_remote_add,
-        initialize_container_workspace,
         is_ext_protocol_allowed,
         list_paude_remotes,
-        podman_exec_builder,
     )
 
     remote_name = resource_name(session_name)
@@ -94,12 +86,10 @@ def _ensure_remote_exists(
             typer.echo("Error: Failed to enable git ext:: protocol.", err=True)
             raise typer.Exit(1)
 
-    cname = resource_name(session_name)
-
     engine = engine_binary_for_backend(backend_type)
-    exec_builder = podman_exec_builder(cname, engine)
-    initialize_container_workspace(exec_builder)
-    remote_url = build_podman_remote_url(cname, engine=engine)
+    remote_url, _transport = _prepare_session_git_remote(
+        session_name, remote_name, engine
+    )
 
     if not git_remote_add(remote_name, remote_url):
         typer.echo(f"Error: Failed to add remote '{remote_name}'.", err=True)
@@ -145,12 +135,7 @@ def harvest_session(
         )
         raise typer.Exit(1)
 
-    remote_name = _ensure_remote_exists(
-        session_name,
-        backend_type,
-        backend,
-        workspace,
-    )
+    remote_name = _ensure_remote_exists(session_name, backend_type)
 
     container_branch = _get_container_branch(backend, session_name)
     typer.echo(f"Container is on branch '{container_branch}'.", err=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -327,88 +327,24 @@ class TestCodexChatgptProvider:
 
 
 @pytest.mark.parametrize(
-    ("command", "patch_target"),
+    "args",
     [
         pytest.param(
-            "start",
-            "paude.cli.commands.lifecycle.find_session_backend",
-            id="start",
+            ["create", "--dry-run", "--github-token", "ghp_test"], id="create"
         ),
         pytest.param(
-            "connect",
-            "paude.cli.commands.connect.find_session_backend",
-            id="connect",
+            ["start", "test-session", "--github-token", "ghp_test"], id="start"
+        ),
+        pytest.param(
+            ["connect", "test-session", "--github-token", "ghp_test"], id="connect"
         ),
     ],
 )
-def test_command_accepts_github_token_flag(command, patch_target):
-    """start/connect accept --github-token flag (session not found is expected)."""
-    with patch(patch_target, return_value=None):
-        result = runner.invoke(
-            app, [command, "test-session", "--github-token", "ghp_test123"]
-        )
-    assert "No such option" not in result.output
-    assert result.exit_code == 1  # Session not found is expected
-
-
-@pytest.mark.parametrize(
-    ("command", "backend_method", "token", "patch_target"),
-    [
-        pytest.param(
-            "start",
-            "start_session",
-            "ghp_test123",
-            "paude.cli.commands.lifecycle.find_session_backend",
-            id="start",
-        ),
-        pytest.param(
-            "connect",
-            "connect_session",
-            "ghp_test456",
-            "paude.cli.commands.connect.find_session_backend",
-            id="connect",
-        ),
-    ],
-)
-def test_command_passes_github_token_to_backend(
-    command, backend_method, token, patch_target
-):
-    """start/connect pass the resolved github_token to the backend."""
-    mock_backend = MagicMock()
-    getattr(mock_backend, backend_method).return_value = 0
-    with patch(patch_target, return_value=(MagicMock(), mock_backend)):
-        runner.invoke(app, [command, "test-session", "--github-token", token])
-
-    getattr(mock_backend, backend_method).assert_called_once_with(
-        "test-session",
-        github_token=token,  # noqa: S106
-    )
-
-
-@patch("paude.cli.commands.lifecycle.find_session_backend")
-def test_start_reads_paude_github_token_env(
-    mock_find_session_backend: MagicMock,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """paude start reads PAUDE_GITHUB_TOKEN env var when --github-token not provided."""
-    monkeypatch.setenv("PAUDE_GITHUB_TOKEN", "ghp_from_env")
-    mock_backend = MagicMock()
-    mock_backend.start_session.return_value = 0
-    mock_find_session_backend.return_value = (MagicMock(), mock_backend)
-
-    runner.invoke(app, ["start", "test-session"])
-
-    mock_backend.start_session.assert_called_once_with(
-        "test-session",
-        github_token="ghp_from_env",  # noqa: S106
-    )
-
-
-def test_create_does_not_accept_github_token():
-    """paude create does NOT accept --github-token (token belongs on start/connect)."""
-    result = runner.invoke(app, ["create", "--dry-run", "--github-token", "ghp_test"])
+def test_no_command_accepts_github_token(args):
+    """No command accepts --github-token; PAUDE_GITHUB_TOKEN env var is the only mechanism."""
+    result = runner.invoke(app, args)
     assert result.exit_code != 0
-    assert "No such option" in result.output or "Error" in result.output
+    assert "No such option" in result.output
 
 
 def _strip_ansi(text: str) -> str:

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -51,8 +51,8 @@ class TestBuildEnvironment:
     def test_gh_token_not_auto_propagated(self, monkeypatch: pytest.MonkeyPatch):
         """GH_TOKEN from host environment is NOT passed into the container.
 
-        Security test: GH_TOKEN must only be injected explicitly via --github-token,
-        never automatically from the host environment.
+        Security test: GH_TOKEN must only be injected explicitly via
+        PAUDE_GITHUB_TOKEN, never automatically from the host environment.
         """
         monkeypatch.setenv("GH_TOKEN", "secret123")
         env = build_environment()

--- a/tests/test_git_remote.py
+++ b/tests/test_git_remote.py
@@ -1,7 +1,7 @@
 """Tests for git_remote module."""
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from paude.git_remote import (
     _build_clone_from_origin_cmd,
@@ -26,6 +26,7 @@ from paude.git_remote import (
     list_paude_remotes,
     podman_exec_builder,
     resolve_origin_cmd,
+    resolve_session_remote,
     set_base_ref_in_container,
     set_origin_in_container,
     setup_precommit_in_container,
@@ -1151,6 +1152,56 @@ class TestBuildSshRemoteUrl:
             workspace_path="/custom/path",
         )
         assert url.endswith("/custom/path")
+
+
+class TestResolveSessionRemote:
+    """Tests for resolve_session_remote."""
+
+    @patch("paude.registry.SessionRegistry")
+    def test_no_registry_entry_uses_podman_url(self, mock_registry_class) -> None:
+        """No registry entry falls back to a local podman/docker URL, no transport."""
+        mock_registry_class.return_value.get.return_value = None
+
+        url, transport = resolve_session_remote(
+            "my-session", "paude-my-session", "podman"
+        )
+
+        assert url == "ext::podman exec -i paude-my-session %S /pvc/workspace"
+        assert transport is None
+
+    @patch("paude.registry.SessionRegistry")
+    def test_local_session_uses_podman_url(self, mock_registry_class) -> None:
+        """A registry entry without ssh_host is treated as local."""
+        mock_registry_class.return_value.get.return_value = MagicMock(
+            ssh_host=None, ssh_key=None
+        )
+
+        url, transport = resolve_session_remote(
+            "my-session", "paude-my-session", "docker"
+        )
+
+        assert url == "ext::docker exec -i paude-my-session %S /pvc/workspace"
+        assert transport is None
+
+    @patch("paude.registry.SessionRegistry")
+    def test_ssh_host_session_uses_ssh_url(self, mock_registry_class) -> None:
+        """A --host session builds an SSH-wrapped URL and a matching transport."""
+        mock_registry_class.return_value.get.return_value = MagicMock(
+            ssh_host="user@gpu-server:2222", ssh_key="/home/user/.ssh/id_ed25519"
+        )
+
+        url, transport = resolve_session_remote(
+            "my-session", "paude-my-session", "docker"
+        )
+
+        assert url == (
+            "ext::ssh -i /home/user/.ssh/id_ed25519 -p 2222 user@gpu-server "
+            "docker exec -i paude-my-session %S /pvc/workspace"
+        )
+        assert transport is not None
+        assert transport.host == "user@gpu-server"
+        assert transport.port == 2222
+        assert transport.key == "/home/user/.ssh/id_ed25519"
 
 
 class TestExecCmdBuilders:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -238,6 +238,145 @@ class TestHarvestSession:
         pr_create_args = pr_create_call[0][0]
         assert pr_create_args[:3] == ["gh", "pr", "create"]
 
+    def _setup_auto_add_mocks(
+        self,
+        mock_find: MagicMock,
+        mock_list: MagicMock,
+        mock_ext_allowed: MagicMock,
+        mock_resolve: MagicMock,
+        tmp_path: Path,
+        resolve_return: tuple[str, MagicMock | None],
+    ) -> None:
+        """Set up mocks for the harvest auto-add-remote path (no remote yet)."""
+        self._setup_mocks(mock_find, tmp_path)
+        mock_list.return_value = []
+        mock_ext_allowed.return_value = True
+        mock_resolve.return_value = resolve_return
+
+    @pytest.mark.parametrize(
+        ("remote_url", "transport"),
+        [
+            pytest.param(
+                "ext::podman exec -i paude-test %S /pvc/workspace", None, id="local"
+            ),
+            pytest.param(
+                "ext::ssh user@gpu-server docker exec -i paude-test %S /pvc/workspace",
+                MagicMock(),
+                id="ssh-host",
+            ),
+        ],
+    )
+    @patch("paude.workflow.subprocess.run")
+    @patch("paude.git_remote.git_diff_stat")
+    @patch("paude.git_remote.git_fetch_from_remote")
+    @patch("paude.git_remote.git_remote_add")
+    @patch("paude.git_remote.initialize_container_workspace")
+    @patch("paude.git_remote.is_container_running_podman")
+    @patch("paude.git_remote.resolve_session_remote")
+    @patch("paude.git_remote.is_ext_protocol_allowed")
+    @patch("paude.git_remote.list_paude_remotes")
+    @patch("paude.cli.find_session_backend")
+    def test_harvest_auto_adds_remote(
+        self,
+        mock_find: MagicMock,
+        mock_list: MagicMock,
+        mock_ext_allowed: MagicMock,
+        mock_resolve: MagicMock,
+        mock_running: MagicMock,
+        mock_init: MagicMock,
+        mock_remote_add: MagicMock,
+        mock_fetch: MagicMock,
+        mock_diff: MagicMock,
+        mock_run: MagicMock,
+        remote_url: str,
+        transport: MagicMock | None,
+        tmp_path: Path,
+    ) -> None:
+        """No existing remote: auto-add uses whatever URL resolve_session_remote returns."""
+        self._setup_auto_add_mocks(
+            mock_find,
+            mock_list,
+            mock_ext_allowed,
+            mock_resolve,
+            tmp_path,
+            (remote_url, transport),
+        )
+        mock_running.return_value = True
+        mock_init.return_value = True
+        mock_remote_add.return_value = True
+        mock_fetch.return_value = True
+        mock_diff.return_value = ""
+        mock_run.return_value = CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+
+        harvest_session("test", "my-branch")
+
+        mock_remote_add.assert_called_once_with("paude-test", remote_url)
+
+    @patch("paude.git_remote.initialize_container_workspace")
+    @patch("paude.git_remote.is_container_running_podman")
+    @patch("paude.git_remote.resolve_session_remote")
+    @patch("paude.git_remote.is_ext_protocol_allowed")
+    @patch("paude.git_remote.list_paude_remotes")
+    @patch("paude.cli.find_session_backend")
+    def test_harvest_auto_add_fails_when_container_not_running(
+        self,
+        mock_find: MagicMock,
+        mock_list: MagicMock,
+        mock_ext_allowed: MagicMock,
+        mock_resolve: MagicMock,
+        mock_running: MagicMock,
+        mock_init: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Auto-add raises instead of silently using an unreachable container."""
+        self._setup_auto_add_mocks(
+            mock_find,
+            mock_list,
+            mock_ext_allowed,
+            mock_resolve,
+            tmp_path,
+            ("ext::ssh ...", MagicMock()),
+        )
+        mock_running.return_value = False
+
+        with pytest.raises(click.exceptions.Exit):
+            harvest_session("test", "my-branch")
+
+        mock_init.assert_not_called()
+
+    @patch("paude.git_remote.initialize_container_workspace")
+    @patch("paude.git_remote.is_container_running_podman")
+    @patch("paude.git_remote.resolve_session_remote")
+    @patch("paude.git_remote.is_ext_protocol_allowed")
+    @patch("paude.git_remote.list_paude_remotes")
+    @patch("paude.cli.find_session_backend")
+    def test_harvest_auto_add_fails_when_init_workspace_fails(
+        self,
+        mock_find: MagicMock,
+        mock_list: MagicMock,
+        mock_ext_allowed: MagicMock,
+        mock_resolve: MagicMock,
+        mock_running: MagicMock,
+        mock_init: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Auto-add raises instead of silently proceeding when init fails."""
+        self._setup_auto_add_mocks(
+            mock_find,
+            mock_list,
+            mock_ext_allowed,
+            mock_resolve,
+            tmp_path,
+            ("ext::podman ...", None),
+        )
+        mock_running.return_value = True
+        mock_init.return_value = False
+
+        with pytest.raises(click.exceptions.Exit):
+            harvest_session("test", "my-branch")
+
 
 class TestStatusSessions:
     """Tests for status_sessions."""


### PR DESCRIPTION
--github-token on start/connect never worked (PodmanBackend accepted but ignored it) since PAUDE_GITHUB_TOKEN already covers this, so the flag is removed. Separately, paude harvest built a local podman/docker exec remote URL even for --host (SSH) sessions instead of branching on the registry's ssh_host like paude remote add already did; both now share a resolve_session_remote()/_prepare_session_git_remote() helper. Resolves SEC-002 and SEC-003 from KNOWN_ISSUES.md, and logs the remaining SSH transport-construction duplication as REFACTOR-005.