### PR TITLE
docs: fix inaccuracies found auditing docs/ against the code

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -140,3 +140,19 @@ Note: README's agent table/examples were not re-audited as part of the 2026-07-3
 
 `src/paude/agents/__init__.py`'s `_REGISTRY` dict is the single source of truth for supported agents, and `list_agents()` returns them dynamically — but `src/paude/cli/help.py`'s "Agents & Providers" panel and `src/paude/cli/create.py`'s `--agent` option help string both hardcode the same agent list as free text. This diff had to hand-patch `create.py`'s copy because it had already drifted (missing `codex` and `opencode`). Consider generating both help strings from `list_agents()` so they can't drift again.
 
+### DOCS-005: `create` docstrings claim "does not start it" but the command auto-starts the container
+
+**Status**: Open
+**Severity**: Low
+**Discovered**: 2026-07-31 during docs/ audit (`docs/SESSIONS.md`, `docs/ORCHESTRATION.md`)
+
+`src/paude/cli/create.py:160` (`"""Create a new persistent session (does not start it)."""`) and the backend `create_session` docstrings (`src/paude/backends/base.py:106`, `src/paude/backends/podman/backend.py:83`, both "Create a new session (does not start it).") contradict actual runtime behavior: the CLI `create` path calls `start_session_no_attach` (`src/paude/cli/create_podman.py:122-123`), which starts the containers and agent, and `_finalize_session_create` prints "created and running" for local backends. The user-facing docs (`docs/SESSIONS.md` line 19, `docs/ORCHESTRATION.md`) correctly say `create` starts the container; only these code docstrings are stale. Update the three docstrings to reflect that local `create` also starts the session.
+
+### DOCS-006: Gas City agent adds a bogus `"gascity"` domain alias with no matching alias definition
+
+**Status**: Open (needs verification)
+**Severity**: Low
+**Discovered**: 2026-07-31 during docs/ audit (`docs/CONFIGURATION.md`)
+
+`src/paude/agents/gascity.py:55-60` lists `"gascity"` in `extra_domain_aliases`, but there is no `"gascity"` key in `DOMAIN_ALIASES` (`src/paude/domains.py`). `expand_domains` (`src/paude/domains.py:167-171`) therefore treats it as a literal domain string, so the session allowlist ends up containing a meaningless entry `gascity` rather than an expanded set of real domains. Verify whether Gas City needs a real domain-alias definition (add a `"gascity"` entry to `DOMAIN_ALIASES`) or whether the literal was unintended and should be removed from `extra_domain_aliases`. `docs/CONFIGURATION.md` correctly omits it, so no doc change is warranted until the code intent is confirmed.
+

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -205,7 +205,7 @@ paude blocked-domains my-session
 #   2 unique domain(s) blocked (11 total requests).
 #
 #   Tip: To allow a domain, run:
-#     paude allowed-domains <name> --add <domain>
+#     paude allowed-domains my-session --add <domain>
 
 # 2. Allow the domain you need
 paude allowed-domains my-session --add registry.npmjs.org
@@ -220,6 +220,16 @@ Use `--raw` to see the full proxy log with timestamps:
 
 ```bash
 paude blocked-domains my-session --raw
+```
+
+`allowed-domains` also supports removing or wholesale-replacing a session's allowlist. `--add`, `--remove`, and `--replace` are mutually exclusive; running `allowed-domains` with no flag lists the current domains:
+
+```bash
+# Remove a domain
+paude allowed-domains my-session --remove registry.npmjs.org
+
+# Replace the entire allowlist
+paude allowed-domains my-session --replace default,pypi
 ```
 
 ## GitHub CLI Access

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -23,10 +23,16 @@ paude status
 
 ```
 SESSION              PROJECT         BACKEND    ACTIVITY   STATE      SUMMARY
-my-project           your-project    podman     2m ago     Active     Refactoring auth module
+my-project           your-project    podman     1m ago     Active     Refactoring auth module (+3)
 ```
 
-The `STATE` column shows `Active` when the agent is working or `Idle` when waiting.
+The `SUMMARY` column shows the latest commit subject with a `(+N)` count of commits ahead of the base branch (a non-default branch name is prefixed too). The `STATE` column shows `Active` when the agent has been active within the last 2 minutes or `Idle` otherwise; sessions that aren't running show their container status instead (e.g. `stopped`, `created`).
+
+To check a single session, pass its name:
+
+```bash
+paude status my-project
+```
 
 ## Harvest Changes
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,7 +5,7 @@ The container intentionally restricts certain operations:
 | Resource | Access | Purpose |
 |----------|--------|---------|
 | Network | proxy-filtered (Vertex AI, PyPI, GitHub, agent-specific) | Prevents data exfiltration |
-| Proxy source IP | only the paired agent container's IP is accepted | Prevents other containers/hosts from riding the proxy's egress allowlist |
+| Proxy source IP | when the proxy has a fixed network IP (as on Podman), only the paired agent container's IP is accepted | Defense-in-depth: prevents other containers/hosts from riding the proxy's egress allowlist |
 | Host working directory | not mounted | Code lives in a separate named volume, synced via git (see [Code Synchronization](SESSIONS.md#code-synchronization)) — the agent never touches host files directly |
 | gcloud credentials | never enter the agent's container; a non-functional stub ADC file is injected instead | Real credentials live only on the network-filtering proxy sidecar, which signs Vertex AI requests on the container's behalf |
 | Agent config | copied in, not mounted | Prevents host config poisoning |

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -62,6 +62,10 @@ paude upgrade my-project           # Rebuilds image, preserves all data
 
 # Delete session completely
 paude delete my-project --confirm
+
+# Remove a session's local config entry without contacting the backend
+# (useful for orphaned or legacy sessions)
+paude delete my-project --confirm --force
 ```
 
 ## Backend Selection
@@ -111,6 +115,9 @@ git pull paude-my-project main
 
 # List all paude git remotes
 paude remote list
+
+# Remove the remote for a specific session
+paude remote remove my-project
 
 # Remove remotes whose sessions no longer exist
 paude remote cleanup


### PR DESCRIPTION
Audited all six docs/ files against src/paude. Fixes:

- ORCHESTRATION.md: the `paude status` example showed an impossible "2m ago" + "Active" pairing (Active requires elapsed < 120s, i.e. at most "1m ago") and a bare summary that can't occur (a non-empty commit subject implies commits_ahead > 0, forcing a "(+N)" suffix). Corrected the row and documented the SUMMARY/STATE columns, non-running STATE values, and the single-session `paude status <name>` form.
- CONFIGURATION.md: blocked-domains example output used a "<name>" placeholder, but the code interpolates the real session name (domains.py:295). Documented `allowed-domains --remove/--replace`.
- SESSIONS.md: documented `paude delete --force` and `paude remote remove`.
- SECURITY.md: proxy source-IP filtering is conditional defense-in-depth (only when the proxy has a fixed IP, as on Podman), not an absolute guarantee — corrected the overstated wording.

Also logged two unrelated code issues surfaced by the audit to KNOWN_ISSUES.md (DOCS-005 stale `create` "does not start it" docstrings; DOCS-006 bogus "gascity" domain alias). Verified with make lint + make typecheck (both pass).