### PR TITLE
Upgrade gascity agent to gc v1.4.0

### DIFF
--- a/src/paude/agents/gascity.py
+++ b/src/paude/agents/gascity.py
@@ -13,7 +13,7 @@ from paude.agents.base import (
     pipefail_install_lines,
 )
 
-GC_VERSION = "1.3.5"
+GC_VERSION = "1.4.0"
 DOLT_VERSION = "2.1.10"
 BD_VERSION = "1.1.0"
 
@@ -36,6 +36,8 @@ class GascityAgent:
         creds.extra_env_vars["NODE_USE_ENV_PROXY"] = "1"
         creds.extra_env_vars["BD_DOLT_AUTO_COMMIT"] = "off"
         creds.extra_env_vars["BD_EXPORT_AUTO"] = "false"
+        creds.extra_env_vars["DO_NOT_TRACK"] = "1"
+        creds.extra_env_vars["GC_DISABLE_USAGE_METRICS"] = "1"
         self._config = AgentConfig(
             name="gascity",
             display_name="Gas City",

--- a/tests/test_gascity.py
+++ b/tests/test_gascity.py
@@ -43,6 +43,8 @@ class TestGascityAgentConfig:
             "NODE_USE_ENV_PROXY": "1",
             "BD_DOLT_AUTO_COMMIT": "off",
             "BD_EXPORT_AUTO": "false",
+            "DO_NOT_TRACK": "1",
+            "GC_DISABLE_USAGE_METRICS": "1",
         }
 
     def test_passthrough_vars(self) -> None:
@@ -194,6 +196,8 @@ class TestGascityAgentBuildEnvironment:
                 "NODE_USE_ENV_PROXY": "1",
                 "BD_DOLT_AUTO_COMMIT": "off",
                 "BD_EXPORT_AUTO": "false",
+                "DO_NOT_TRACK": "1",
+                "GC_DISABLE_USAGE_METRICS": "1",
             }
 
     def test_passes_through_vertex_vars(self) -> None:


### PR DESCRIPTION
Bump Gas City from v1.3.5 to v1.4.0 (Dolt and beads pins unchanged, as 1.4.0 doesn't raise those floors). Also opt out of gc's new CLI usage telemetry via DO_NOT_TRACK and GC_DISABLE_USAGE_METRICS, consistent with disabling Dolt's own metrics and paude's network-filtered security model.