### PR TITLE
feat: add --agents/--providers list options with singular aliases

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -106,6 +106,22 @@ GitHub's GraphQL API uses POST for ALL operations, including reads (`gh pr list`
 
 Consider making this diagnostic durable — e.g. write it to a log file under `$HOME` that survives `clear`, or print it after `clear` runs, or fail loudly instead of silently falling back — so any future recurrence of this class of bug is diagnosable from the user's own terminal instead of requiring a live `podman exec` investigation.
 
+## Test Suite
+
+### TEST-001: `test_proxy_shuts_down_on_sigterm` is flaky under full-suite load
+
+**Status**: Open
+**Priority**: Low
+**Discovered**: 2026-08-01 during a review-fix pass on the `--agents/--providers` branch
+
+`tests/test_port_forward_proxy.py::TestPortForwardProxy::test_proxy_shuts_down_on_sigterm`
+intermittently fails when run as part of the full `make test` suite but passes
+reliably in isolation (`uv run pytest tests/test_port_forward_proxy.py::TestPortForwardProxy::test_proxy_shuts_down_on_sigterm`).
+The failure is timing/resource-contention related (SIGTERM delivery and socket
+teardown racing under concurrent full-suite load), not a product defect. Consider
+adding an explicit wait/retry on the shutdown assertion or isolating the test's
+port/socket allocation so it is deterministic under load.
+
 ## Documentation Gaps
 
 Found during a 2026-07-22 audit to add OpenCode support to README/docs/CLI help.

--- a/README.md
+++ b/README.md
@@ -16,16 +16,19 @@ Run AI coding agents in secure containers. They make commits, you pull them back
 
 > Agents are installed automatically inside the container — no local agent installation needed. You just need authentication credentials for your chosen provider.
 
-Use `--agents` (and `--providers`) to select more than one at once — values are
-comma-separated and/or repeatable, and the first agent is the primary:
+Use `--agents` (and `--providers`) to parse, resolve, and preview more than one
+at once — values are comma-separated and/or repeatable, and the first agent is
+the primary. Creating multiple agents in a single session is not yet supported,
+so pair the lists with `--dry-run` to preview the full resolution:
 
 ```bash
-paude create --agents gascity,claude,codex --providers vertex,chatgpt my-project
+paude create --agents gascity,claude,codex --providers vertex,chatgpt --dry-run my-project
 ```
 
-The singular `--agent`/`--provider` flags remain as aliases for a single agent.
-Each agent uses its own default provider unless overridden; the primary agent
-honors the first `--providers` value.
+A real (non-`--dry-run`) create launches only the primary agent and warns that
+the extra agents were ignored. The singular `--agent`/`--provider` flags remain
+as aliases for a single agent. Each agent uses its own default provider unless
+overridden; the primary agent honors the first `--providers` value.
 
 ## Why Paude?
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ Run AI coding agents in secure containers. They make commits, you pull them back
 
 > Agents are installed automatically inside the container — no local agent installation needed. You just need authentication credentials for your chosen provider.
 
