### PR TITLE
Persist agent state across image upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,20 @@ uv tool install paude
 
 > **First run**: Paude pulls container images on first use. This takes a few minutes; subsequent runs start immediately.
 
+### Persistent sessions and upgrades
+
+Agent configuration, logins, conversation history, skills, and workspace data
+are stored on each session's private volume. They survive `start`, `stop`, and
+container recreation. After updating Paude, refresh a session with:
+
+```bash
+paude upgrade SESSION
+```
+
+The command performs a fresh build with the latest stable agent tooling and
+migrates state from older containers before replacing them. See
+[Session Management](docs/SESSIONS.md) for the per-agent persistence paths.
+
 ### Your First Session
 
 ```bash

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -8,7 +8,7 @@ The container intentionally restricts certain operations:
 | Proxy source IP | when the proxy has a fixed network IP (as on Podman), only the paired agent container's IP is accepted | Defense-in-depth: prevents other containers/hosts from riding the proxy's egress allowlist |
 | Host working directory | not mounted | Code lives in a separate named volume, synced via git (see [Code Synchronization](SESSIONS.md#code-synchronization)) — the agent never touches host files directly |
 | gcloud credentials | never enter the agent's container; a non-functional stub ADC file is injected instead | Real credentials live only on the network-filtering proxy sidecar, which signs Vertex AI requests on the container's behalf |
-| Agent config | copied in, not mounted | Prevents host config poisoning |
+| Agent config and session state | copied in, then stored on the private session volume | Prevents host config poisoning while preserving settings and history across container upgrades |
 | `~/.gitconfig` | writable copy, persisted on the session volume (read-only bind mount only for `--host` remote sessions) | Git identity |
 | SSH keys | not mounted | Prevents git push via SSH |
 | GitHub CLI config | not mounted | Prevents cached host credentials |

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -21,7 +21,7 @@ paude
 | `stop` | Stops the container, preserves the volume |
 | `connect` | Attaches to running session |
 | `cp` | Copies files between local machine and session |
-| `upgrade` | Upgrades session to current paude version; can also reconfigure options (`--otel-endpoint`, `--allowed-domains`, `--gpu`/`--no-gpu`, `--yolo`/`--no-yolo`, `--provider`) in place, preserving data |
+| `upgrade` | Pulls current bases, rebuilds with the latest stable agent tooling, and recreates the session while preserving workspace and agent state; can also reconfigure options (`--otel-endpoint`, `--allowed-domains`, `--gpu`/`--no-gpu`, `--yolo`/`--no-yolo`, `--provider`) |
 | `remote` | Manages git remotes for code sync |
 | `delete` | Removes all resources including volume |
 | `list` | Shows all sessions with version info |
@@ -67,6 +67,31 @@ paude delete my-project --confirm
 # (useful for orphaned or legacy sessions)
 paude delete my-project --confirm --force
 ```
+
+`upgrade` performs a fresh build even when the session already uses the
+current Paude version. Before replacing the container, it migrates state from
+older container writable layers into the session volume. This preserves agent
+configuration, logins, conversation history, installed skills, and other
+mutable state in addition to `/pvc/workspace`.
+
+The legacy `--rebuild` option is still accepted for compatibility, but is no
+longer necessary because upgrades always rebuild.
+
+### Persisted agent state
+
+| Agent | PVC-backed home paths |
+|-------|-----------------------|
+| Claude Code | `~/.claude`, `~/.claude.json` |
+| Codex CLI | `~/.codex`, `~/.agents` |
+| Cursor CLI | `~/.cursor`, `~/.config/cursor` |
+| Gemini CLI | `~/.gemini`, `~/.agents` |
+| OpenCode | `~/.config/opencode`, `~/.local/share/opencode`, `~/.local/state/opencode` |
+| OpenClaw | `~/.openclaw` |
+| Gas City | `~/.gc`, bundled-agent paths |
+
+Shared writable Git and Dolt configuration is also stored on the session
+volume. Regenerable caches and image-installed binaries are rebuilt instead
+of persisted.
 
 ## Backend Selection
 

--- a/src/paude/agents/base.py
+++ b/src/paude/agents/base.py
@@ -26,6 +26,8 @@ class AgentConfig:
         secret_env_vars: Host env vars to deliver securely (not in container spec).
         passthrough_env_prefixes: Host env var prefixes to forward.
         config_dir_name: Config directory under HOME (e.g., ".claude").
+        extra_persistent_dir_names: Additional mutable directories under HOME
+            that must survive container recreation.
         config_file_name: Config file under HOME (e.g., ".claude.json"), or None.
         activity_files: Paths (relative to config dir) for activity detection.
         yolo_flag: CLI flag to skip permissions
@@ -54,6 +56,7 @@ class AgentConfig:
     secret_env_vars: list[str] = field(default_factory=list)
     passthrough_env_prefixes: list[str] = field(default_factory=list)
     config_dir_name: str = ".claude"
+    extra_persistent_dir_names: list[str] = field(default_factory=list)
     config_file_name: str | None = ".claude.json"
     activity_files: list[str] = field(default_factory=list)
     yolo_flag: str | None = "--dangerously-skip-permissions"
@@ -65,6 +68,13 @@ class AgentConfig:
     default_base_image: str | None = None
     provider: str | None = None
     bundled_agents: list[str] = field(default_factory=list)
+
+    @property
+    def persistent_dir_names(self) -> list[str]:
+        """Return every HOME-relative directory that must live on the PVC."""
+        return list(
+            dict.fromkeys([self.config_dir_name, *self.extra_persistent_dir_names])
+        )
 
 
 @dataclass
