### PR TITLE
Merge Paude settings into Codex config

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,10 @@ Pass `--provider openai` to use the plain `OPENAI_API_KEY` provider instead
 — no ChatGPT plan, no proxy-managed auth. The default Codex network policy
 allows `chatgpt.com` and `auth.openai.com` for the ChatGPT API and OAuth
 exchange.
-Paude selects Codex's HTTP/SSE transport by default because the local MITM
-proxy does not support the Responses WebSocket transport. Codex Apps are
+Paude merges the required HTTP/SSE provider settings into the session's
+persistent Codex `config.toml` because the local MITM proxy does not support
+the Responses WebSocket transport. Existing model, MCP, project trust, and
+other user settings are preserved across starts and upgrades. Codex Apps are
 disabled for ChatGPT OAuth sessions so the Apps MCP integration does not
 attempt to connect from the container; standalone MCP server configuration
 is unchanged.

--- a/containers/paude/entrypoint-lib-config.sh
+++ b/containers/paude/entrypoint-lib-config.sh
@@ -22,7 +22,9 @@ persist_config_dir() {
 
     if [[ ! -L "$home_dir" ]]; then
         if [[ -d "$home_dir" ]]; then
-            cp -dR --preserve=mode,timestamps "$home_dir/." "$pvc_dir/" 2>/dev/null || true
+            # Image-baked files seed missing PVC state but never replace state
+            # that already survived a restart or container recreation.
+            cp -dRn --preserve=mode,timestamps "$home_dir/." "$pvc_dir/" 2>/dev/null || true
             rm -rf "$home_dir" 2>/dev/null || true
         fi
         if [[ ! -e "$home_dir" ]]; then

--- a/containers/paude/entrypoint-session.sh
+++ b/containers/paude/entrypoint-session.sh
@@ -39,38 +39,6 @@ if ! mkdir -p "$HOME" 2>/dev/null || ! touch "$HOME/.test" 2>/dev/null; then
 fi
 rm -f "$HOME/.test" 2>/dev/null || true
 
-# Paude's ChatGPT OAuth profile uses HTTP/SSE because the local MITM proxy
-# does not transparently support Codex's Responses WebSocket transport.  The
-# profile file is injected only for sessions with host ChatGPT OAuth state.
-if [[ "$AGENT_NAME" == "codex" ]] && [[ -f "$HOME/.codex/paude-chatgpt-http.config.toml" ]]; then
-    AGENT_ARGS="--profile paude-chatgpt-http ${AGENT_ARGS}"
-fi
-
-# Make the same ChatGPT HTTP/SSE profile available to Codex processes started
-# by an orchestrator such as Gas City. The primary Codex path above uses
-# launch arguments; child Codex processes need a PATH-level wrapper instead.
-if [[ "${PAUDE_CODEX_CHATGPT_MODE:-}" == "1" ]] && [[ "$AGENT_NAME" != "codex" ]]; then
-    _real_codex=""
-    for _candidate in /home/paude/.local/bin/codex /pvc/.local/bin/codex /usr/local/bin/codex; do
-        if [[ -x "$_candidate" ]]; then
-            _real_codex="$_candidate"
-            break
-        fi
-    done
-    if [[ -n "$_real_codex" ]]; then
-        mkdir -p /tmp/paude-bin
-        cat > /tmp/paude-bin/codex <<CODEX_WRAPPER
-#!/bin/bash
-for arg in "\$@"; do
-    [[ "\$arg" == "--profile" ]] && exec "$_real_codex" "\$@"
-done
-exec "$_real_codex" --profile paude-chatgpt-http "\$@"
-CODEX_WRAPPER
-        chmod 755 /tmp/paude-bin/codex
-        export PATH="/tmp/paude-bin:$PATH"
-    fi
-fi
-
 # Update CA trust early (before any HTTPS calls like agent install)
 # The CA cert is injected by the host after the container starts.
 setup_ca_trust
@@ -103,13 +71,6 @@ fi
 # Add PVC local bin to PATH (for agent and other tools installed to PVC)
 # Also keep home .local/bin for tools installed during image build
 export PATH="/pvc/.local/bin:$HOME/.local/bin:$PATH"
-# Keep the ChatGPT Codex wrapper ahead of the normal tool directories after
-# adding the persistent install locations above. This matters when an
-# orchestrator launches Codex as a child process.
-if [[ -d /tmp/paude-bin ]]; then
-    export PATH="/tmp/paude-bin:$PATH"
-fi
-
 # Set up GitHub token from the synced credentials file if available.
 if [[ -f /credentials/github_token ]]; then
     GH_TOKEN=$(<"/credentials/github_token")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "click>=8.0.0",
     "typer>=0.9.0",
     "rich>=13.0.0",
+    "tomlkit>=0.13.0",
 ]
 
 [dependency-groups]

