### PR TITLE
fix: warn on dropped providers, reject empty --provider, fix dry-run display

### DIFF
--- a/src/paude/cli/create.py
+++ b/src/paude/cli/create.py
@@ -317,6 +317,14 @@ def session_create(
             err=True,
         )
 
+    if resolved.dropped_providers:
+        dropped_providers = ", ".join(resolved.dropped_providers)
+        typer.echo(
+            "Warning: some --providers entries are not used by any agent; "
+            f"ignoring: {dropped_providers}.",
+            err=True,
+        )
+
     if ssh_key and not host:
         typer.echo(
             "Error: --ssh-key requires --host.",

--- a/src/paude/config/resolver.py
+++ b/src/paude/config/resolver.py
@@ -73,6 +73,8 @@ class ResolvedCreateOptions:
     agents_provenance: list[tuple[list[str], Source]] = field(default_factory=list)
     providers: list[str] = field(default_factory=list)
     providers_provenance: list[tuple[list[str], Source]] = field(default_factory=list)
+    # Explicit --providers entries never assigned to any agent (real create warns).
+    dropped_providers: list[str] = field(default_factory=list)
     # Derived per-agent provider mapping (ordered, first = primary).
     agent_providers: list[tuple[str, str]] = field(default_factory=list)
     allowed_domains: list[str] = field(default_factory=list)
@@ -312,6 +314,11 @@ def _resolve_agents_and_providers(
         user=user_defaults.providers or _as_list(user_defaults.provider),
         builtin=[],
     )
+    if not provider_pool and providers_source != "built-in":
+        raise ValueError(
+            "Provider name cannot be empty. Specify a non-empty "
+            "--provider/--providers value."
+        )
 
     # The primary provider scalar mirrors the highest-precedence explicit
     # provider (first in the pool), or None when nothing was configured.
@@ -339,6 +346,7 @@ def _resolve_agents_and_providers(
         result.providers_provenance.append((used_explicit, providers_source))
     if auto_added:
         result.providers_provenance.append((auto_added, "built-in"))
+    result.dropped_providers = [p for p in provider_pool if p not in used]
 
 
 def _as_list(value: str | None) -> list[str] | None:

--- a/src/paude/dry_run.py
+++ b/src/paude/dry_run.py
@@ -10,7 +10,12 @@ import typer
 from paude.agents import get_agent
 from paude.config import detect_config, parse_config
 from paude.config.dockerfile import generate_workspace_dockerfile
-from paude.config.resolver import ResolvedCreateOptions, Source, format_setting
+from paude.config.resolver import (
+    ResolvedCreateOptions,
+    SettingValue,
+    Source,
+    format_setting,
+)
 from paude.domains import format_domains_for_display
 
 
@@ -141,7 +146,14 @@ def _show_agents_and_providers(resolved: ResolvedCreateOptions) -> None:
         _show_provenance_groups(resolved.providers_provenance)
     else:
         typer.echo("  providers: (not set)  (built-in)")
-    typer.echo(format_setting("provider", resolved.provider))
+
+    # The legacy scalar mirrors the primary agent's effective provider so it
+    # doesn't contradict "per-agent providers" below when no explicit
+    # --provider/--providers was given.
+    provider_display = resolved.provider
+    if provider_display.value is None and resolved.agent_providers:
+        provider_display = SettingValue(resolved.agent_providers[0][1], "built-in")
+    typer.echo(format_setting("provider", provider_display))
 
     # Derived per-agent provider mapping (first = primary).
     if resolved.agent_providers:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -478,6 +478,52 @@ class TestAgentsProvidersLists:
         assert result.exception is None or not isinstance(result.exception, IndexError)
         assert "Agent name cannot be empty" in _strip_ansi(result.output)
 
+    def test_empty_provider_rejected_cleanly(self):
+        """An explicit empty --provider fails with a clean error, not a silent default."""
+        result = runner.invoke(app, ["create", "--provider", "", "--dry-run"])
+        assert result.exit_code != 0
+        assert "Provider name cannot be empty" in _strip_ansi(result.output)
+
+    @patch("paude.cli.create_podman.create_podman_session")
+    @patch("paude.cli.create._prepare_session_create")
+    def test_unused_explicit_provider_warns_on_real_create(
+        self, mock_prepare, mock_create
+    ):
+        """A real create warns when an explicit --providers entry goes unused."""
+        mock_prepare.return_value = ([], [], {}, False)
+        result = runner.invoke(
+            app,
+            [
+                "create",
+                "--agents",
+                "claude,codex",
+                "--providers",
+                "anthropic,openai",
+            ],
+        )
+        assert result.exit_code == 0
+        out = _strip_ansi(result.output)
+        assert "not used by any agent" in out
+        assert "openai" in out
+        mock_create.assert_called_once()
+
+    @patch("paude.cli.create_podman.create_podman_session")
+    @patch("paude.cli.create._prepare_session_create")
+    def test_single_agent_unused_provider_warns_on_real_create(
+        self, mock_prepare, mock_create
+    ):
+        """A real create with one agent still warns about unused --providers entries."""
+        mock_prepare.return_value = ([], [], {}, False)
+        result = runner.invoke(
+            app, ["create", "--agents", "claude", "--providers", "vertex,openai"]
+        )
+        assert result.exit_code == 0
+        out = _strip_ansi(result.output)
+        assert "multi-agent creation is not yet supported" not in out
+        assert "not used by any agent" in out
+        assert "openai" in out
+        mock_create.assert_called_once()
+
     def test_unused_explicit_provider_not_shown_in_dry_run(self):
         """A --providers entry unused by any agent doesn't appear in the preview."""
         result = runner.invoke(

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -187,3 +187,24 @@ class TestShowDryRun:
         assert "per-agent providers:" in captured.out
         assert "gascity -> vertex" in captured.out
         assert "codex -> chatgpt" in captured.out
+
+    def test_provider_scalar_matches_agent_default_when_unset(
+        self, capsys: pytest.CaptureFixture[str]
+    ):
+        """Legacy provider scalar mirrors the derived default, not '(not set)'."""
+        from paude.config.resolver import ResolvedCreateOptions
+
+        resolved = ResolvedCreateOptions(
+            agents=["claude"],
+            agent_providers=[("claude", "vertex")],
+        )
+
+        with patch("paude.dry_run.Path.cwd") as mock_cwd:
+            mock_cwd.return_value = Path("/test")
+            with patch("paude.dry_run.detect_config") as mock_detect:
+                mock_detect.return_value = None
+                show_dry_run({}, resolved=resolved)
+
+        captured = capsys.readouterr()
+        assert "provider: vertex" in captured.out
+        assert "provider: (not set)" not in captured.out

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -364,6 +364,25 @@ class TestResolveAgentsAndProviders:
         all_listed = {p for values, _ in result.providers_provenance for p in values}
         assert "openai" not in all_listed
 
+    def test_unused_explicit_provider_recorded_as_dropped(self):
+        """A --providers entry never assigned to any agent is recorded as dropped."""
+        result = self._resolve(
+            cli_agents=["claude", "codex"],
+            cli_providers=["anthropic", "openai"],
+        )
+        assert result.dropped_providers == ["openai"]
+
+    def test_empty_provider_rejected_cleanly(self):
+        """An explicit empty-string --provider raises ValueError, not a silent default."""
+        with pytest.raises(ValueError, match="Provider name cannot be empty"):
+            self._resolve(cli_agents=["claude"], cli_provider="")
+
+    def test_empty_provider_from_user_defaults_rejected_cleanly(self):
+        """An explicit empty-string provider in user defaults raises ValueError."""
+        user = UserDefaults(provider="")
+        with pytest.raises(ValueError, match="Provider name cannot be empty"):
+            self._resolve(user_defaults=user)
+
 
 class TestUserDefaultsGpu:
     """Tests for GPU field in user defaults."""


### PR DESCRIPTION
Code review of the --agents/--providers list feature found three gaps: a real create silently dropped unused --providers entries with no warning (unlike agents), --provider "" silently fell back to a default instead of erroring like --agent "" does, and dry-run's legacy "provider: (not set)" line contradicted the accurate "per-agent providers" mapping next to it.