@@ -389,7 +399,9 @@ def compose_dockerfile_install_lines(
     """
     config_dirs = list(
         dict.fromkeys(
-            f"{container_home}/{agent.config.config_dir_name}" for agent in agents
+            f"{container_home}/{directory}"
+            for agent in agents
+            for directory in agent.config.persistent_dir_names
         )
     )
     combined: list[str] = [

--- a/src/paude/agents/codex.py
+++ b/src/paude/agents/codex.py
@@ -12,7 +12,6 @@ from paude.agents.base import (
 )
 from paude.constants import CONTAINER_HOME
 
-CODEX_VERSION = "0.144.5"
 CODEX_CHATGPT_PROFILE_NAME = "paude-chatgpt-http"
 CODEX_CHATGPT_PROFILE_TARGET = (
     f"/home/paude/.codex/{CODEX_CHATGPT_PROFILE_NAME}.config.toml"
@@ -39,9 +38,8 @@ _INSTALL_SCRIPT = (
     '*) echo "Unsupported architecture: $ARCH" && exit 1 ;; '
     "esac && "
     "curl -fsSL "
-    '"https://github.com/openai/codex/releases/download/'
-    f"rust-v{CODEX_VERSION}"
-    '/codex-${CODEX_ARCH}.tar.gz"'
+    '"https://github.com/openai/codex/releases/latest/download/'
+    'codex-${CODEX_ARCH}.tar.gz"'
     ' | tar xz -C "$HOME/.local/bin" "codex-${CODEX_ARCH}" && '
     'mv "$HOME/.local/bin/codex-${CODEX_ARCH}" "$HOME/.local/bin/codex"'
 )
@@ -64,6 +62,7 @@ class CodexAgent:
             secret_env_vars=creds.secret_env_vars,
             passthrough_env_prefixes=creds.passthrough_env_prefixes,
             config_dir_name=".codex",
+            extra_persistent_dir_names=[".agents"],
             config_file_name=None,
             activity_files=[],
             yolo_flag="--dangerously-bypass-approvals-and-sandbox",

--- a/src/paude/agents/cursor.py
+++ b/src/paude/agents/cursor.py
@@ -32,6 +32,7 @@ class CursorAgent:
             secret_env_vars=creds.secret_env_vars,
             passthrough_env_prefixes=creds.passthrough_env_prefixes,
             config_dir_name=".cursor",
+            extra_persistent_dir_names=[".config/cursor"],
             config_file_name=None,
             activity_files=[],
             yolo_flag="--yolo",

--- a/src/paude/agents/gascity.py
+++ b/src/paude/agents/gascity.py
@@ -11,10 +11,6 @@ from paude.agents.base import (
     nodejs_prereq_install_lines,
 )
 
-GC_VERSION = "1.4.0"
-DOLT_VERSION = "2.1.10"
-BD_VERSION = "1.1.0"
-
 
 class GascityAgent:
     """Gas City agent — composite agent with gc, Claude Code, and Gemini CLI.
@@ -45,7 +41,7 @@ class GascityAgent:
             passthrough_env_vars=creds.passthrough_env_vars,
             secret_env_vars=creds.secret_env_vars,
             passthrough_env_prefixes=creds.passthrough_env_prefixes,
-            config_dir_name=".gascity",
+            config_dir_name=".gc",
             config_file_name=None,
             yolo_flag=None,
             clear_command=None,
@@ -84,18 +80,27 @@ class GascityAgent:
             'aarch64) BIN_ARCH="arm64" ;; '
             '*) echo "Unsupported: $ARCH" && exit 1 ;; '
             "esac && "
+            "DOLT_URL=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "
+            "https://github.com/dolthub/dolt/releases/latest) && "
+            "DOLT_TAG=${DOLT_URL##*/} && DOLT_VERSION=${DOLT_TAG#v} && "
+            "BD_URL=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "
+            "https://github.com/gastownhall/beads/releases/latest) && "
+            "BD_TAG=${BD_URL##*/} && BD_VERSION=${BD_TAG#v} && "
+            "GC_URL=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "
+            "https://github.com/gastownhall/gascity/releases/latest) && "
+            "GC_TAG=${GC_URL##*/} && GC_VERSION=${GC_TAG#v} && "
             'curl -fsSL "https://github.com/dolthub/dolt'
-            f"/releases/download/v{DOLT_VERSION}"
+            "/releases/download/${DOLT_TAG}"
             '/dolt-linux-${BIN_ARCH}.tar.gz"'
             " | tar xz --strip-components=2"
             " -C $D dolt-linux-${BIN_ARCH}/bin/dolt && "
             'curl -fsSL "https://github.com/gastownhall'
-            f"/beads/releases/download/v{BD_VERSION}"
-            f'/beads_{BD_VERSION}_linux_${{BIN_ARCH}}.tar.gz"'
+            "/beads/releases/download/${BD_TAG}"
+            '/beads_${BD_VERSION}_linux_${BIN_ARCH}.tar.gz"'
             " | tar xz -C $D bd && "
             'curl -fsSL "https://github.com/gastownhall'
-            f"/gascity/releases/download/v{GC_VERSION}"
-            f"/gascity_{GC_VERSION}_linux_${{BIN_ARCH}}"
+            "/gascity/releases/download/${GC_TAG}"
+            "/gascity_${GC_VERSION}_linux_${BIN_ARCH}"
             '.tar.gz" | tar xz -C $D gc && '
             "$D/dolt config --global --set metrics.disabled true && "
             '$D/dolt config --global --set user.name "Paude Agent" && '

--- a/src/paude/agents/gemini.py
+++ b/src/paude/agents/gemini.py
@@ -26,13 +26,14 @@ class GeminiAgent:
             # Runtime fallback only — requires Node.js already in the image.
             # Normal path: dockerfile_install_lines bakes Node.js + CLI into image,
             # and install_agent() skips via `command -v gemini`.
-            install_script="npm install -g @google/gemini-cli@0.35.3",
+            install_script="npm install -g @google/gemini-cli@latest",
             install_dir=".local/bin",
             env_vars=creds.extra_env_vars,
             passthrough_env_vars=creds.passthrough_env_vars,
             secret_env_vars=creds.secret_env_vars,
             passthrough_env_prefixes=creds.passthrough_env_prefixes,
             config_dir_name=".gemini",
+            extra_persistent_dir_names=[".agents"],
             config_file_name=None,
             activity_files=[],
             yolo_flag="--yolo",
@@ -52,7 +53,7 @@ class GeminiAgent:
             *nodejs_prereq_install_lines(),
             "",
             "# Install Gemini CLI and patch OTEL proxy",
-            "RUN npm install -g @google/gemini-cli@0.35.3"
+            "RUN npm install -g @google/gemini-cli@latest"
             " && /usr/local/bin/patch-gemini-otel-proxy.sh"
             " --force 2>&1",
             "",

--- a/src/paude/agents/opencode.py
+++ b/src/paude/agents/opencode.py
@@ -29,6 +29,10 @@ class OpenCodeAgent:
             secret_env_vars=creds.secret_env_vars,
             passthrough_env_prefixes=creds.passthrough_env_prefixes,
             config_dir_name=".config/opencode",
+            extra_persistent_dir_names=[
+                ".local/share/opencode",
+                ".local/state/opencode",
+            ],
             config_file_name=None,
             activity_files=[],
             yolo_flag="--auto",

--- a/src/paude/backends/podman/backend.py
+++ b/src/paude/backends/podman/backend.py
@@ -97,7 +97,10 @@ class PodmanBackend:
         created_at = datetime.now(UTC).isoformat()
         labels = SessionSetup.build_session_labels(config, name, created_at)
         print(f"Creating session '{name}'...", file=sys.stderr)
-        if config.reuse_volume and self._volume_manager.volume_exists(vname):
+        volume_reused = config.reuse_volume and self._volume_manager.volume_exists(
+            vname
+        )
+        if volume_reused:
             print(f"Reusing existing volume {vname}...", file=sys.stderr)
         else:
             print(f"Creating volume {vname}...", file=sys.stderr)
@@ -119,7 +122,9 @@ class PodmanBackend:
             composition = get_agent_composition(
                 get_agent(config.agent, provider=config.provider)
             )
-        network, proxy_ip = self._create_session_proxy(config, name, composition, vname)
+        network, proxy_ip = self._create_session_proxy(
+            config, name, composition, vname, volume_reused
+        )
         try:
             self._setup.create_session_container(
                 config,
@@ -131,7 +136,7 @@ class PodmanBackend:
                 proxy_ip,
             )
         except Exception:
-            self._rollback_session_resources(config, name, vname)
+            self._rollback_session_resources(config, name, vname, volume_reused)
             raise
 
         print(f"Session '{name}' created (stopped).", file=sys.stderr)
@@ -154,6 +159,7 @@ class PodmanBackend:
         session_name: str,
         composition: AgentComposition,
         vname: str,
+        volume_reused: bool,
     ) -> tuple[str | None, str | None]:
         """Set up proxy for session creation, return (network, proxy_ip)."""
         if not config.proxy_image:
@@ -163,7 +169,7 @@ class PodmanBackend:
                 self._proxy, config, session_name, composition
             )
         except Exception:
-            if not config.reuse_volume:
+            if not volume_reused:
                 self._volume_manager.remove_volume(vname, force=True)
             raise
         return network, proxy_ip
@@ -173,13 +179,15 @@ class PodmanBackend:
         config: SessionConfig,
         session_name: str,
         vname: str,
+        volume_reused: bool,
     ) -> None:
         """Clean up proxy/volume on container creation failure."""
         if config.proxy_image:
             pname = proxy_container_name(session_name)
             self._runner.remove_container(pname, force=True)
             self._network_manager.remove_network(network_name(session_name))
-        self._volume_manager.remove_volume(vname, force=True)
+        if not volume_reused:
+            self._volume_manager.remove_volume(vname, force=True)
 
     def start_session_no_attach(self, name: str) -> None:
         """Start containers without attaching (for git setup, etc.)."""

--- a/src/paude/backends/session_env.py
+++ b/src/paude/backends/session_env.py
@@ -28,6 +28,7 @@ def build_agent_env(config: AgentConfig) -> dict[str, str]:
         "PAUDE_AGENT_SESSION_NAME": config.session_name,
         "PAUDE_AGENT_LAUNCH_CMD": config.process_name,
         "PAUDE_AGENT_CONFIG_FILE": config.config_file_name or "",
+        "PAUDE_AGENT_CONFIG_DIRS": " ".join(config.persistent_dir_names),
     }
     return env
 