--- a/src/paude/agents/codex.py
+++ b/src/paude/agents/codex.py
@@ -12,23 +12,6 @@ from paude.agents.base import (
 )
 from paude.constants import CONTAINER_HOME
 
-CODEX_CHATGPT_PROFILE_NAME = "paude-chatgpt-http"
-CODEX_CHATGPT_PROFILE_TARGET = (
-    f"/home/paude/.codex/{CODEX_CHATGPT_PROFILE_NAME}.config.toml"
-)
-SYNTHETIC_CODEX_PROFILE_TOML = f'''model_provider = "{CODEX_CHATGPT_PROFILE_NAME}"
-
-[model_providers.{CODEX_CHATGPT_PROFILE_NAME}]
-name = "Paude ChatGPT HTTP"
-base_url = "https://chatgpt.com/backend-api/codex"
-wire_api = "responses"
-requires_openai_auth = true
-supports_websockets = false
-
-[features]
-apps = false
-'''
-
 _INSTALL_SCRIPT = (
     'mkdir -p "$HOME/.local/bin" && '
     "ARCH=$(uname -m) && "

--- a/src/paude/agents/codex_config.py
+++ b/src/paude/agents/codex_config.py
@@ -1,0 +1,128 @@
+"""Merge Paude's required settings into Codex's persistent config."""
+
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+
+import tomlkit
+from tomlkit.exceptions import ParseError
+
+CODEX_CONFIG_TARGET = "/pvc/.codex/config.toml"
+LEGACY_CODEX_PROFILE_TARGET = "/pvc/.codex/paude-chatgpt-http.config.toml"
+CODEX_CHATGPT_PROVIDER_NAME = "paude-chatgpt-http"
+
+_MANAGED_PROVIDER_VALUES: dict[str, object] = {
+    "name": "Paude ChatGPT HTTP",
+    "base_url": "https://chatgpt.com/backend-api/codex",
+    "wire_api": "responses",
+    "requires_openai_auth": True,
+    "supports_websockets": False,
+}
+
+
+class CodexConfigError(ValueError):
+    """Raised when an existing Codex config cannot be safely updated."""
+
+
+@dataclass(frozen=True)
+class CodexConfigUpdate:
+    """Result of reconciling Codex configuration."""
+
+    content: str
+    changed: bool
+    remove_legacy_profile: bool
+
+
+def reconcile_codex_config(
+    default_content: str | None,
+    legacy_content: str | None,
+    *,
+    chatgpt_mode: bool,
+) -> CodexConfigUpdate:
+    """Return a minimally updated default config and legacy cleanup state."""
+    document = _parse(default_content, CODEX_CONFIG_TARGET)
+
+    if legacy_content is not None:
+        legacy = _parse(legacy_content, LEGACY_CODEX_PROFILE_TARGET)
+        _remove_managed_values(legacy)
+        _merge_active_config(document, legacy)
+
+    if chatgpt_mode:
+        _apply_chatgpt_values(document)
+    else:
+        _remove_managed_values(document)
+
+    content = tomlkit.dumps(document)
+    return CodexConfigUpdate(
+        content=content,
+        changed=content != (default_content or ""),
+        remove_legacy_profile=legacy_content is not None,
+    )
+
+
+def _parse(content: str | None, path: str) -> tomlkit.TOMLDocument:
+    try:
+        return tomlkit.parse(content or "")
+    except ParseError as exc:
+        raise CodexConfigError(
+            f"Cannot update Codex config because {path} is invalid TOML: {exc}"
+        ) from exc
+
+
+def _merge_active_config(
+    target: MutableMapping[str, Any], active: MutableMapping[str, Any]
+) -> None:
+    """Recursively merge the formerly active profile over the default config."""
+    for key, value in active.items():
+        current = target.get(key)
+        if isinstance(current, MutableMapping) and isinstance(value, MutableMapping):
+            _merge_active_config(current, value)
+        else:
+            target[key] = deepcopy(value)
+
+
+def _apply_chatgpt_values(document: tomlkit.TOMLDocument) -> None:
+    document["model_provider"] = CODEX_CHATGPT_PROVIDER_NAME
+
+    providers = _table(document, "model_providers")
+    provider = _table(providers, CODEX_CHATGPT_PROVIDER_NAME)
+    for key, value in _MANAGED_PROVIDER_VALUES.items():
+        provider[key] = value
+
+    features = _table(document, "features")
+    features["apps"] = False
+
+
+def _remove_managed_values(document: MutableMapping[str, Any]) -> None:
+    if document.get("model_provider") == CODEX_CHATGPT_PROVIDER_NAME:
+        del document["model_provider"]
+
+    providers = document.get("model_providers")
+    if isinstance(providers, MutableMapping):
+        provider = providers.get(CODEX_CHATGPT_PROVIDER_NAME)
+        if isinstance(provider, MutableMapping):
+            for key, managed_value in _MANAGED_PROVIDER_VALUES.items():
+                if provider.get(key) == managed_value:
+                    del provider[key]
+            if not provider:
+                del providers[CODEX_CHATGPT_PROVIDER_NAME]
+        if not providers:
+            del document["model_providers"]
+
+    features = document.get("features")
+    if isinstance(features, MutableMapping) and features.get("apps") is False:
+        del features["apps"]
+        if not features:
+            del document["features"]
+
+
+def _table(parent: MutableMapping[str, Any], key: str) -> MutableMapping[str, Any]:
+    value: Any = parent.get(key)
+    if isinstance(value, MutableMapping):
+        return value
+    table = tomlkit.table()
+    parent[key] = table
+    return table

--- a/src/paude/backends/podman/session_setup.py
+++ b/src/paude/backends/podman/session_setup.py
@@ -7,9 +7,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from paude.agents.base import AgentComposition
-from paude.agents.codex import (
-    CODEX_CHATGPT_PROFILE_TARGET,
-    SYNTHETIC_CODEX_PROFILE_TOML,
+from paude.agents.codex_config import (
+    CODEX_CONFIG_TARGET,
+    LEGACY_CODEX_PROFILE_TARGET,
+    reconcile_codex_config,
 )
 from paude.backends.labels import (
     PAUDE_LABEL_AGENT,
@@ -55,6 +56,7 @@ from paude.constants import (
     SANDBOX_CONFIG_TARGET,
 )
 from paude.container.engine import ContainerEngine
+from paude.container.files import ContainerFileManager
 from paude.container.runner import ContainerRunner
 
 if TYPE_CHECKING:
@@ -69,6 +71,7 @@ class SessionSetup:
     def __init__(self, runner: ContainerRunner, engine: ContainerEngine) -> None:
         self._runner = runner
         self._engine = engine
+        self._files = ContainerFileManager(engine)
 
     def get_port_urls(self, agent: Agent | AgentComposition) -> list[str]:
         """Get port-forward URL strings for an agent."""
@@ -180,22 +183,27 @@ class SessionSetup:
 
         self._runner.inject_file(cname, STUB_ADC_JSON, GCP_ADC_TARGET, owner="paude")
 
-    def inject_codex_auth(self, cname: str, *, chatgpt_mode: bool) -> None:
-        """Install the ChatGPT provider profile for Codex; else clear codex auth."""
-        if chatgpt_mode:
-            self._runner.inject_file(
+    def configure_codex(self, cname: str, *, chatgpt_mode: bool) -> None:
+        """Reconcile Paude's settings with Codex's persistent default config."""
+        default_content = self._files.read_file(cname, CODEX_CONFIG_TARGET)
+        legacy_content = self._files.read_file(cname, LEGACY_CODEX_PROFILE_TARGET)
+        update = reconcile_codex_config(
+            default_content,
+            legacy_content,
+            chatgpt_mode=chatgpt_mode,
+        )
+        if update.changed:
+            self._files.replace_file(
                 cname,
-                SYNTHETIC_CODEX_PROFILE_TOML,
-                CODEX_CHATGPT_PROFILE_TARGET,
+                CODEX_CONFIG_TARGET,
+                update.content,
                 owner="paude",
-                mode="600",
             )
-        else:
+        if update.remove_legacy_profile:
+            self._files.remove_file(cname, LEGACY_CODEX_PROFILE_TARGET)
+        if not chatgpt_mode:
             self._runner.exec_in_container(
                 cname, ["rm", "-f", CODEX_AUTH_TARGET], check=False
-            )
-            self._runner.exec_in_container(
-                cname, ["rm", "-f", CODEX_CHATGPT_PROFILE_TARGET], check=False
             )
 
     def fix_volume_permissions(self, container_name: str) -> None:
@@ -237,7 +245,7 @@ class SessionSetup:
             item for item in composition.agents if item.config.name == "codex"
         ]
         if codex_agents:
-            self.inject_codex_auth(
+            self.configure_codex(
                 cname,
                 chatgpt_mode=any(
                     item.config.provider == "chatgpt" for item in codex_agents

--- a/src/paude/backends/session_env.py
+++ b/src/paude/backends/session_env.py
@@ -118,11 +118,6 @@ def build_session_env(
             f"{item.config.name}={item.config.provider or ''}"
             for item in composition.agents
         )
-        if any(
-            item.config.name == "codex" and item.config.provider == "chatgpt"
-            for item in composition.agents
-        ):
-            env["PAUDE_CODEX_CHATGPT_MODE"] = "1"
 
     if config.credential_providers:
         env["PAUDE_PROVIDERS"] = ",".join(config.credential_providers)

--- a/src/paude/cli/help.py
+++ b/src/paude/cli/help.py
@@ -163,8 +163,8 @@ _SECTIONS: tuple[HelpSection, ...] = (
             " network access (enables data exfil).\n"
             "Combining --yolo with --allowed-domains all"
             " is maximum risk mode.\n"
-            "Codex Apps are disabled for ChatGPT OAuth sessions;"
-            " standalone MCP servers are unchanged.\n"
+            "Codex ChatGPT settings are merged into persistent config;"
+            " Apps are disabled and standalone MCP servers are unchanged.\n"
             "PAUDE_GITHUB_TOKEN is explicit only;"
             " host GH_TOKEN is never auto-propagated."
         ),

--- a/src/paude/container/files.py
+++ b/src/paude/container/files.py
@@ -1,0 +1,76 @@
+"""Read and atomically replace files inside running containers."""
+
+from __future__ import annotations
+
+import subprocess
+
+from paude.container.engine import ContainerEngine
+
+
+class ContainerFileManager:
+    """Container file operations used for persistent mutable configuration."""
+
+    def __init__(self, engine: ContainerEngine) -> None:
+        self._engine = engine
+
+    def read_file(self, container: str, path: str) -> str | None:
+        """Return a file's content, or None when the file does not exist."""
+        exists = self._engine.run("exec", container, "test", "-e", path, check=False)
+        if exists.returncode != 0:
+            return None
+        result = self._engine.run("exec", container, "cat", path, check=False)
+        if result.returncode != 0:
+            raise subprocess.CalledProcessError(
+                result.returncode,
+                [self._engine.binary, "exec", container, "cat", path],
+                result.stdout,
+                result.stderr,
+            )
+        return result.stdout
+
+    def replace_file(
+        self,
+        container: str,
+        path: str,
+        content: str,
+        *,
+        owner: str,
+        mode: str = "600",
+    ) -> None:
+        """Atomically replace a file without exposing partial content."""
+        script = r"""
+set -e
+target="$1"
+owner="$2"
+mode="$3"
+parent=$(dirname "$target")
+mkdir -p "$parent"
+chown "$owner" "$parent"
+chmod g+rwX "$parent"
+temporary=$(mktemp "${target}.tmp.XXXXXX")
+trap 'rm -f "$temporary"' EXIT
+cat > "$temporary"
+chown "$owner" "$temporary"
+chmod "$mode" "$temporary"
+mv -f "$temporary" "$target"
+trap - EXIT
+"""
+        self._engine.run(
+            "exec",
+            "-i",
+            "--user",
+            "root",
+            container,
+            "sh",
+            "-c",
+            script,
+            "paude-config-replace",
+            path,
+            owner,
+            mode,
+            input=content,
+        )
+
+    def remove_file(self, container: str, path: str) -> None:
+        """Remove a specific file when present."""
+        self._engine.run("exec", container, "rm", "-f", path, check=False)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import tomllib
 from pathlib import Path
 from unittest.mock import patch
 
@@ -19,11 +18,7 @@ from paude.agents.base import (
     pipefail_install_lines,
 )
 from paude.agents.claude import ClaudeAgent
-from paude.agents.codex import (
-    CODEX_CHATGPT_PROFILE_NAME,
-    SYNTHETIC_CODEX_PROFILE_TOML,
-    CodexAgent,
-)
+from paude.agents.codex import CodexAgent
 from paude.agents.cursor import CursorAgent
 from paude.agents.gascity import GascityAgent
 from paude.agents.gemini import GeminiAgent
@@ -533,20 +528,6 @@ class TestCodexAgentConfig:
 
     def test_env_vars_empty(self) -> None:
         assert CodexAgent().config.env_vars == {"CODEX_HOME": "/home/paude/.codex"}
-
-    def test_chatgpt_profile_disables_websockets(self) -> None:
-        assert f'model_provider = "{CODEX_CHATGPT_PROFILE_NAME}"' in (
-            SYNTHETIC_CODEX_PROFILE_TOML
-        )
-        assert 'base_url = "https://chatgpt.com/backend-api/codex"' in (
-            SYNTHETIC_CODEX_PROFILE_TOML
-        )
-        assert "requires_openai_auth = true" in SYNTHETIC_CODEX_PROFILE_TOML
-        assert "supports_websockets = false" in SYNTHETIC_CODEX_PROFILE_TOML
-
-    def test_chatgpt_profile_disables_apps(self) -> None:
-        profile = tomllib.loads(SYNTHETIC_CODEX_PROFILE_TOML)
-        assert profile["features"]["apps"] is False
 
     def test_activity_files_empty(self) -> None:
         assert CodexAgent().config.activity_files == []

--- a/tests/test_codex_config.py
+++ b/tests/test_codex_config.py
@@ -1,0 +1,160 @@
+"""Tests for non-destructive Codex default-config reconciliation."""
+
+from __future__ import annotations
+
+import tomllib
+
+import pytest
+
+from paude.agents.codex_config import CodexConfigError, reconcile_codex_config
+
+
+def _load(content: str) -> dict[str, object]:
+    return tomllib.loads(content)
+
+
+def test_fresh_chatgpt_config_contains_required_settings() -> None:
+    update = reconcile_codex_config(None, None, chatgpt_mode=True)
+
+    config = _load(update.content)
+    assert config["model_provider"] == "paude-chatgpt-http"
+    provider = config["model_providers"]["paude-chatgpt-http"]  # type: ignore[index]
+    assert provider == {
+        "name": "Paude ChatGPT HTTP",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "wire_api": "responses",
+        "requires_openai_auth": True,
+        "supports_websockets": False,
+    }
+    assert config["features"] == {"apps": False}
+    assert update.changed is True
+
+
+def test_preserves_user_settings_comments_and_project_trust() -> None:
+    existing = """# personal config
+model = "gpt-custom"
+model_reasoning_effort = "high"
+
+[projects."/pvc/workspace"]
+trust_level = "trusted" # keep this decision
+
+[mcp_servers.example]
+command = "example-mcp"
+"""
+
+    update = reconcile_codex_config(existing, None, chatgpt_mode=True)
+
+    assert "# personal config" in update.content
+    assert "# keep this decision" in update.content
+    config = _load(update.content)
+    assert config["model"] == "gpt-custom"
+    assert config["model_reasoning_effort"] == "high"
+    assert config["projects"] == {"/pvc/workspace": {"trust_level": "trusted"}}
+    assert config["mcp_servers"] == {"example": {"command": "example-mcp"}}
+
+
+def test_correct_config_is_byte_for_byte_noop() -> None:
+    first = reconcile_codex_config(None, None, chatgpt_mode=True)
+    second = reconcile_codex_config(first.content, None, chatgpt_mode=True)
+
+    assert second.content == first.content
+    assert second.changed is False
+
+
+def test_only_required_values_are_corrected() -> None:
+    existing = """model = "user-model"
+model_provider = "another-provider"
+
+[model_providers.paude-chatgpt-http]
+base_url = "https://wrong.invalid"
+custom_option = "preserve-me"
+
+[features]
+apps = true
+another_feature = true
+"""
+
+    update = reconcile_codex_config(existing, None, chatgpt_mode=True)
+
+    config = _load(update.content)
+    assert config["model"] == "user-model"
+    provider = config["model_providers"]["paude-chatgpt-http"]  # type: ignore[index]
+    assert provider["base_url"] == "https://chatgpt.com/backend-api/codex"
+    assert provider["custom_option"] == "preserve-me"
+    assert config["features"] == {"apps": False, "another_feature": True}
+
+
+def test_legacy_profile_merges_over_default_then_is_removed() -> None:
+    default = """model = "default-model"
+
+[projects."/default"]
+trust_level = "trusted"
+"""
+    legacy = """model = "active-model"
+model_provider = "paude-chatgpt-http"
+
+[model_providers.paude-chatgpt-http]
+name = "Paude ChatGPT HTTP"
+base_url = "https://chatgpt.com/backend-api/codex"
+wire_api = "responses"
+requires_openai_auth = true
+supports_websockets = false
+
+[features]
+apps = false
+
+[projects."/pvc/workspace"]
+trust_level = "trusted"
+"""
+
+    update = reconcile_codex_config(default, legacy, chatgpt_mode=True)
+
+    config = _load(update.content)
+    assert config["model"] == "active-model"
+    assert config["projects"] == {
+        "/default": {"trust_level": "trusted"},
+        "/pvc/workspace": {"trust_level": "trusted"},
+    }
+    assert update.remove_legacy_profile is True
+
+
+def test_non_chatgpt_removes_only_exact_managed_values() -> None:
+    existing = """model = "user-model"
+model_provider = "paude-chatgpt-http"
+
+[model_providers.paude-chatgpt-http]
+name = "Paude ChatGPT HTTP"
+base_url = "https://user-modified.example"
+wire_api = "responses"
+requires_openai_auth = true
+supports_websockets = false
+custom_option = "preserve-me"
+
+[features]
+apps = false
+another_feature = true
+"""
+
+    update = reconcile_codex_config(existing, None, chatgpt_mode=False)
+
+    config = _load(update.content)
+    assert "model_provider" not in config
+    provider = config["model_providers"]["paude-chatgpt-http"]  # type: ignore[index]
+    assert provider == {
+        "base_url": "https://user-modified.example",
+        "custom_option": "preserve-me",
+    }
+    assert config["features"] == {"another_feature": True}
+
+
+@pytest.mark.parametrize("legacy", [False, True])
+def test_invalid_toml_fails_without_a_replacement(legacy: bool) -> None:
+    default_content = "valid = true\n" if legacy else "not = [valid"
+    legacy_content = "not = [valid" if legacy else None
+
+    with pytest.raises(CodexConfigError, match="invalid TOML"):
+        reconcile_codex_config(
+            default_content,
+            legacy_content,
+            chatgpt_mode=True,
+        )

--- a/tests/test_container_files.py
+++ b/tests/test_container_files.py
@@ -1,0 +1,59 @@
+"""Tests for persistent file operations inside containers."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from paude.container.files import ContainerFileManager
+
+
+def test_read_file_returns_none_when_path_is_missing() -> None:
+    engine = MagicMock()
+    engine.run.return_value = MagicMock(returncode=1)
+
+    assert ContainerFileManager(engine).read_file("container", "/missing") is None
+
+
+def test_read_file_returns_exact_content() -> None:
+    engine = MagicMock()
+    engine.run.side_effect = [
+        MagicMock(returncode=0),
+        MagicMock(returncode=0, stdout="# config\nvalue = true\n"),
+    ]
+
+    content = ContainerFileManager(engine).read_file("container", "/config.toml")
+
+    assert content == "# config\nvalue = true\n"
+
+
+def test_read_file_raises_when_existing_path_cannot_be_read() -> None:
+    engine = MagicMock(binary="podman")
+    engine.run.side_effect = [
+        MagicMock(returncode=0),
+        MagicMock(returncode=1, stdout="", stderr="permission denied"),
+    ]
+
+    with pytest.raises(subprocess.CalledProcessError):
+        ContainerFileManager(engine).read_file("container", "/config.toml")
+
+
+def test_replace_file_uses_same_directory_atomic_rename() -> None:
+    engine = MagicMock()
+
+    ContainerFileManager(engine).replace_file(
+        "container",
+        "/pvc/.codex/config.toml",
+        'model = "gpt"\n',
+        owner="paude",
+    )
+
+    call = engine.run.call_args
+    command = call.args
+    script = command[command.index("-c") + 1]
+    assert 'mktemp "${target}.tmp.XXXXXX"' in script
+    assert 'mv -f "$temporary" "$target"' in script
+    assert command[-3:] == ("/pvc/.codex/config.toml", "paude", "600")
+    assert call.kwargs["input"] == 'model = "gpt"\n'

--- a/tests/test_docker_compat.py
+++ b/tests/test_docker_compat.py
@@ -6,9 +6,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from paude.agents.codex import (
-    CODEX_CHATGPT_PROFILE_TARGET,
-    SYNTHETIC_CODEX_PROFILE_TOML,
+from paude.agents.codex_config import (
+    CODEX_CONFIG_TARGET,
+    LEGACY_CODEX_PROFILE_TARGET,
+    CodexConfigError,
+    reconcile_codex_config,
 )
 from paude.backends.naming import is_local_backend
 from paude.backends.podman import PodmanBackend
@@ -442,36 +444,62 @@ class TestStubCredentialInjection:
         assert exec_calls[0][1].get("input") == STUB_ADC_JSON
 
 
-class TestCodexSyntheticAuth:
-    """Tests for Codex ChatGPT provider profile injection in the agent container."""
+class TestCodexConfigReconciliation:
+    """Tests for persistent default-config handling shared by Docker and Podman."""
 
-    @patch("subprocess.run")
-    def test_injects_only_provider_profile(self, mock_run: MagicMock) -> None:
-        """No auth.json is ever seeded; only `codex login` itself writes it."""
-        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
-        backend = PodmanBackend(engine=ContainerEngine("podman"))
-
-        backend._setup.inject_codex_auth("paude-test", chatgpt_mode=True)
-
-        injections = [
-            c for c in mock_run.call_args_list if c[1].get("input") is not None
+    def test_chatgpt_updates_default_and_removes_legacy_profile(self) -> None:
+        backend = PodmanBackend(engine=MagicMock())
+        backend._setup._files = MagicMock()
+        backend._setup._files.read_file.side_effect = [
+            'model = "user-model"\n',
+            '[projects."/pvc/workspace"]\ntrust_level = "trusted"\n',
         ]
-        assert len(injections) == 1
-        assert injections[0][1]["input"] == SYNTHETIC_CODEX_PROFILE_TOML
-        assert CODEX_CHATGPT_PROFILE_TARGET in injections[0][0][0][-1]
 
-    @patch("subprocess.run")
-    def test_removes_auth_when_not_chatgpt_mode(self, mock_run: MagicMock) -> None:
-        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
-        backend = PodmanBackend(engine=ContainerEngine("podman"))
+        backend._setup.configure_codex("paude-test", chatgpt_mode=True)
 
-        backend._setup.inject_codex_auth("paude-test", chatgpt_mode=False)
-
-        exec_args = [c[0][0] for c in mock_run.call_args_list if "exec" in c[0][0]]
-        assert any(
-            "rm" in args and "/home/paude/.codex/auth.json" in args
-            for args in exec_args
+        write = backend._setup._files.replace_file.call_args
+        assert write.args[:2] == ("paude-test", CODEX_CONFIG_TARGET)
+        assert 'model = "user-model"' in write.args[2]
+        assert 'trust_level = "trusted"' in write.args[2]
+        assert 'model_provider = "paude-chatgpt-http"' in write.args[2]
+        backend._setup._files.remove_file.assert_called_once_with(
+            "paude-test", LEGACY_CODEX_PROFILE_TARGET
         )
-        assert any(
-            "rm" in args and CODEX_CHATGPT_PROFILE_TARGET in args for args in exec_args
+
+    def test_correct_chatgpt_config_is_not_rewritten(self) -> None:
+        backend = PodmanBackend(engine=MagicMock())
+        backend._setup._files = MagicMock()
+        first = reconcile_codex_config(None, None, chatgpt_mode=True)
+        backend._setup._files.read_file.side_effect = [first.content, None]
+
+        backend._setup.configure_codex("paude-test", chatgpt_mode=True)
+
+        backend._setup._files.replace_file.assert_not_called()
+
+    def test_invalid_config_is_not_rewritten_or_cleaned_up(self) -> None:
+        backend = PodmanBackend(engine=MagicMock())
+        backend._setup._files = MagicMock()
+        backend._setup._files.read_file.side_effect = [
+            "invalid = [toml",
+            'model = "legacy"\n',
+        ]
+
+        with pytest.raises(CodexConfigError, match="invalid TOML"):
+            backend._setup.configure_codex("paude-test", chatgpt_mode=True)
+
+        backend._setup._files.replace_file.assert_not_called()
+        backend._setup._files.remove_file.assert_not_called()
+
+    def test_non_chatgpt_removes_container_auth(self) -> None:
+        backend = PodmanBackend(engine=MagicMock())
+        backend._setup._files = MagicMock()
+        backend._setup._files.read_file.side_effect = [None, None]
+        backend._setup._runner = MagicMock()
+
+        backend._setup.configure_codex("paude-test", chatgpt_mode=False)
+
+        backend._setup._runner.exec_in_container.assert_called_once_with(
+            "paude-test",
+            ["rm", "-f", "/home/paude/.codex/auth.json"],
+            check=False,
         )

--- a/tests/test_entrypoint_seed_copy.py
+++ b/tests/test_entrypoint_seed_copy.py
@@ -112,12 +112,11 @@ class TestEntrypointContract:
             in content
         )
 
-    def test_entrypoint_wraps_child_codex_for_chatgpt_http(self) -> None:
-        """Gas City child Codex processes inherit the ChatGPT HTTP profile."""
+    def test_entrypoint_does_not_select_a_separate_codex_profile(self) -> None:
+        """Codex uses its persistent default config for every launch path."""
         content = ENTRYPOINT_PATH.read_text()
-        assert "PAUDE_CODEX_CHATGPT_MODE" in content
-        assert r'exec "$_real_codex" --profile paude-chatgpt-http "\$@"' in content
-        assert 'export PATH="/tmp/paude-bin:$PATH"' in content
+        assert "PAUDE_CODEX_CHATGPT_MODE" not in content
+        assert "--profile paude-chatgpt-http" not in content
 
 
 def _build_gemini_sandbox_script(
@@ -464,7 +463,7 @@ def _persist_config_dir_bash_function(pvc_dir: str) -> str:
 
             if [[ ! -L "$home_dir" ]]; then
                 if [[ -d "$home_dir" ]]; then
-                    cp -RPp "$home_dir/." "$pvc_dir/" 2>/dev/null || true
+                    cp -RPpn "$home_dir/." "$pvc_dir/" 2>/dev/null || true
                     rm -rf "$home_dir" 2>/dev/null || true
                 fi
                 if [[ ! -e "$home_dir" ]]; then
@@ -617,6 +616,32 @@ class TestPersistAgentConfig:
         assert (home / ".claude").is_symlink()
         # Baked content was merged into PVC
         assert (pvc / ".claude" / "settings.json").read_text() == '{"baked": true}'
+
+    def test_image_baked_config_does_not_replace_pvc_state(
+        self, tmp_path: Path
+    ) -> None:
+        """A recreated container cannot overwrite persistent user config."""
+        home = tmp_path / "home"
+        home.mkdir()
+        pvc = tmp_path / "pvc"
+        pvc.mkdir()
+        baked_config = home / ".codex"
+        baked_config.mkdir()
+        (baked_config / "config.toml").write_text('model = "baked"\n')
+        pvc_config = pvc / ".codex"
+        pvc_config.mkdir()
+        (pvc_config / "config.toml").write_text('model = "user"\n')
+
+        script = _build_persist_script(
+            str(home),
+            str(pvc),
+            agent_config_dir=".codex",
+            agent_config_file="",
+        )
+        result = _run_script(script)
+
+        assert result.returncode == 0, result.stderr
+        assert (pvc_config / "config.toml").read_text() == 'model = "user"\n'
 
     def test_idempotent_on_reconnect(self, tmp_path: Path) -> None:
         """Reconnect: symlinks already exist, no-op."""

--- a/tests/test_podman_session.py
+++ b/tests/test_podman_session.py
@@ -1190,7 +1190,7 @@ class TestComposedCodexAuthentication:
         [("openai", False), ("chatgpt", True)],
     )
     @patch("paude.backends.podman.session_setup.get_session_composition")
-    def test_codex_profile_uses_codex_provider_only(
+    def test_codex_config_uses_codex_provider_only(
         self,
         mock_composition: MagicMock,
         codex_provider: str,
@@ -1210,14 +1210,14 @@ class TestComposedCodexAuthentication:
             return_value=ProxyCredentials(chatgpt_oauth_mode=True)
         )
         setup.inject_stub_credentials = MagicMock()  # type: ignore[method-assign]
-        setup.inject_codex_auth = MagicMock()  # type: ignore[method-assign]
+        setup.configure_codex = MagicMock()  # type: ignore[method-assign]
         setup.sync_host_config = MagicMock()  # type: ignore[method-assign]
         setup.sync_sandbox_config = MagicMock()  # type: ignore[method-assign]
         proxy = MagicMock()
 
         setup.start_session_containers("session", "container", proxy)
 
-        setup.inject_codex_auth.assert_called_once_with(
+        setup.configure_codex.assert_called_once_with(
             "container", chatgpt_mode=expected_chatgpt_mode
         )
 

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -78,7 +78,7 @@ class TestBuildSessionEnv:
         assert env["PAUDE_AGENT_PROVIDERS"] == (
             "gascity=vertex,claude=vertex,codex=chatgpt"
         )
-        assert env["PAUDE_CODEX_CHATGPT_MODE"] == "1"
+        assert "PAUDE_CODEX_CHATGPT_MODE" not in env
         assert env["CLAUDE_CODE_USE_VERTEX"] == "1"
         assert env["CODEX_HOME"] == "/home/paude/.codex"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -326,6 +326,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "rich" },
+    { name = "tomlkit" },
     { name = "typer" },
 ]
 
@@ -342,6 +343,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
+    { name = "tomlkit", specifier = ">=0.13.0" },
     { name = "typer", specifier = ">=0.9.0" },
 ]
 
@@ -581,6 +583,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Use the persistent default Codex config instead of replacing a generated profile on every start. Merge only proxy-required settings so project trust and other user configuration survive container restarts and upgrades.