+Use `--agents` (and `--providers`) to select more than one at once — values are
+comma-separated and/or repeatable, and the first agent is the primary:
+
+```bash
+paude create --agents gascity,claude,codex --providers vertex,chatgpt my-project
+```
+
+The singular `--agent`/`--provider` flags remain as aliases for a single agent.
+Each agent uses its own default provider unless overridden; the primary agent
+honors the first `--providers` value.
+
 ## Why Paude?
 
 - **Isolated execution**: Your agent runs in a container, not on your host machine

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -86,7 +86,7 @@ Projects can declare defaults in their `paude.json` or `devcontainer.json` so th
 }
 ```
 
-Only `allowed-domains`, `agent`, `provider`, `otel-endpoint`, and `forward-ports` are supported as project-level create hints.
+Only `allowed-domains`, `agent`, `provider`, `agents`, `providers`, `otel-endpoint`, and `forward-ports` are supported as project-level create hints.
 
 ### Domain Merging
 
@@ -123,6 +123,8 @@ paude create --dry-run
 | `allowed-domains` | yes | yes | `--allowed-domains` | `["default"]` |
 | `gpu` | yes | — | `--gpu` / `--no-gpu` | (none) |
 | `provider` | yes | yes | `--provider` | (none) |
+| `agents` | yes | yes | `--agents` | `["claude"]` |
+| `providers` | yes | yes | `--providers` | (none) |
 | `otel-endpoint` | yes | yes | `--otel-endpoint` | (none) |
 | `forward-ports` | yes | yes | `--forward-port` | (none) |
 

--- a/src/paude/cli/create.py
+++ b/src/paude/cli/create.py
@@ -305,6 +305,18 @@ def session_create(
         )
         raise typer.Exit()
 
+    # Multi-agent creation is not yet supported: a real (non-dry-run) create
+    # launches only the primary agent. Warn so extra agents aren't dropped
+    # silently -- use --dry-run to preview the full multi-agent resolution.
+    if len(resolved.agents) > 1:
+        dropped = ", ".join(resolved.agents[1:])
+        typer.echo(
+            "Warning: multi-agent creation is not yet supported; creating only "
+            f"the primary agent '{r_agent}'. Ignoring: {dropped}. "
+            "Use --dry-run to preview the full multi-agent resolution.",
+            err=True,
+        )
+
     if ssh_key and not host:
         typer.echo(
             "Error: --ssh-key requires --host.",

--- a/src/paude/cli/create.py
+++ b/src/paude/cli/create.py
@@ -13,6 +13,7 @@ from paude.cli.helpers import (
     _expand_allowed_domains,
     _parse_agent_args,
     _prepare_session_create,
+    _split_list_option,
 )
 
 
@@ -92,7 +93,18 @@ def session_create(
             "--agent",
             help=(
                 "Agent to use: claude (default), codex, cursor, gascity, "
-                "gemini, openclaw, opencode."
+                "gemini, openclaw, opencode. Alias for a single-item --agents."
+            ),
+        ),
+    ] = None,
+    agents: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--agents",
+            help=(
+                "Agents to use (comma-separated and/or repeatable; first is "
+                "primary), e.g. --agents gascity,claude,codex. Cannot be "
+                "combined with --agent."
             ),
         ),
     ] = None,
@@ -100,7 +112,21 @@ def session_create(
         str | None,
         typer.Option(
             "--provider",
-            help="Inference provider (e.g., vertex, openai, anthropic).",
+            help=(
+                "Inference provider (e.g., vertex, openai, anthropic). "
+                "Alias for a single-item --providers."
+            ),
+        ),
+    ] = None,
+    providers: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--providers",
+            help=(
+                "Inference providers (comma-separated and/or repeatable), "
+                "e.g. --providers vertex,chatgpt. Cannot be combined with "
+                "--provider."
+            ),
         ),
     ] = None,
     git: Annotated[
@@ -193,12 +219,18 @@ def session_create(
     if no_gpu:
         cli_gpu = ""  # empty string sentinel = explicitly disabled
 
+    # Normalize repeatable, comma-separated list options.
+    cli_agents = _split_list_option(agents)
+    cli_providers = _split_list_option(providers)
+
     # Resolve layered configuration
     try:
         resolved = resolve_create_options(
             cli_backend=backend.value if backend is not None else None,
             cli_agent=agent,
             cli_provider=provider,
+            cli_agents=cli_agents,
+            cli_providers=cli_providers,
             cli_yolo=yolo,
             cli_git=git,
             cli_platform=platform,

--- a/src/paude/cli/help.py
+++ b/src/paude/cli/help.py
@@ -171,7 +171,8 @@ _SECTIONS: tuple[HelpSection, ...] = (
             ("--agent openclaw", "OpenClaw (web UI on port 18789)"),
             (
                 "--agents a,b,c",
-                "Multiple agents (comma-separated/repeatable; first is primary)",
+                "Preview multiple agents with --dry-run; a real create uses "
+                "only the primary (first)",
             ),
             ("", ""),
             (

--- a/src/paude/cli/help.py
+++ b/src/paude/cli/help.py
@@ -141,7 +141,8 @@ _SECTIONS: tuple[HelpSection, ...] = (
             "User defaults: ~/.config/paude/defaults.json"
             " (backend, yolo, git, domains, etc.)\n"
             'Project hints: paude.json "create" section'
-            " (allowed-domains, agent, provider, forward-ports)"
+            " (allowed-domains, agent, provider, agents, providers,"
+            " forward-ports)"
         ),
     ),
     HelpSection(
@@ -177,7 +178,8 @@ _SECTIONS: tuple[HelpSection, ...] = (
             ("", ""),
             (
                 "--providers x,y",
-                "Providers per agent (comma-separated/repeatable)",
+                "Provider pool (comma-separated/repeatable); only the "
+                "primary agent's default is overridden",
             ),
             ("--provider vertex", "Vertex AI (default for claude, openclaw)"),
             ("--provider anthropic", "Anthropic API"),

--- a/src/paude/cli/help.py
+++ b/src/paude/cli/help.py
@@ -169,7 +169,15 @@ _SECTIONS: tuple[HelpSection, ...] = (
             ("--agent gemini", "Gemini CLI"),
             ("--agent opencode", "OpenCode"),
             ("--agent openclaw", "OpenClaw (web UI on port 18789)"),
+            (
+                "--agents a,b,c",
+                "Multiple agents (comma-separated/repeatable; first is primary)",
+            ),
             ("", ""),
+            (
+                "--providers x,y",
+                "Providers per agent (comma-separated/repeatable)",
+            ),
             ("--provider vertex", "Vertex AI (default for claude, openclaw)"),
             ("--provider anthropic", "Anthropic API"),
             ("--provider chatgpt", "Codex ChatGPT-plan OAuth, HTTP/SSE (default)"),

--- a/src/paude/cli/helpers.py
+++ b/src/paude/cli/helpers.py
@@ -181,6 +181,26 @@ def _parse_agent_args(claude_args: str | None) -> list[str]:
 _parse_claude_args = _parse_agent_args
 
 
+def _split_list_option(values: list[str] | None) -> list[str] | None:
+    """Normalize a repeatable, comma-separated CLI option into a list.
+
+    Each occurrence may itself contain comma-separated entries, so
+    ``--agents a,b --agents c`` yields ``["a", "b", "c"]``. Whitespace is
+    stripped and empty entries are dropped. Returns None when the option was
+    not provided (``values is None``) or contained no usable entries, so the
+    resolver can distinguish "unset" from an explicit list.
+    """
+    if values is None:
+        return None
+    items = [
+        entry.strip()
+        for value in values
+        for entry in value.split(",")
+        if entry.strip()
+    ]
+    return items or None
+
+
 def _get_provider_aliases(
     provider_name: str | None, agent_name: str
 ) -> list[str] | None:

--- a/src/paude/config/models.py
+++ b/src/paude/config/models.py
@@ -54,6 +54,8 @@ class PaudeConfig:
     create_allowed_domains: list[str] = field(default_factory=list)
     create_agent: str | None = None
     create_provider: str | None = None
+    create_agents: list[str] = field(default_factory=list)
+    create_providers: list[str] = field(default_factory=list)
     create_otel_endpoint: str | None = None
     create_forward_ports: list[str] = field(default_factory=list)
 

--- a/src/paude/config/parser.py
+++ b/src/paude/config/parser.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -128,13 +129,7 @@ def _parse_devcontainer(config_file: Path, data: dict[str, Any]) -> PaudeConfig:
 
     # Parse create hints from customizations.paude.create
     create_section = data.get("customizations", {}).get("paude", {}).get("create", {})
-    (
-        create_allowed_domains,
-        create_agent,
-        create_provider,
-        create_otel_endpoint,
-        create_forward_ports,
-    ) = _parse_create_section(create_section)
+    create_hints = _parse_create_section(create_section)
 
     return PaudeConfig(
         config_file=config_file,
@@ -146,11 +141,13 @@ def _parse_devcontainer(config_file: Path, data: dict[str, Any]) -> PaudeConfig:
         post_create_command=post_create_command,
         container_env=container_env,
         build_args=build_args,
-        create_allowed_domains=create_allowed_domains,
-        create_agent=create_agent,
-        create_provider=create_provider,
-        create_otel_endpoint=create_otel_endpoint,
-        create_forward_ports=create_forward_ports,
+        create_allowed_domains=create_hints.allowed_domains,
+        create_agent=create_hints.agent,
+        create_provider=create_hints.provider,
+        create_agents=create_hints.agents,
+        create_providers=create_hints.providers,
+        create_otel_endpoint=create_hints.otel_endpoint,
+        create_forward_ports=create_hints.forward_ports,
     )
 
 
@@ -184,13 +181,7 @@ def _parse_paude_json(config_file: Path, data: dict[str, Any]) -> PaudeConfig:
         )
 
     # Parse "create" section for create hints
-    (
-        create_allowed_domains,
-        create_agent,
-        create_provider,
-        create_otel_endpoint,
-        create_forward_ports,
-    ) = _parse_create_section(data.get("create", {}))
+    create_hints = _parse_create_section(data.get("create", {}))
 
     return PaudeConfig(
         config_file=config_file,
@@ -201,11 +192,13 @@ def _parse_paude_json(config_file: Path, data: dict[str, Any]) -> PaudeConfig:
         build_args=build_args,
         packages=packages,
         post_create_command=setup_command,
-        create_allowed_domains=create_allowed_domains,
-        create_agent=create_agent,
-        create_provider=create_provider,
-        create_otel_endpoint=create_otel_endpoint,
-        create_forward_ports=create_forward_ports,
+        create_allowed_domains=create_hints.allowed_domains,
+        create_agent=create_hints.agent,
+        create_provider=create_hints.provider,
+        create_agents=create_hints.agents,
+        create_providers=create_hints.providers,
+        create_otel_endpoint=create_hints.otel_endpoint,
+        create_forward_ports=create_hints.forward_ports,
     )
 
 
@@ -213,30 +206,43 @@ _KNOWN_CREATE_KEYS = {
     "allowed-domains",
     "agent",
     "provider",
+    "agents",
+    "providers",
     "otel-endpoint",
     "forward-ports",
 }
 
 
-def _parse_create_section(
-    create_data: dict[str, Any],
-) -> tuple[list[str], str | None, str | None, str | None, list[str]]:
+@dataclass
+class CreateHints:
+    """Parsed create hints from a project config 'create' section."""
+
+    allowed_domains: list[str] = field(default_factory=list)
+    agent: str | None = None
+    provider: str | None = None
+    agents: list[str] = field(default_factory=list)
+    providers: list[str] = field(default_factory=list)
+    otel_endpoint: str | None = None
+    forward_ports: list[str] = field(default_factory=list)
+
+
+def _parse_create_section(create_data: dict[str, Any]) -> CreateHints:
     """Parse the 'create' section from project config.
 
     Args:
         create_data: The parsed "create" object (may be empty).
 
     Returns:
-        Tuple of (allowed_domains, agent, provider, otel_endpoint, forward_ports).
+        Parsed CreateHints. Unknown or wrongly-typed values are dropped.
     """
     if not isinstance(create_data, dict):
-        return [], None, None, None, []
+        return CreateHints()
 
     _warn_unknown_keys(create_data, _KNOWN_CREATE_KEYS, "create section")
 
-    allowed_domains = create_data.get("allowed-domains", [])
-    if not isinstance(allowed_domains, list):
-        allowed_domains = []
+    allowed_domains = _string_list(create_data.get("allowed-domains", []))
+    agents = _string_list(create_data.get("agents", []))
+    providers = _string_list(create_data.get("providers", []))
 
     agent = create_data.get("agent")
     if agent is not None and not isinstance(agent, str):
@@ -256,7 +262,22 @@ def _parse_create_section(
     else:
         forward_ports = [str(p) for p in forward_ports]
 
-    return allowed_domains, agent, provider, otel_endpoint, forward_ports
+    return CreateHints(
+        allowed_domains=allowed_domains,
+        agent=agent,
+        provider=provider,
+        agents=agents,
+        providers=providers,
+        otel_endpoint=otel_endpoint,
+        forward_ports=forward_ports,
+    )
+
+
+def _string_list(value: Any) -> list[str]:
+    """Coerce a JSON value into a list of strings, dropping non-strings."""
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
 
 
 def _warn_unsupported_properties(data: dict[str, Any]) -> None:

--- a/src/paude/config/parser.py
+++ b/src/paude/config/parser.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from paude.config.models import FeatureSpec, PaudeConfig
-from paude.config.user_config import _warn_unknown_keys
+from paude.config.user_config import _string_list, _warn_unknown_keys
 
 
 class ConfigError(Exception):
@@ -271,13 +271,6 @@ def _parse_create_section(create_data: dict[str, Any]) -> CreateHints:
         otel_endpoint=otel_endpoint,
         forward_ports=forward_ports,
     )
-
-
-def _string_list(value: Any) -> list[str]:
-    """Coerce a JSON value into a list of strings, dropping non-strings."""
-    if not isinstance(value, list):
-        return []
-    return [item for item in value if isinstance(item, str)]
 
 
 def _warn_unsupported_properties(data: dict[str, Any]) -> None:

--- a/src/paude/config/resolver.py
+++ b/src/paude/config/resolver.py
@@ -294,21 +294,21 @@ def _resolve_agents_and_providers(
     # A singular flag/hint contributes a one-element list at its layer.
     agents, agents_source = _resolve_option_list(
         cli=cli_agents if cli_agents is not None else _as_list(cli_agent),
-        project=_project_list(
-            project_config, "create_agents", "create_agent"
-        ),
+        project=_project_list(project_config, "create_agents", "create_agent"),
         user=user_defaults.agents or _as_list(user_defaults.agent),
         builtin=["claude"],
     )
+    if not agents:
+        raise ValueError(
+            "Agent name cannot be empty. Specify a non-empty --agent/--agents value."
+        )
     result.agents = agents
     result.agents_provenance = [(agents, agents_source)]
     result.agent = SettingValue(agents[0], agents_source)
 
     provider_pool, providers_source = _resolve_option_list(
         cli=cli_providers if cli_providers is not None else _as_list(cli_provider),
-        project=_project_list(
-            project_config, "create_providers", "create_provider"
-        ),
+        project=_project_list(project_config, "create_providers", "create_provider"),
         user=user_defaults.providers or _as_list(user_defaults.provider),
         builtin=[],
     )
@@ -326,14 +326,17 @@ def _resolve_agents_and_providers(
     # agent uses its own default provider.
     result.agent_providers = _derive_agent_providers(agents, primary_provider)
 
-    # Each agent's resolved provider must appear in the providers list; append
-    # any that a per-agent default contributed beyond the explicit pool.
-    derived = [provider for _, provider in result.agent_providers]
-    auto_added = [p for p in _dedupe(derived) if p not in provider_pool]
-    result.providers = _dedupe(provider_pool + derived)
+    # Only list providers that are actually assigned to some agent: an
+    # explicit --providers entry beyond what the primary agent consumes is
+    # never applied to any agent, so including it here would misleadingly
+    # suggest it's in effect.
+    used = _dedupe(provider for _, provider in result.agent_providers)
+    used_explicit = [p for p in provider_pool if p in used]
+    auto_added = [p for p in used if p not in provider_pool]
+    result.providers = used
     result.providers_provenance = []
-    if provider_pool:
-        result.providers_provenance.append((provider_pool, providers_source))
+    if used_explicit:
+        result.providers_provenance.append((used_explicit, providers_source))
     if auto_added:
         result.providers_provenance.append((auto_added, "built-in"))
 

--- a/src/paude/config/resolver.py
+++ b/src/paude/config/resolver.py
@@ -38,6 +38,11 @@ class ResolvedCreateOptions:
     resolved provider. The ``agents``/``providers`` lists hold the full
     resolved sets, and ``agent_providers`` maps each agent to the provider it
     will use (first = primary).
+
+    Note: session creation currently uses only the primary agent/provider
+    scalars; the ``agents``/``providers``/``agent_providers`` lists are consumed
+    by the ``--dry-run`` preview only. Multi-agent creation is not yet
+    implemented, so a real create ignores all but the primary agent.
     """
 
     backend: SettingValue[str] = field(

--- a/src/paude/config/resolver.py
+++ b/src/paude/config/resolver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any, Generic, Literal, TypeVar
 
@@ -30,7 +31,14 @@ def format_setting(name: str, setting: SettingValue[Any]) -> str:
 
 @dataclass
 class ResolvedCreateOptions:
-    """Fully-resolved create options with provenance tracking."""
+    """Fully-resolved create options with provenance tracking.
+
+    The ``agent`` and ``provider`` scalars are retained for backward
+    compatibility and always describe the *primary* (first) agent and its
+    resolved provider. The ``agents``/``providers`` lists hold the full
+    resolved sets, and ``agent_providers`` maps each agent to the provider it
+    will use (first = primary).
+    """
 
     backend: SettingValue[str] = field(
         default_factory=lambda: SettingValue("podman", "built-in")
@@ -56,6 +64,12 @@ class ResolvedCreateOptions:
     otel_endpoint: SettingValue[str | None] = field(
         default_factory=lambda: SettingValue(None, "built-in")
     )
+    agents: list[str] = field(default_factory=lambda: ["claude"])
+    agents_provenance: list[tuple[list[str], Source]] = field(default_factory=list)
+    providers: list[str] = field(default_factory=list)
+    providers_provenance: list[tuple[list[str], Source]] = field(default_factory=list)
+    # Derived per-agent provider mapping (ordered, first = primary).
+    agent_providers: list[tuple[str, str]] = field(default_factory=list)
     allowed_domains: list[str] = field(default_factory=list)
     allowed_domains_provenance: list[tuple[list[str], Source]] = field(
         default_factory=list
@@ -70,6 +84,8 @@ def resolve_create_options(
     cli_backend: str | None,
     cli_agent: str | None,
     cli_provider: str | None = None,
+    cli_agents: list[str] | None = None,
+    cli_providers: list[str] | None = None,
     cli_yolo: bool | None,
     cli_git: bool | None,
     cli_platform: str | None,
@@ -90,8 +106,21 @@ def resolve_create_options(
 
     Domains merge (union) across user defaults and project config,
     unless CLI --allowed-domains was explicitly provided.
+
+    The singular ``cli_agent``/``cli_provider`` arguments and the list-valued
+    ``cli_agents``/``cli_providers`` arguments are mutually exclusive: passing
+    both a singular flag and its plural counterpart raises ``ValueError``.
+
+    Raises:
+        ValueError: On unsupported backend, conflicting singular/plural flags,
+            an unknown agent name, or an unsupported agent/provider combination.
     """
     result = ResolvedCreateOptions()
+
+    if cli_agent is not None and cli_agents is not None:
+        raise ValueError("Specify --agent or --agents, not both.")
+    if cli_provider is not None and cli_providers is not None:
+        raise ValueError("Specify --provider or --providers, not both.")
 
     if user_defaults.backend not in (None, "podman", "docker"):
         raise ValueError(
@@ -107,18 +136,15 @@ def resolve_create_options(
         builtin="podman",
     )
 
-    result.agent = _resolve_scalar(
-        cli=cli_agent,
-        project=project_config.create_agent if project_config else None,
-        user=user_defaults.agent,
-        builtin="claude",
-    )
-
-    result.provider = _resolve_scalar(
-        cli=cli_provider,
-        project=project_config.create_provider if project_config else None,
-        user=user_defaults.provider,
-        builtin=None,
+    # --- Agent/provider lists (CLI > project > user > built-in) ---
+    _resolve_agents_and_providers(
+        result=result,
+        cli_agent=cli_agent,
+        cli_agents=cli_agents,
+        cli_provider=cli_provider,
+        cli_providers=cli_providers,
+        project_config=project_config,
+        user_defaults=user_defaults,
     )
 
     result.otel_endpoint = _resolve_scalar(
@@ -191,6 +217,17 @@ def _resolve_scalar(
     return SettingValue(builtin, "built-in")
 
 
+def _dedupe(items: Iterable[str]) -> list[str]:
+    """Return items with duplicates removed, preserving first-seen order."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in items:
+        if item and item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out
+
+
 def _resolve_list(
     *,
     cli: list[str] | None,
@@ -210,6 +247,144 @@ def _resolve_list(
     if user:
         return SettingValue(list(user), "user defaults")
     return SettingValue([], "built-in")
+
+
+def _resolve_option_list(
+    *,
+    cli: list[str] | None,
+    project: list[str] | None,
+    user: list[str] | None,
+    builtin: list[str],
+) -> tuple[list[str], Source]:
+    """Resolve a list-valued setting using precedence order.
+
+    An empty list at any layer is treated as "not set" and falls through to
+    the next layer. The returned list is de-duplicated preserving order.
+    """
+    if cli:
+        return _dedupe(cli), "cli"
+    if project:
+        return _dedupe(project), "paude.json"
+    if user:
+        return _dedupe(user), "user defaults"
+    return _dedupe(builtin), "built-in"
+
+
+def _resolve_agents_and_providers(
+    *,
+    result: ResolvedCreateOptions,
+    cli_agent: str | None,
+    cli_agents: list[str] | None,
+    cli_provider: str | None,
+    cli_providers: list[str] | None,
+    project_config: PaudeConfig | None,
+    user_defaults: UserDefaults,
+) -> None:
+    """Resolve the agent and provider lists, then derive per-agent providers.
+
+    Populates ``agents``/``providers`` (with provenance), the ``agent``/
+    ``provider`` primary scalars (for back-compat), and the ``agent_providers``
+    mapping. Validates every agent name and agent/provider combination.
+    """
+    # A singular flag/hint contributes a one-element list at its layer.
+    agents, agents_source = _resolve_option_list(
+        cli=cli_agents if cli_agents is not None else _as_list(cli_agent),
+        project=_project_list(
+            project_config, "create_agents", "create_agent"
+        ),
+        user=user_defaults.agents or _as_list(user_defaults.agent),
+        builtin=["claude"],
+    )
+    result.agents = agents
+    result.agents_provenance = [(agents, agents_source)]
+    result.agent = SettingValue(agents[0], agents_source)
+
+    provider_pool, providers_source = _resolve_option_list(
+        cli=cli_providers if cli_providers is not None else _as_list(cli_provider),
+        project=_project_list(
+            project_config, "create_providers", "create_provider"
+        ),
+        user=user_defaults.providers or _as_list(user_defaults.provider),
+        builtin=[],
+    )
+
+    # The primary provider scalar mirrors the highest-precedence explicit
+    # provider (first in the pool), or None when nothing was configured.
+    primary_provider = provider_pool[0] if provider_pool else None
+    result.provider = SettingValue(
+        primary_provider,
+        providers_source if provider_pool else "built-in",
+    )
+
+    # Derive the provider each agent will use. The primary agent honors the
+    # explicit primary provider (back-compat with `--provider`); every other
+    # agent uses its own default provider.
+    result.agent_providers = _derive_agent_providers(agents, primary_provider)
+
+    # Each agent's resolved provider must appear in the providers list; append
+    # any that a per-agent default contributed beyond the explicit pool.
+    derived = [provider for _, provider in result.agent_providers]
+    auto_added = [p for p in _dedupe(derived) if p not in provider_pool]
+    result.providers = _dedupe(provider_pool + derived)
+    result.providers_provenance = []
+    if provider_pool:
+        result.providers_provenance.append((provider_pool, providers_source))
+    if auto_added:
+        result.providers_provenance.append((auto_added, "built-in"))
+
+
+def _as_list(value: str | None) -> list[str] | None:
+    """Wrap a scalar into a one-element list, or None when unset."""
+    return [value] if value is not None else None
+
+
+def _project_list(
+    project_config: PaudeConfig | None,
+    list_attr: str,
+    scalar_attr: str,
+) -> list[str] | None:
+    """Extract a project-config list, falling back to its singular scalar."""
+    if project_config is None:
+        return None
+    plural: list[str] = getattr(project_config, list_attr)
+    if plural:
+        return plural
+    return _as_list(getattr(project_config, scalar_attr))
+
+
+def _derive_agent_providers(
+    agents: list[str], primary_provider: str | None
+) -> list[tuple[str, str]]:
+    """Map each agent to the provider it will use, validating each combination.
+
+    The primary (first) agent uses ``primary_provider`` when one was supplied,
+    otherwise its own default. Every subsequent agent uses its default. Each
+    (agent, provider) pair is validated via ``resolve_agent_provider``.
+
+    Raises:
+        ValueError: If an agent name is unknown or the agent/provider
+            combination is unsupported.
+    """
+    from paude.agents import get_agent
+    from paude.providers.agent_providers import (
+        DEFAULT_PROVIDER,
+        resolve_agent_provider,
+    )
+
+    mapping: list[tuple[str, str]] = []
+    for index, agent in enumerate(agents):
+        # Validate the agent name (raises with a friendly message if unknown).
+        get_agent(agent)
+
+        if index == 0 and primary_provider is not None:
+            provider = primary_provider
+        else:
+            provider = DEFAULT_PROVIDER.get(agent) or ""
+
+        # Validate the combination and resolve the effective provider name.
+        provider_config, _ = resolve_agent_provider(agent, provider or None)
+        mapping.append((agent, provider_config.name))
+    return mapping
 
 
 def _resolve_domains(

--- a/src/paude/config/user_config.py
+++ b/src/paude/config/user_config.py
@@ -21,6 +21,8 @@ class UserDefaults:
     backend: str | None = None
     agent: str | None = None
     provider: str | None = None
+    agents: list[str] = field(default_factory=list)
+    providers: list[str] = field(default_factory=list)
     yolo: bool | None = None
     git: bool | None = None
     platform: str | None = None
@@ -35,6 +37,8 @@ _KNOWN_KEYS = {
     "backend",
     "agent",
     "provider",
+    "agents",
+    "providers",
     "yolo",
     "git",
     "platform",
@@ -111,10 +115,6 @@ def _warn_unknown_keys(
 
 def _parse_defaults(data: dict[str, Any], path: Path) -> UserDefaults:
     """Parse the 'defaults' object into a UserDefaults dataclass."""
-    allowed_domains = data.get("allowed-domains", [])
-    if not isinstance(allowed_domains, list):
-        allowed_domains = []
-
     forward_ports = data.get("forward-ports", [])
     if not isinstance(forward_ports, list):
         forward_ports = []
@@ -125,11 +125,20 @@ def _parse_defaults(data: dict[str, Any], path: Path) -> UserDefaults:
         backend=data.get("backend"),
         agent=data.get("agent"),
         provider=data.get("provider"),
+        agents=_string_list(data.get("agents", [])),
+        providers=_string_list(data.get("providers", [])),
         yolo=data.get("yolo"),
         git=data.get("git"),
         platform=data.get("platform"),
         gpu=data.get("gpu"),
-        allowed_domains=allowed_domains,
+        allowed_domains=_string_list(data.get("allowed-domains", [])),
         otel_endpoint=data.get("otel-endpoint"),
         forward_ports=forward_ports,
     )
+
+
+def _string_list(value: Any) -> list[str]:
+    """Coerce a JSON value into a list of strings, dropping non-strings."""
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]

--- a/src/paude/dry_run.py
+++ b/src/paude/dry_run.py
@@ -10,7 +10,7 @@ import typer
 from paude.agents import get_agent
 from paude.config import detect_config, parse_config
 from paude.config.dockerfile import generate_workspace_dockerfile
-from paude.config.resolver import ResolvedCreateOptions, format_setting
+from paude.config.resolver import ResolvedCreateOptions, Source, format_setting
 from paude.domains import format_domains_for_display
 
 
@@ -89,8 +89,7 @@ def _show_resolved_flags(
     typer.echo("Flags:")
     typer.echo(format_setting("backend", resolved.backend))
     typer.echo(f"  verbose: {flags.get('verbose', False)}")
-    typer.echo(format_setting("agent", resolved.agent))
-    typer.echo(format_setting("provider", resolved.provider))
+    _show_agents_and_providers(resolved)
     typer.echo(format_setting("yolo", resolved.yolo))
     typer.echo(format_setting("git", resolved.git))
 
@@ -123,6 +122,40 @@ def _show_resolved_flags(
 
     if flags.get("claude_args"):
         typer.echo(f"  args: {flags['claude_args']}")
+
+
+def _show_agents_and_providers(resolved: ResolvedCreateOptions) -> None:
+    """Show the agents/providers lists, their provenance, and per-agent mapping.
+
+    The scalar ``agent``/``provider`` lines are retained for backward
+    compatibility and describe the primary (first) agent and its provider.
+    """
+    # Agents list with provenance groups.
+    typer.echo(f"  agents: {', '.join(resolved.agents)}")
+    _show_provenance_groups(resolved.agents_provenance)
+    typer.echo(format_setting("agent", resolved.agent))
+
+    # Providers list with provenance groups.
+    if resolved.providers:
+        typer.echo(f"  providers: {', '.join(resolved.providers)}")
+        _show_provenance_groups(resolved.providers_provenance)
+    else:
+        typer.echo("  providers: (not set)  (built-in)")
+    typer.echo(format_setting("provider", resolved.provider))
+
+    # Derived per-agent provider mapping (first = primary).
+    if resolved.agent_providers:
+        typer.echo("  per-agent providers:")
+        for agent, provider in resolved.agent_providers:
+            typer.echo(f"    {agent} -> {provider}")
+
+
+def _show_provenance_groups(
+    provenance: list[tuple[list[str], Source]],
+) -> None:
+    """Print each ``(values, source)`` provenance group as an indented line."""
+    for values, source in provenance:
+        typer.echo(f"    {', '.join(values)}  ({source})")
 
 
 def _show_legacy_flags(flags: dict[str, Any]) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -370,6 +370,86 @@ class TestCodexChatgptProvider:
         assert result.exit_code != 0
 
 
+class TestAgentsProvidersLists:
+    """Tests for the list-valued --agents/--providers options."""
+
+    def test_agents_providers_dry_run(self):
+        """--agents/--providers show both lists and per-agent providers."""
+        result = runner.invoke(
+            app,
+            [
+                "create",
+                "--agents",
+                "gascity,claude,codex",
+                "--providers",
+                "vertex,chatgpt",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0
+        out = _strip_ansi(result.stdout)
+        assert "agents: gascity, claude, codex" in out
+        assert "providers: vertex, chatgpt" in out
+        # Derived per-agent providers.
+        assert "gascity -> vertex" in out
+        assert "claude -> vertex" in out
+        assert "codex -> chatgpt" in out
+
+    def test_agents_repeatable_option(self):
+        """--agents can be repeated as well as comma-separated."""
+        result = runner.invoke(
+            app,
+            ["create", "--agents", "gascity", "--agents", "claude", "--dry-run"],
+        )
+        assert result.exit_code == 0
+        assert "agents: gascity, claude" in _strip_ansi(result.stdout)
+
+    def test_singular_agent_alias_dry_run(self):
+        """--agent still resolves to a single-item agents list."""
+        result = runner.invoke(app, ["create", "--agent", "gascity", "--dry-run"])
+        assert result.exit_code == 0
+        assert "agents: gascity" in _strip_ansi(result.stdout)
+
+    def test_agents_deduplicated(self):
+        """Duplicate agents are removed, preserving order."""
+        result = runner.invoke(
+            app, ["create", "--agents", "claude,claude,codex", "--dry-run"]
+        )
+        assert result.exit_code == 0
+        assert "agents: claude, codex" in _strip_ansi(result.stdout)
+
+    def test_agent_and_agents_conflict(self):
+        """Passing both --agent and --agents fails with a clear message."""
+        result = runner.invoke(
+            app, ["create", "--agent", "claude", "--agents", "codex", "--dry-run"]
+        )
+        assert result.exit_code != 0
+        assert "not both" in _strip_ansi(result.output)
+
+    def test_provider_and_providers_conflict(self):
+        """Passing both --provider and --providers fails with a clear message."""
+        result = runner.invoke(
+            app,
+            [
+                "create",
+                "--provider",
+                "vertex",
+                "--providers",
+                "chatgpt",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "not both" in _strip_ansi(result.output)
+
+    def test_unknown_agent_rejected(self):
+        """An unknown agent name in --agents is rejected."""
+        result = runner.invoke(
+            app, ["create", "--agents", "not-a-real-agent", "--dry-run"]
+        )
+        assert result.exit_code != 0
+
+
 @pytest.mark.parametrize(
     "args",
     [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -449,6 +449,34 @@ class TestAgentsProvidersLists:
         )
         assert result.exit_code != 0
 
+    @patch("paude.cli.create_podman.create_podman_session")
+    @patch("paude.cli.create._prepare_session_create")
+    def test_multi_agent_real_create_warns(self, mock_prepare, mock_create):
+        """A real (non-dry-run) create with >1 agent warns and drops extras."""
+        mock_prepare.return_value = ([], [], {}, False)
+        result = runner.invoke(
+            app, ["create", "--agents", "claude,codex,gascity"]
+        )
+        assert result.exit_code == 0
+        out = _strip_ansi(result.output)
+        assert "multi-agent creation is not yet supported" in out
+        assert "codex, gascity" in out
+        # Only the primary agent is actually created.
+        mock_create.assert_called_once()
+        assert mock_create.call_args.kwargs["agent_name"] == "claude"
+
+    @patch("paude.cli.create_podman.create_podman_session")
+    @patch("paude.cli.create._prepare_session_create")
+    def test_single_agent_real_create_no_warning(self, mock_prepare, mock_create):
+        """A real create with a single agent emits no multi-agent warning."""
+        mock_prepare.return_value = ([], [], {}, False)
+        result = runner.invoke(app, ["create", "--agents", "claude"])
+        assert result.exit_code == 0
+        assert "multi-agent creation is not yet supported" not in _strip_ansi(
+            result.output
+        )
+        mock_create.assert_called_once()
+
 
 @pytest.mark.parametrize(
     "args",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -119,9 +119,7 @@ def test_dry_run_no_gpu_hides_gpu():
 
 def test_dry_run_shows_forward_ports():
     """--dry-run shows forward-ports with cli provenance when specified."""
-    result = runner.invoke(
-        app, ["create", "--forward-port", "8372", "--dry-run"]
-    )
+    result = runner.invoke(app, ["create", "--forward-port", "8372", "--dry-run"])
     assert result.exit_code == 0
     assert "forward-ports: 8372  (cli)" in result.stdout
 
@@ -152,9 +150,7 @@ def test_dry_run_hides_forward_ports_when_unset():
 
 def test_forward_port_invalid_spec_errors():
     """An invalid --forward-port spec fails with a clear error."""
-    result = runner.invoke(
-        app, ["create", "--forward-port", "not-a-port", "--dry-run"]
-    )
+    result = runner.invoke(app, ["create", "--forward-port", "not-a-port", "--dry-run"])
     assert result.exit_code == 1
     # Error goes to stderr, which typer may redirect to stdout
     output = result.stdout + (result.stderr or "")
@@ -454,9 +450,7 @@ class TestAgentsProvidersLists:
     def test_multi_agent_real_create_warns(self, mock_prepare, mock_create):
         """A real (non-dry-run) create with >1 agent warns and drops extras."""
         mock_prepare.return_value = ([], [], {}, False)
-        result = runner.invoke(
-            app, ["create", "--agents", "claude,codex,gascity"]
-        )
+        result = runner.invoke(app, ["create", "--agents", "claude,codex,gascity"])
         assert result.exit_code == 0
         out = _strip_ansi(result.output)
         assert "multi-agent creation is not yet supported" in out
@@ -476,6 +470,32 @@ class TestAgentsProvidersLists:
             result.output
         )
         mock_create.assert_called_once()
+
+    def test_empty_agent_rejected_cleanly(self):
+        """An explicit empty --agent fails with a clean error, not a traceback."""
+        result = runner.invoke(app, ["create", "--agent", "", "--dry-run"])
+        assert result.exit_code != 0
+        assert result.exception is None or not isinstance(result.exception, IndexError)
+        assert "Agent name cannot be empty" in _strip_ansi(result.output)
+
+    def test_unused_explicit_provider_not_shown_in_dry_run(self):
+        """A --providers entry unused by any agent doesn't appear in the preview."""
+        result = runner.invoke(
+            app,
+            [
+                "create",
+                "--agents",
+                "claude,codex",
+                "--providers",
+                "anthropic,openai",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0
+        out = _strip_ansi(result.stdout)
+        assert "providers: anthropic, chatgpt" in out
+        assert "openai" not in out
+        assert "codex -> chatgpt" in out
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -348,6 +348,33 @@ class TestParseConfig:
         assert config.create_allowed_domains == []
         assert config.create_agent is None
 
+    def test_parses_paude_json_create_agents_providers(self, tmp_path: Path):
+        """parse_config extracts create agents/providers lists from paude.json."""
+        config_file = tmp_path / "paude.json"
+        config_file.write_text(
+            json.dumps(
+                {
+                    "create": {
+                        "agents": ["gascity", "claude"],
+                        "providers": ["vertex", "chatgpt"],
+                    },
+                }
+            )
+        )
+
+        config = parse_config(config_file)
+        assert config.create_agents == ["gascity", "claude"]
+        assert config.create_providers == ["vertex", "chatgpt"]
+
+    def test_create_agents_default_to_empty(self, tmp_path: Path):
+        """create agents/providers default to empty lists when not present."""
+        config_file = tmp_path / "paude.json"
+        config_file.write_text(json.dumps({"create": {"agent": "claude"}}))
+
+        config = parse_config(config_file)
+        assert config.create_agents == []
+        assert config.create_providers == []
+
     def test_parses_devcontainer_create_section(self, tmp_path: Path):
         """parse_config extracts create hints from devcontainer customizations."""
         config_file = tmp_path / ".devcontainer.json"

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -156,3 +156,34 @@ class TestShowDryRun:
 
         captured = capsys.readouterr()
         assert "gpu:" not in captured.out
+
+    def test_shows_agents_providers_lists(self, capsys: pytest.CaptureFixture[str]):
+        """Shows agents/providers lists, provenance, and per-agent mapping."""
+        from paude.config.resolver import ResolvedCreateOptions, SettingValue
+
+        resolved = ResolvedCreateOptions(
+            agent=SettingValue("gascity", "cli"),
+            provider=SettingValue("vertex", "cli"),
+            agents=["gascity", "claude", "codex"],
+            agents_provenance=[(["gascity", "claude", "codex"], "cli")],
+            providers=["vertex", "chatgpt"],
+            providers_provenance=[(["vertex", "chatgpt"], "cli")],
+            agent_providers=[
+                ("gascity", "vertex"),
+                ("claude", "vertex"),
+                ("codex", "chatgpt"),
+            ],
+        )
+
+        with patch("paude.dry_run.Path.cwd") as mock_cwd:
+            mock_cwd.return_value = Path("/test")
+            with patch("paude.dry_run.detect_config") as mock_detect:
+                mock_detect.return_value = None
+                show_dry_run({}, resolved=resolved)
+
+        captured = capsys.readouterr()
+        assert "agents: gascity, claude, codex" in captured.out
+        assert "providers: vertex, chatgpt" in captured.out
+        assert "per-agent providers:" in captured.out
+        assert "gascity -> vertex" in captured.out
+        assert "codex -> chatgpt" in captured.out

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -204,6 +204,140 @@ class TestResolveCreateOptions:
         assert result.forward_ports.source == "cli"
 
 
+class TestResolveAgentsAndProviders:
+    """Tests for list-valued agents/providers resolution."""
+
+    def _resolve(self, **kwargs):
+        defaults = {
+            "cli_backend": None,
+            "cli_agent": None,
+            "cli_yolo": None,
+            "cli_git": None,
+            "cli_platform": None,
+            "cli_gpu": None,
+            "cli_allowed_domains": None,
+            "project_config": None,
+            "user_defaults": UserDefaults(),
+        }
+        defaults.update(kwargs)
+        return resolve_create_options(**defaults)
+
+    def test_builtin_agents_default(self):
+        """Defaults to a single-item [claude] agents list."""
+        result = self._resolve()
+        assert result.agents == ["claude"]
+        assert result.agent.value == "claude"
+        assert result.agents_provenance == [(["claude"], "built-in")]
+
+    def test_cli_agents_list(self):
+        """--agents populates the list; first is the primary scalar."""
+        result = self._resolve(cli_agents=["gascity", "claude", "codex"])
+        assert result.agents == ["gascity", "claude", "codex"]
+        assert result.agent.value == "gascity"
+        assert result.agent.source == "cli"
+        assert result.agents_provenance == [
+            (["gascity", "claude", "codex"], "cli")
+        ]
+
+    def test_singular_agent_alias(self):
+        """--agent behaves as a single-item --agents list."""
+        result = self._resolve(cli_agent="gascity")
+        assert result.agents == ["gascity"]
+        assert result.agent.value == "gascity"
+
+    def test_agent_and_agents_conflict(self):
+        """Passing both --agent and --agents raises a clear error."""
+        with pytest.raises(ValueError, match="not both"):
+            self._resolve(cli_agent="claude", cli_agents=["codex"])
+
+    def test_provider_and_providers_conflict(self):
+        """Passing both --provider and --providers raises a clear error."""
+        with pytest.raises(ValueError, match="not both"):
+            self._resolve(cli_provider="vertex", cli_providers=["chatgpt"])
+
+    def test_agents_deduplicated_preserving_order(self):
+        """Duplicate agent names are removed, keeping first-seen order."""
+        result = self._resolve(cli_agents=["claude", "claude", "codex"])
+        assert result.agents == ["claude", "codex"]
+
+    def test_unknown_agent_rejected(self):
+        """An unknown agent name raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown agent"):
+            self._resolve(cli_agents=["not-a-real-agent"])
+
+    def test_invalid_primary_provider_rejected(self):
+        """An unsupported primary agent/provider combination raises."""
+        with pytest.raises(ValueError, match="does not support provider"):
+            self._resolve(cli_agents=["codex"], cli_providers=["vertex"])
+
+    def test_per_agent_providers_derived(self):
+        """Each agent maps to its provider; primary honors --providers[0]."""
+        result = self._resolve(
+            cli_agents=["gascity", "claude", "codex"],
+            cli_providers=["vertex", "chatgpt"],
+        )
+        assert result.agent_providers == [
+            ("gascity", "vertex"),
+            ("claude", "vertex"),
+            ("codex", "chatgpt"),
+        ]
+        # The explicit pool keeps its provenance and order.
+        assert result.providers == ["vertex", "chatgpt"]
+        assert result.providers_provenance == [(["vertex", "chatgpt"], "cli")]
+
+    def test_provider_auto_added_from_default(self):
+        """A non-primary agent's default provider is auto-added to the list."""
+        result = self._resolve(
+            cli_agents=["claude", "codex"],
+            cli_providers=["vertex"],
+        )
+        # codex defaults to chatgpt, which was not in the explicit pool.
+        assert result.agent_providers == [
+            ("claude", "vertex"),
+            ("codex", "chatgpt"),
+        ]
+        assert result.providers == ["vertex", "chatgpt"]
+        sources = {source for _, source in result.providers_provenance}
+        assert sources == {"cli", "built-in"}
+
+    def test_providers_default_from_agent_defaults(self):
+        """With no --providers, each agent's default provider is derived."""
+        result = self._resolve(cli_agents=["claude"])
+        assert result.providers == ["vertex"]
+        assert result.agent_providers == [("claude", "vertex")]
+        # The scalar provider stays unset for back-compat when not given.
+        assert result.provider.value is None
+
+    def test_agents_from_user_defaults(self):
+        """Agents resolve from user defaults when no CLI value is given."""
+        user = UserDefaults(agents=["gemini", "codex"])
+        result = self._resolve(user_defaults=user)
+        assert result.agents == ["gemini", "codex"]
+        assert result.agents_provenance == [(["gemini", "codex"], "user defaults")]
+
+    def test_cli_agents_override_user_defaults(self):
+        """CLI --agents overrides user-default agents."""
+        user = UserDefaults(agents=["gemini"])
+        result = self._resolve(cli_agents=["claude"], user_defaults=user)
+        assert result.agents == ["claude"]
+        assert result.agents_provenance == [(["claude"], "cli")]
+
+    def test_project_agents_override_user(self):
+        """Project config agents override user defaults."""
+        user = UserDefaults(agents=["gemini"])
+        project = PaudeConfig(create_agents=["claude", "codex"])
+        result = self._resolve(user_defaults=user, project_config=project)
+        assert result.agents == ["claude", "codex"]
+        assert result.agents_provenance == [(["claude", "codex"], "paude.json")]
+
+    def test_project_singular_agent_alias(self):
+        """Project singular create_agent acts as a one-item list."""
+        project = PaudeConfig(create_agent="cursor")
+        result = self._resolve(project_config=project)
+        assert result.agents == ["cursor"]
+        assert result.agents_provenance == [(["cursor"], "paude.json")]
+
+
 class TestUserDefaultsGpu:
     """Tests for GPU field in user defaults."""
 
@@ -282,3 +416,39 @@ class TestUserDefaultsForwardPorts:
 
         result = load_user_defaults(config)
         assert result.forward_ports == []
+
+
+class TestUserDefaultsAgentsProviders:
+    """Tests for agents/providers lists in user defaults."""
+
+    def test_agents_list_loads_from_json(self, tmp_path: Path):
+        """agents/providers lists load from JSON config."""
+        config = tmp_path / "defaults.json"
+        config.write_text(
+            json.dumps(
+                {"defaults": {"agents": ["gascity", "claude"], "providers": ["vertex"]}}
+            )
+        )
+
+        result = load_user_defaults(config)
+        assert result.agents == ["gascity", "claude"]
+        assert result.providers == ["vertex"]
+
+    def test_agents_default_to_empty(self, tmp_path: Path):
+        """agents/providers default to empty lists when not in config."""
+        config = tmp_path / "defaults.json"
+        config.write_text(json.dumps({"defaults": {"backend": "podman"}}))
+
+        result = load_user_defaults(config)
+        assert result.agents == []
+        assert result.providers == []
+
+    def test_agents_non_strings_dropped(self, tmp_path: Path):
+        """Non-string entries in agents/providers are dropped."""
+        config = tmp_path / "defaults.json"
+        config.write_text(
+            json.dumps({"defaults": {"agents": ["claude", 42, None, "codex"]}})
+        )
+
+        result = load_user_defaults(config)
+        assert result.agents == ["claude", "codex"]

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -235,9 +235,7 @@ class TestResolveAgentsAndProviders:
         assert result.agents == ["gascity", "claude", "codex"]
         assert result.agent.value == "gascity"
         assert result.agent.source == "cli"
-        assert result.agents_provenance == [
-            (["gascity", "claude", "codex"], "cli")
-        ]
+        assert result.agents_provenance == [(["gascity", "claude", "codex"], "cli")]
 
     def test_singular_agent_alias(self):
         """--agent behaves as a single-item --agents list."""
@@ -336,6 +334,35 @@ class TestResolveAgentsAndProviders:
         result = self._resolve(project_config=project)
         assert result.agents == ["cursor"]
         assert result.agents_provenance == [(["cursor"], "paude.json")]
+
+    def test_empty_agent_rejected_cleanly(self):
+        """An explicit empty-string --agent raises ValueError, not IndexError."""
+        with pytest.raises(ValueError, match="Agent name cannot be empty"):
+            self._resolve(cli_agent="")
+
+    def test_empty_agent_from_user_defaults_rejected_cleanly(self):
+        """An explicit empty-string agent in user defaults raises ValueError."""
+        user = UserDefaults(agent="")
+        with pytest.raises(ValueError, match="Agent name cannot be empty"):
+            self._resolve(user_defaults=user)
+
+    def test_unused_explicit_provider_excluded(self):
+        """A --providers entry never assigned to any agent is not listed."""
+        result = self._resolve(
+            cli_agents=["claude", "codex"],
+            cli_providers=["anthropic", "openai"],
+        )
+        # codex isn't the primary, so it falls back to its own default
+        # (chatgpt) rather than the explicit "openai" — which should not
+        # appear anywhere in the resolved providers.
+        assert result.agent_providers == [
+            ("claude", "anthropic"),
+            ("codex", "chatgpt"),
+        ]
+        assert result.providers == ["anthropic", "chatgpt"]
+        assert "openai" not in result.providers
+        all_listed = {p for values, _ in result.providers_provenance for p in values}
+        assert "openai" not in all_listed
 
 
 class TestUserDefaultsGpu:


### PR DESCRIPTION
Introduce list-valued `--agents` and `--providers` on `paude create` while
keeping the singular `--agent`/`--provider` flags as backward-compatible
aliases. Both plural options accept comma-separated values and are repeatable;
the first agent is the primary and duplicates are removed preserving order.

- cli/create.py: add --agents/--providers, normalize via _split_list_option,
  and pass them through resolve_create_options.
- cli/helpers.py: add _split_list_option to flatten comma-separated/repeatable
  option values.
- config/resolver.py: ResolvedCreateOptions grows agents/providers lists (with
  provenance) plus a derived per-agent agent_providers mapping; the agent/
  provider scalars remain as the primary. Singular and plural forms are
  mutually exclusive. Each agent's default provider is auto-added to the pool;
  the primary agent honors the first explicit provider (back-compat).
- config/models.py, parser.py, user_config.py: accept create_agents/
  create_providers in paude.json and agents/providers in user defaults.
- dry_run.py: display both lists with provenance and the per-agent providers.
- Update README.md and cli/help.py for the new options.

Tests cover plural parse, singular alias, both-given error, dedup, provenance,
and per-agent provider derivation across CLI, resolver, parser, user-config,
and dry-run layers.