@@ -101,7 +102,11 @@ def build_session_env(
     if composition is not None:
         configs = [item.config for item in composition.agents]
         env["PAUDE_AGENT_CONFIG_DIRS"] = " ".join(
-            config.config_dir_name for config in configs
+            dict.fromkeys(
+                directory
+                for config in configs
+                for directory in config.persistent_dir_names
+            )
         )
         config_files = list(
             dict.fromkeys(

--- a/src/paude/cli/help.py
+++ b/src/paude/cli/help.py
@@ -48,7 +48,10 @@ _SECTIONS: tuple[HelpSection, ...] = (
             ("paude connect", "Reconnect to running session"),
             ("git push paude-<name> main", "Push more changes to container"),
             ("paude stop", "Stop session (preserves data)"),
-            ("paude upgrade NAME", "Upgrade or reconfigure session"),
+            (
+                "paude upgrade NAME",
+                "Refresh agent tooling, preserving workspace and state",
+            ),
             ("paude delete NAME --confirm", "Delete session permanently"),
             ("paude delete NAME --confirm --force", "Remove from local config only"),
         ),

--- a/src/paude/cli/upgrade.py
+++ b/src/paude/cli/upgrade.py
@@ -46,7 +46,10 @@ def session_upgrade(
     name: Annotated[str, typer.Argument(help="Session name to upgrade")],
     rebuild: Annotated[
         bool,
-        typer.Option("--rebuild", help="Force image rebuild even at same version."),
+        typer.Option(
+            "--rebuild",
+            help="Deprecated compatibility flag; upgrades always rebuild.",
+        ),
     ] = False,
     backend: Annotated[
         BackendType | None,
@@ -120,8 +123,8 @@ def session_upgrade(
     """Upgrade a session to the current paude version.
 
     Can also reconfigure session options (e.g., --otel-endpoint, --gpu)
-    without losing workspace data. Use --rebuild to force an image rebuild
-    when only changing configuration at the same version.
+    without losing workspace or agent data. Upgrades always pull and rebuild
+    agent tooling, including when the Paude version is unchanged.
     """
     from paude import __version__
     from paude.backends.podman.backend import PodmanBackend
@@ -181,16 +184,7 @@ def session_upgrade(
 
     has_overrides = overrides.has_changes()
 
-    # Check version
-    if session.version == __version__ and not rebuild and not has_overrides:
-        typer.echo(
-            f"Session '{name}' is already at version {__version__}. "
-            "Use --rebuild to force an image rebuild, or pass config "
-            "flags (e.g. --otel-endpoint) to reconfigure."
-        )
-        return
-
-    if has_overrides and not rebuild and session.version == __version__:
+    if has_overrides and session.version == __version__:
         typer.echo(
             f"Reconfiguring session '{name}' (version {__version__})...",
             err=True,
@@ -209,7 +203,7 @@ def session_upgrade(
 
     try:
         if isinstance(backend_obj, PodmanBackend):
-            _upgrade_podman(name, backend_obj, rebuild, overrides)
+            _upgrade_podman(name, backend_obj, True, overrides)
         else:
             typer.echo("Unsupported backend for upgrade.", err=True)
             raise typer.Exit(1)
@@ -384,6 +378,13 @@ def _upgrade_podman(
     agent_specs = [
         (item.config.name, item.config.provider or "") for item in composition.agents
     ]
+
+    # Salvage state written by older images before deleting their writable layer.
+    from paude.cli.upgrade_persistence import migrate_legacy_state
+
+    typer.echo("Migrating persistent agent state...", err=True)
+    migrate_legacy_state(backend._runner, container_name(name), composition)
+
     image_manager = ImageManager(
         script_dir=_detect_dev_script_dir(),
         agent=agent_instance,
@@ -394,10 +395,10 @@ def _upgrade_podman(
     try:
         if config is not None and config.has_customizations:
             image = image_manager.ensure_custom_image(
-                config, force_rebuild=rebuild, workspace=workspace
+                config, force_rebuild=True, workspace=workspace
             )
         else:
-            image = image_manager.ensure_default_image(force_rebuild=rebuild)
+            image = image_manager.ensure_default_image(force_rebuild=True)
     except Exception as e:
         typer.echo(f"Error building image: {e}", err=True)
         raise typer.Exit(1) from None
@@ -405,7 +406,7 @@ def _upgrade_podman(
     # Build proxy image (always required — all sessions use proxy)
     proxy_image: str | None = None
     try:
-        proxy_image = image_manager.ensure_proxy_image(force_rebuild=rebuild)
+        proxy_image = image_manager.ensure_proxy_image(force_rebuild=True)
     except Exception as e:
         typer.echo(f"Error building proxy image: {e}", err=True)
         raise typer.Exit(1) from None

--- a/src/paude/cli/upgrade_persistence.py
+++ b/src/paude/cli/upgrade_persistence.py
@@ -1,0 +1,106 @@
+"""State migration helpers used before replacing a session container."""
+
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING
+
+from paude.constants import CONTAINER_HOME
+
+if TYPE_CHECKING:
+    from paude.agents.base import AgentComposition
+    from paude.container.runner import ContainerRunner
+
+
+_MIGRATE_SCRIPT = r"""
+set -e
+mode=dirs
+for relative in "$@"; do
+    if [ "$relative" = "--files" ]; then mode=files; continue; fi
+    source_path="$HOME/$relative"
+    target_path="/pvc/$relative"
+    if [ -L "$source_path" ]; then continue; fi
+    if [ "$mode" = "dirs" ] && [ -d "$source_path" ]; then
+        mkdir -p "$target_path"
+        cp -dR --preserve=mode,timestamps "$source_path/." "$target_path/"
+        chmod -R g+rwX "$target_path" 2>/dev/null || true
+        chcon -R --reference=/pvc "$target_path" 2>/dev/null || true
+    elif [ "$mode" = "files" ] && [ -f "$source_path" ]; then
+        mkdir -p "$(dirname "$target_path")"
+        cp -f --preserve=mode,timestamps "$source_path" "$target_path"
+        chmod g+rw "$target_path" 2>/dev/null || true
+        chcon --reference=/pvc "$target_path" 2>/dev/null || true
+    fi
+done
+"""
+
+
+def persistent_state_paths(
+    composition: AgentComposition,
+) -> tuple[list[str], list[str]]:
+    """Return deduplicated HOME-relative state directories and files."""
+    directories = list(
+        dict.fromkeys(
+            [
+                *(
+                    directory
+                    for agent in composition.agents
+                    for directory in agent.config.persistent_dir_names
+                ),
+                ".dolt",
+            ]
+        )
+    )
+    files = list(
+        dict.fromkeys(
+            [
+                *(
+                    agent.config.config_file_name
+                    for agent in composition.agents
+                    if agent.config.config_file_name
+                ),
+                ".gitconfig",
+            ]
+        )
+    )
+    _validate_relative_paths([*directories, *files])
+    return directories, files
+
+
+def migrate_legacy_state(
+    runner: ContainerRunner,
+    container_name: str,
+    composition: AgentComposition,
+) -> None:
+    """Copy legacy writable-layer state into the mounted session volume."""
+    directories, files = persistent_state_paths(composition)
+    was_running = runner.container_running(container_name)
+    if was_running:
+        runner.stop_container_graceful(container_name)
+    runner.start_container(container_name)
+    try:
+        runner.exec_in_container(
+            container_name,
+            [
+                "env",
+                f"HOME={CONTAINER_HOME}",
+                "bash",
+                "-c",
+                _MIGRATE_SCRIPT,
+                "paude-state-migration",
+                *directories,
+                "--files",
+                *files,
+            ],
+        )
+    finally:
+        if not was_running:
+            runner.stop_container_graceful(container_name)
+
+
+def _validate_relative_paths(paths: list[str]) -> None:
+    """Reject persistence declarations that could escape HOME or the PVC."""
+    for raw_path in paths:
+        path = PurePosixPath(raw_path)
+        if path.is_absolute() or ".." in path.parts or not raw_path.strip():
+            raise ValueError(f"Unsafe persistent state path: {raw_path!r}")

--- a/src/paude/config/dockerfile.py
+++ b/src/paude/config/dockerfile.py
@@ -131,24 +131,24 @@ def generate_workspace_dockerfile(
 RUN if command -v apt-get >/dev/null 2>&1; then \\
         apt-get update && \\
         apt-get install -y --no-install-recommends \\
-            git curl ca-certificates bash tmux locales socat \\
+            git curl ca-certificates bash tmux locales socat jq \\
             coreutils findutils grep sed gawk diffutils less file \\
             tar gzip xz-utils unzip zip && \\
         rm -rf /var/lib/apt/lists/* && \\
         localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8; \\
     elif command -v apk >/dev/null 2>&1; then \\
-        apk add --no-cache git curl ca-certificates bash tmux socat \\
+        apk add --no-cache git curl ca-certificates bash tmux socat jq \\
             coreutils findutils grep sed gawk diffutils less file \\
             tar gzip xz unzip zip; \\
     elif command -v dnf >/dev/null 2>&1; then \\
         dnf install -y --allowerasing \\
-            git curl ca-certificates bash glibc-langpack-en socat \\
+            git curl ca-certificates bash glibc-langpack-en socat jq \\
             which coreutils findutils grep sed gawk diffutils less file \\
             tar gzip xz unzip zip && \\
         dnf clean all; \\
     elif command -v yum >/dev/null 2>&1; then \\
         yum install -y --allowerasing \\
-            git curl ca-certificates bash glibc-langpack-en socat \\
+            git curl ca-certificates bash glibc-langpack-en socat jq \\
             which coreutils findutils grep sed gawk diffutils less file \\
             tar gzip xz unzip zip && \\
         yum clean all; \\
@@ -211,7 +211,11 @@ RUN if ! command -v tini >/dev/null 2>&1; then \\
     else:
         raise ValueError("An agent is required when no composition is provided")
     config_dirs = list(
-        dict.fromkeys(item.config.config_dir_name for item in install_agents)
+        dict.fromkeys(
+            directory
+            for item in install_agents
+            for directory in item.config.persistent_dir_names
+        )
     )
     lines.append(
         "RUN (id paude >/dev/null 2>&1 || (groupadd paude 2>/dev/null && useradd -M -d /home/paude -s /bin/bash -g paude paude 2>/dev/null) || adduser -D -s /bin/bash paude) && "

--- a/src/paude/container/image.py
+++ b/src/paude/container/image.py
@@ -69,8 +69,8 @@ class ImageManager:
         """
         if self.agent and self.agent.config.default_base_image:
             return self._ensure_agent_base_image(force_rebuild=force_rebuild)
-        base_tag = self._ensure_base_image()
-        return self._ensure_runtime_image(base_tag)
+        base_tag = self._ensure_base_image(force_refresh=force_rebuild)
+        return self._ensure_runtime_image(base_tag, force_rebuild=force_rebuild)
 
     def _ensure_agent_base_image(self, force_rebuild: bool = False) -> str:
         """Build image using agent's default base image with paude infrastructure.
@@ -118,7 +118,11 @@ class ImageManager:
             build_args = {"BASE_IMAGE": base_image}
             try:
                 self.build_image(
-                    Path(tmpdir) / "Dockerfile", tag, Path(tmpdir), build_args
+                    Path(tmpdir) / "Dockerfile",
+                    tag,
+                    Path(tmpdir),
+                    build_args,
+                    fresh=force_rebuild,
                 )
             except Exception:
                 engine_name = self._engine.binary
@@ -135,7 +139,7 @@ class ImageManager:
         print(f"{agent_display} installed successfully.", file=sys.stderr)
         return tag
 
-    def _ensure_base_image(self) -> str:
+    def _ensure_base_image(self, force_refresh: bool = False) -> str:
         """Ensure the base paude image (without agent) is available."""
         import sys
 
@@ -145,15 +149,15 @@ class ImageManager:
                 tag = f"paude-base-centos10:latest-{arch}"
             else:
                 tag = "paude-base-centos10:latest"
-            if not self._engine.image_exists(tag):
+            if force_refresh or not self._engine.image_exists(tag):
                 print(f"Building {tag} image...", file=sys.stderr)
                 dockerfile = self.script_dir / "containers" / "paude" / "Dockerfile"
                 context = self.script_dir / "containers" / "paude"
-                self.build_image(dockerfile, tag, context)
+                self.build_image(dockerfile, tag, context, fresh=force_refresh)
             return tag
         else:
             tag = f"{self.registry}/paude-base-centos10:{self.version}"
-            if not self._engine.image_exists(tag):
+            if force_refresh or not self._engine.image_exists(tag):
                 print(f"Pulling {tag}...", file=sys.stderr)
                 try:
                     self._engine.run(
@@ -169,7 +173,9 @@ class ImageManager:
                     raise
             return tag
 
-    def _ensure_runtime_image(self, base_image: str) -> str:
+    def _ensure_runtime_image(
+        self, base_image: str, force_rebuild: bool = False
+    ) -> str:
         """Ensure the runtime image (with agent installed) is available."""
         import sys
 
@@ -188,7 +194,7 @@ class ImageManager:
         else:
             runtime_tag = f"paude-runtime:{layer_hash[:12]}"
 
-        if self._engine.image_exists(runtime_tag):
+        if not force_rebuild and self._engine.image_exists(runtime_tag):
             print(f"Using cached runtime image: {runtime_tag}", file=sys.stderr)
             return runtime_tag
 
@@ -201,7 +207,14 @@ class ImageManager:
 
             build_args = {"BASE_IMAGE": base_image}
             try:
-                self.build_image(dockerfile_path, runtime_tag, Path(tmpdir), build_args)
+                self.build_image(
+                    dockerfile_path,
+                    runtime_tag,
+                    Path(tmpdir),
+                    build_args,
+                    fresh=force_rebuild,
+                    pull=False,
+                )
             except Exception:
                 engine_name = self._engine.binary
                 print(
@@ -255,7 +268,9 @@ class ImageManager:
             return tag
 
         print("Building workspace image...", file=sys.stderr)
-        base_image, using_default = self._resolve_custom_base(config, config_hash)
+        base_image, using_default = self._resolve_custom_base(
+            config, config_hash, force_rebuild=force_rebuild
+        )
         dockerfile_content = generate_dockerfile_content(
             config,
             using_default,
@@ -273,7 +288,14 @@ class ImageManager:
                 copy_features_cache(Path(tmpdir))
 
             build_args = {"BASE_IMAGE": base_image}
-            self.build_image(Path(tmpdir) / "Dockerfile", tag, Path(tmpdir), build_args)
+            self.build_image(
+                Path(tmpdir) / "Dockerfile",
+                tag,
+                Path(tmpdir),
+                build_args,
+                fresh=force_rebuild,
+                pull=not using_default and config.dockerfile is None,
+            )
 
         print(f"Build complete (cached as {tag})", file=sys.stderr)
         return tag
@@ -288,7 +310,10 @@ class ImageManager:
         )
 
     def _resolve_custom_base(
-        self, config: PaudeConfig, config_hash: str
+        self,
+        config: PaudeConfig,
+        config_hash: str,
+        force_rebuild: bool = False,
     ) -> tuple[str, bool]:
         """Resolve the base image for custom workspace builds."""
         import sys
@@ -301,7 +326,11 @@ class ImageManager:
             print(f"  → Building from: {config.dockerfile}", file=sys.stderr)
             user_build_args = dict(config.build_args)
             self.build_image(
-                config.dockerfile, user_image, build_context, user_build_args
+                config.dockerfile,
+                user_image,
+                build_context,
+                user_build_args,
+                fresh=force_rebuild,
             )
             print("  → Adding paude requirements...", file=sys.stderr)
             return user_image, False
@@ -313,7 +342,7 @@ class ImageManager:
             print(f"  → Using agent default base: {base}", file=sys.stderr)
             return base, False
         else:
-            base_image = self.ensure_default_image()
+            base_image = self.ensure_default_image(force_rebuild=force_rebuild)
             print(f"  → Using default paude image: {base_image}", file=sys.stderr)
             return base_image, True
 
@@ -335,11 +364,11 @@ class ImageManager:
                 print(f"Building {tag} image...", file=sys.stderr)
                 dockerfile = self.script_dir / "containers" / "proxy" / "Dockerfile"
                 context = self.script_dir / "containers" / "proxy"
-                self.build_image(dockerfile, tag, context)
+                self.build_image(dockerfile, tag, context, fresh=force_rebuild)
             return tag
         else:
             tag = f"{self.registry}/paude-proxy-centos10:{self.version}"
-            if not self._engine.image_exists(tag):
+            if force_rebuild or not self._engine.image_exists(tag):
                 print(f"Pulling {tag}...", file=sys.stderr)
                 try:
                     self._engine.run(
@@ -361,6 +390,8 @@ class ImageManager:
         tag: str,
         context: Path,
         build_args: dict[str, str] | None = None,
+        fresh: bool = False,
+        pull: bool | None = None,
     ) -> None:
         """Build a container image.
 
@@ -368,10 +399,23 @@ class ImageManager:
         remote host via tar pipe before building.
         """
         if self._engine.is_remote:
-            self._build_image_remote(dockerfile, tag, context, build_args)
+            self._build_image_remote(
+                dockerfile,
+                tag,
+                context,
+                build_args,
+                fresh=fresh,
+                pull=pull,
+            )
             return
 
         cmd = ["build", "-f", str(dockerfile), "-t", tag]
+
+        should_pull = fresh if pull is None else pull
+        if should_pull:
+            cmd.append("--pull")
+        if fresh:
+            cmd.append("--no-cache")
 
         if self.platform:
             cmd.extend(["--platform", self.platform])
@@ -387,6 +431,8 @@ class ImageManager:
         tag: str,
         context: Path,
         build_args: dict[str, str] | None = None,
+        fresh: bool = False,
+        pull: bool | None = None,
     ) -> None:
         """Build an image on a remote host by transferring the build context."""
         import subprocess
@@ -448,6 +494,11 @@ class ImageManager:
 
             # Build on remote
             cmd = ["build", "-f", remote_dockerfile, "-t", tag]
+            should_pull = fresh if pull is None else pull
+            if should_pull:
+                cmd.append("--pull")
+            if fresh:
+                cmd.append("--no-cache")
             if self.platform:
                 cmd.extend(["--platform", self.platform])
             if build_args:

--- a/tests/integration/test_upgrade_podman.py
+++ b/tests/integration/test_upgrade_podman.py
@@ -70,7 +70,11 @@ class TestPodmanUpgrade:
                     container,
                     "sh",
                     "-c",
-                    "mkdir -p /pvc/workspace && echo upgrade-test > /pvc/workspace/marker.txt",
+                    "mkdir -p /pvc/workspace && "
+                    "echo upgrade-test > /pvc/workspace/marker.txt && "
+                    "rm -rf /home/paude/.gemini && "
+                    "mkdir -p /home/paude/.gemini && "
+                    "echo legacy-agent-state > /home/paude/.gemini/settings.json",
                 ],
                 check=True,
                 capture_output=True,
@@ -132,6 +136,21 @@ class TestPodmanUpgrade:
             )
             assert result.returncode == 0
             assert "upgrade-test" in result.stdout
+
+            # Legacy state from the old container layer was migrated to PVC.
+            result = subprocess.run(
+                [
+                    "podman",
+                    "exec",
+                    container,
+                    "cat",
+                    "/pvc/.gemini/settings.json",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            assert result.returncode == 0
+            assert "legacy-agent-state" in result.stdout
 
             # 7. Verify proxy container exists
             result = subprocess.run(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -21,7 +21,6 @@ from paude.agents.base import (
 from paude.agents.claude import ClaudeAgent
 from paude.agents.codex import (
     CODEX_CHATGPT_PROFILE_NAME,
-    CODEX_VERSION,
     SYNTHETIC_CODEX_PROFILE_TOML,
     CodexAgent,
 )
@@ -269,6 +268,8 @@ class TestAgentConfig:
         assert cfg.extra_domain_aliases == ["claude"]
         assert cfg.exposed_ports == []
         assert cfg.default_base_image is None
+        assert cfg.extra_persistent_dir_names == []
+        assert cfg.persistent_dir_names == [".claude"]
 
 
 class TestClaudeAgentConfig:
@@ -478,15 +479,18 @@ class TestCodexAgentConfig:
         cfg = CodexAgent().config
         assert "openai/codex" in cfg.install_script
 
-    def test_install_script_contains_version(self) -> None:
+    def test_install_script_uses_latest_stable_release(self) -> None:
         cfg = CodexAgent().config
-        assert CODEX_VERSION in cfg.install_script
+        assert "releases/latest/download" in cfg.install_script
 
     def test_config_dir_name(self) -> None:
         assert CodexAgent().config.config_dir_name == ".codex"
 
     def test_config_file_name_is_none(self) -> None:
         assert CodexAgent().config.config_file_name is None
+
+    def test_persistent_dirs(self) -> None:
+        assert CodexAgent().config.persistent_dir_names == [".codex", ".agents"]
 
     def test_yolo_flag(self) -> None:
         assert (
@@ -570,7 +574,7 @@ class TestCodexAgentDockerfile:
     def test_contains_version(self) -> None:
         lines = CodexAgent().dockerfile_install_lines("/home/paude")
         text = "\n".join(lines)
-        assert CODEX_VERSION in text
+        assert "releases/latest/download" in text
 
     def test_contains_arch_detection(self) -> None:
         lines = CodexAgent().dockerfile_install_lines("/home/paude")
@@ -725,6 +729,9 @@ class TestGeminiAgentConfig:
 
     def test_config_file_name_is_none(self) -> None:
         assert GeminiAgent().config.config_file_name is None
+
+    def test_persistent_dirs(self) -> None:
+        assert GeminiAgent().config.persistent_dir_names == [".gemini", ".agents"]
 
     def test_yolo_flag(self) -> None:
         assert GeminiAgent().config.yolo_flag == "--yolo"
@@ -889,6 +896,12 @@ class TestCursorAgentConfig:
 
     def test_config_file_name_is_none(self) -> None:
         assert CursorAgent().config.config_file_name is None
+
+    def test_persistent_dirs(self) -> None:
+        assert CursorAgent().config.persistent_dir_names == [
+            ".cursor",
+            ".config/cursor",
+        ]
 
     def test_yolo_flag(self) -> None:
         assert CursorAgent().config.yolo_flag == "--yolo"
@@ -1420,6 +1433,13 @@ class TestOpenCodeAgentConfig:
 
     def test_config_file_name_is_none(self) -> None:
         assert OpenCodeAgent().config.config_file_name is None
+
+    def test_persistent_dirs(self) -> None:
+        assert OpenCodeAgent().config.persistent_dir_names == [
+            ".config/opencode",
+            ".local/share/opencode",
+            ".local/state/opencode",
+        ]
 
     def test_yolo_flag(self) -> None:
         assert OpenCodeAgent().config.yolo_flag == "--auto"

--- a/tests/test_build_agent_env.py
+++ b/tests/test_build_agent_env.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from paude.agents.base import AgentConfig
+from paude.backends.session_env import build_agent_env
 
 
 def _make_config(**overrides: object) -> AgentConfig:
@@ -16,3 +17,11 @@ def _make_config(**overrides: object) -> AgentConfig:
     }
     defaults.update(overrides)
     return AgentConfig(**defaults)  # type: ignore[arg-type]
+
+
+def test_build_agent_env_includes_all_persistent_dirs() -> None:
+    config = _make_config(extra_persistent_dir_names=[".agents", ".local/share/test"])
+
+    env = build_agent_env(config)
+
+    assert env["PAUDE_AGENT_CONFIG_DIRS"] == ".claude .agents .local/share/test"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -562,6 +562,7 @@ class TestGenerateWorkspaceDockerfile:
         dockerfile = generate_workspace_dockerfile(config)
 
         for pkg in [
+            "jq",
             "findutils",
             "grep",
             "sed",

--- a/tests/test_entrypoint_seed_copy.py
+++ b/tests/test_entrypoint_seed_copy.py
@@ -767,6 +767,26 @@ class TestPersistConfigDir:
             '{"metrics.disabled":true}'
         )
 
+    def test_persists_nested_xdg_directory(self, tmp_path: Path) -> None:
+        """Nested state paths retain their HOME-relative layout on the PVC."""
+        home = tmp_path / "home"
+        state = home / ".local" / "share" / "opencode"
+        state.mkdir(parents=True)
+        (state / "opencode.db").write_text("session data")
+        pvc = tmp_path / "pvc"
+        pvc.mkdir()
+
+        script = _build_persist_config_dir_script(
+            str(home), str(pvc), ".local/share/opencode"
+        )
+        result = _run_script(script)
+
+        assert result.returncode == 0, result.stderr
+        assert state.is_symlink()
+        assert (pvc / ".local/share/opencode/opencode.db").read_text() == (
+            "session data"
+        )
+
     def test_preserves_pvc_state_on_reconnect(self, tmp_path: Path) -> None:
         """Reconnect: PVC has existing dolt data, symlink preserved."""
         home = tmp_path / "home"

--- a/tests/test_gascity.py
+++ b/tests/test_gascity.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from paude.agents import get_agents
 from paude.agents.base import compose_dockerfile_install_lines
-from paude.agents.gascity import BD_VERSION, DOLT_VERSION, GC_VERSION, GascityAgent
+from paude.agents.gascity import GascityAgent
 
 
 class TestGascityAgentConfig:
@@ -26,7 +26,7 @@ class TestGascityAgentConfig:
         assert GascityAgent().config.session_name == "gascity"
 
     def test_config_dir_name(self) -> None:
-        assert GascityAgent().config.config_dir_name == ".gascity"
+        assert GascityAgent().config.config_dir_name == ".gc"
 
     def test_config_file_name_is_none(self) -> None:
         assert GascityAgent().config.config_file_name is None
@@ -109,17 +109,21 @@ class TestGascityAgentDockerfile:
     def test_contains_dolt(self) -> None:
         text = "\n".join(GascityAgent().dockerfile_install_lines("/home/paude"))
         assert "dolthub/dolt" in text
-        assert DOLT_VERSION in text
+        assert "dolthub/dolt/releases/latest" in text
 
     def test_contains_bd(self) -> None:
         text = "\n".join(GascityAgent().dockerfile_install_lines("/home/paude"))
         assert "gastownhall/beads" in text
-        assert BD_VERSION in text
+        assert "gastownhall/beads/releases/latest" in text
 
     def test_contains_gc(self) -> None:
         text = "\n".join(GascityAgent().dockerfile_install_lines("/home/paude"))
         assert "gastownhall/gascity" in text
-        assert GC_VERSION in text
+        assert "gastownhall/gascity/releases/latest" in text
+
+    def test_latest_release_lookup_does_not_require_jq(self) -> None:
+        text = "\n".join(GascityAgent().dockerfile_install_lines("/home/paude"))
+        assert "jq" not in text
 
     def test_contains_flock(self) -> None:
         text = "\n".join(GascityAgent().dockerfile_install_lines("/home/paude"))
@@ -273,11 +277,11 @@ class TestGascityComposedInstall:
     def test_contains_gc_dolt_bd(self) -> None:
         text = self._composed()
         assert "gastownhall/gascity" in text
-        assert GC_VERSION in text
+        assert "gastownhall/gascity/releases/latest" in text
         assert "dolthub/dolt" in text
-        assert DOLT_VERSION in text
+        assert "dolthub/dolt/releases/latest" in text
         assert "gastownhall/beads" in text
-        assert BD_VERSION in text
+        assert "gastownhall/beads/releases/latest" in text
 
     def test_contains_claude(self) -> None:
         text = self._composed()
@@ -376,6 +380,6 @@ class TestGascityBuildPathInstall:
         assert "claude.ai/install.sh" in dockerfile
         assert "openai/codex" in dockerfile
         assert "@google/gemini-cli" not in dockerfile
-        assert "/home/paude/.gascity" in dockerfile
+        assert "/home/paude/.gc" in dockerfile
         assert "/home/paude/.claude" in dockerfile
         assert "/home/paude/.codex" in dockerfile

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from paude.container.image import ImageManager, _detect_native_platform
 
@@ -61,3 +62,46 @@ class TestImageManagerComposition:
         assert manager._composition_fingerprint() == (
             "gascity:vertex,claude:vertex,codex:chatgpt"
         )
+
+
+class TestFreshBuild:
+    """Tests for cache-bypassing image refreshes."""
+
+    def test_local_fresh_build_pulls_and_disables_cache(self) -> None:
+        engine = MagicMock()
+        engine.is_remote = False
+        manager = ImageManager(engine=engine, platform="linux/amd64")
+
+        manager.build_image(Path("Dockerfile"), "test:latest", Path("."), fresh=True)
+
+        args = engine.run.call_args.args
+        assert "--pull" in args
+        assert "--no-cache" in args
+
+    def test_normal_build_keeps_cache_available(self) -> None:
+        engine = MagicMock()
+        engine.is_remote = False
+        manager = ImageManager(engine=engine, platform="linux/amd64")
+
+        manager.build_image(Path("Dockerfile"), "test:latest", Path("."))
+
+        args = engine.run.call_args.args
+        assert "--pull" not in args
+        assert "--no-cache" not in args
+
+    def test_fresh_local_wrapper_can_skip_registry_pull(self) -> None:
+        engine = MagicMock()
+        engine.is_remote = False
+        manager = ImageManager(engine=engine, platform="linux/amd64")
+
+        manager.build_image(
+            Path("Dockerfile"),
+            "test:latest",
+            Path("."),
+            fresh=True,
+            pull=False,
+        )
+
+        args = engine.run.call_args.args
+        assert "--pull" not in args
+        assert "--no-cache" in args

--- a/tests/test_podman_session.py
+++ b/tests/test_podman_session.py
@@ -313,6 +313,33 @@ class TestPodmanBackendCreateSession:
         mock_volume.remove_volume.assert_called_once()
 
     @patch("paude.backends.podman.backend.ContainerRunner")
+    def test_reuse_missing_volume_cleans_up_on_container_failure(
+        self, mock_runner_class: MagicMock
+    ) -> None:
+        """A newly created reuse target is removed if container creation fails."""
+        mock_runner = MagicMock()
+        mock_runner.container_exists.return_value = False
+        mock_runner.create_container.side_effect = RuntimeError("Container failed")
+        mock_runner_class.return_value = mock_runner
+        mock_volume = MagicMock()
+        mock_volume.volume_exists.return_value = False
+        backend = _make_create_session_backend(mock_runner, mock_volume)
+        config = SessionConfig(
+            name="test-session",
+            workspace=Path("/home/user/project"),
+            image="paude:latest",
+            reuse_volume=True,
+        )
+
+        with pytest.raises(RuntimeError, match="Container failed"):
+            backend.create_session(config)
+
+        mock_volume.create_volume.assert_called_once()
+        mock_volume.remove_volume.assert_called_once_with(
+            "paude-test-session-workspace", force=True
+        )
+
+    @patch("paude.backends.podman.backend.ContainerRunner")
     def test_create_session_with_yolo_mode(self, mock_runner_class: MagicMock) -> None:
         """Create session with yolo=True adds permission skip flag."""
         mock_runner = MagicMock()

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -73,7 +73,7 @@ class TestBuildSessionEnv:
 
         env, _args = build_session_env(config, composition, proxy_name="proxy-test")
 
-        assert env["PAUDE_AGENT_CONFIG_DIRS"] == ".gascity .claude .codex"
+        assert env["PAUDE_AGENT_CONFIG_DIRS"] == ".gc .claude .codex .agents"
         assert env["PAUDE_AGENT_CONFIG_FILES"] == ".claude.json"
         assert env["PAUDE_AGENT_PROVIDERS"] == (
             "gascity=vertex,claude=vertex,codex=chatgpt"

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -61,12 +61,17 @@ class TestUpgradeCommand:
         output = result.stdout + (result.stderr or "")
         assert "not found" in output
 
+    @patch("paude.cli.upgrade._upgrade_podman")
     @patch("paude.cli.upgrade.find_session_backend")
-    def test_upgrade_already_up_to_date(self, mock_find: MagicMock) -> None:
-        """Session version matches current __version__, should print up to date."""
+    def test_upgrade_same_version_still_refreshes(
+        self, mock_find: MagicMock, mock_upgrade_podman: MagicMock
+    ) -> None:
+        """A same-version upgrade still refreshes agent tooling."""
         from paude import __version__
+        from paude.backends.podman.backend import PodmanBackend
 
         mock_backend = MagicMock()
+        mock_backend.__class__ = PodmanBackend
         mock_backend.get_session.return_value = _make_session(
             "test-session", version=__version__
         )
@@ -75,8 +80,8 @@ class TestUpgradeCommand:
         result = runner.invoke(app, ["upgrade", "test-session"])
 
         assert result.exit_code == 0
-        output = result.stdout + (result.stderr or "")
-        assert "already at version" in output
+        mock_upgrade_podman.assert_called_once()
+        assert mock_upgrade_podman.call_args.args[2] is True
 
     @patch("paude.cli.upgrade._upgrade_podman")
     @patch("paude.cli.upgrade.find_session_backend")
@@ -184,6 +189,31 @@ class TestUpgradePodman:
         if proxy_image is not None:
             labels[PAUDE_LABEL_PROXY_IMAGE] = proxy_image
         return labels
+
+    def test_reused_volume_survives_container_creation_rollback(self) -> None:
+        from paude.backends import SessionConfig
+        from paude.backends.podman.backend import PodmanBackend
+
+        backend = MagicMock(spec=PodmanBackend)
+        backend._runner = MagicMock()
+        backend._network_manager = MagicMock()
+        backend._volume_manager = MagicMock()
+        config = SessionConfig(
+            name="test-session",
+            workspace=Path("/workspace"),
+            image="paude:latest",
+            reuse_volume=True,
+        )
+
+        PodmanBackend._rollback_session_resources(
+            backend,
+            config,
+            "test-session",
+            "paude-test-session-workspace",
+            volume_reused=True,
+        )
+
+        backend._volume_manager.remove_volume.assert_not_called()
 
     @patch("paude.mounts.build_mounts", return_value=[])
     @patch("paude.cli.helpers._prepare_session_create")
@@ -325,7 +355,9 @@ class TestUpgradePodman:
 
         _upgrade_podman("test-session", backend, rebuild=False, overrides=_NO_OVERRIDES)
 
-        mock_image_manager.ensure_default_image.assert_called_once()
+        mock_image_manager.ensure_default_image.assert_called_once_with(
+            force_rebuild=True
+        )
 
     @patch("paude.mounts.build_mounts", return_value=[])
     @patch("paude.cli.helpers._prepare_session_create")

--- a/tests/test_upgrade_persistence.py
+++ b/tests/test_upgrade_persistence.py
@@ -1,0 +1,75 @@
+"""Tests for pre-upgrade migration of legacy container state."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from paude.agents import get_agents
+from paude.cli.upgrade_persistence import (
+    migrate_legacy_state,
+    persistent_state_paths,
+)
+
+
+def test_composed_state_paths_include_agent_and_shared_state() -> None:
+    composition = get_agents(
+        ["codex", "cursor", "opencode", "gemini"], include_bundled=False
+    )
+
+    directories, files = persistent_state_paths(composition)
+
+    assert directories == [
+        ".codex",
+        ".agents",
+        ".cursor",
+        ".config/cursor",
+        ".config/opencode",
+        ".local/share/opencode",
+        ".local/state/opencode",
+        ".gemini",
+        ".dolt",
+    ]
+    assert files == [".gitconfig"]
+
+
+def test_migration_starts_and_restops_a_stopped_container() -> None:
+    runner = MagicMock()
+    runner.container_running.return_value = False
+
+    migrate_legacy_state(runner, "paude-demo", get_agents(["claude"]))
+
+    runner.start_container.assert_called_once_with("paude-demo")
+    runner.stop_container_graceful.assert_called_once_with("paude-demo")
+    command = runner.exec_in_container.call_args.args[1]
+    assert ".claude" in command
+    assert ".claude.json" in command
+    assert ".dolt" in command
+    assert ".gitconfig" in command
+
+
+def test_migration_quiesces_an_already_running_container() -> None:
+    runner = MagicMock()
+    runner.container_running.return_value = True
+
+    migrate_legacy_state(runner, "paude-demo", get_agents(["codex"]))
+
+    runner.stop_container_graceful.assert_called_once_with("paude-demo")
+    runner.start_container.assert_called_once_with("paude-demo")
+    assert runner.method_calls[:3] == [
+        call.container_running("paude-demo"),
+        call.stop_container_graceful("paude-demo"),
+        call.start_container("paude-demo"),
+    ]
+
+
+def test_migration_restops_container_when_copy_fails() -> None:
+    runner = MagicMock()
+    runner.container_running.return_value = False
+    runner.exec_in_container.side_effect = RuntimeError("copy failed")
+
+    with pytest.raises(RuntimeError, match="copy failed"):
+        migrate_legacy_state(runner, "paude-demo", get_agents(["opencode"]))
+
+    runner.stop_container_graceful.assert_called_once_with("paude-demo")


### PR DESCRIPTION
Store agent-specific state directories on the session volume and migrate existing container state when upgrading to images with persistence support.

Teach image builds and session metadata about persistent directories, and document the new upgrade behavior.