### PR TITLE
Fix remote Git config writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,11 @@ uv tool install paude
 
 Agent configuration, logins, conversation history, skills, and workspace data
 are stored on each session's private volume. They survive `start`, `stop`, and
-container recreation. After updating Paude, refresh a session with:
+container recreation. Each session gets a writable `/pvc/.gitconfig`, seeded
+from the host config when available or created empty otherwise. All container
+processes use it, so `git config --global` works consistently for local and
+SSH-remote Docker/Podman sessions without modifying the host config.
+After updating Paude, refresh a session with:
 
 ```bash
 paude upgrade SESSION

--- a/containers/paude/entrypoint-lib-credentials.sh
+++ b/containers/paude/entrypoint-lib-credentials.sh
@@ -80,11 +80,49 @@ setup_ca_trust() {
     fi
 }
 
+# Seed the writable global Git config used inside the container.
+#
+# Local sessions provide the host config through /credentials/gitconfig. SSH
+# sessions provide it as a read-only $HOME/.gitconfig bind mount. Both paths
+# must converge on the same writable, persistent PVC file.
+setup_gitconfig() {
+    local config_path="$1"
+    local home_path="$2"
+    local pvc_path="$3"
+    local source_path=""
+
+    if [[ -f "$config_path/gitconfig" ]]; then
+        source_path="$config_path/gitconfig"
+    elif [[ -f "$home_path/.gitconfig" ]]; then
+        source_path="$home_path/.gitconfig"
+    fi
+
+    # Seed once so user changes survive reconnects and container recreation.
+    # A session without a host config still needs a real PVC-backed file so
+    # git config --global does not fall back to the container writable layer.
+    if [[ ! -f "$pvc_path/.gitconfig" ]]; then
+        if [[ -n "$source_path" ]]; then
+            cp -f "$source_path" "$pvc_path/.gitconfig" 2>/dev/null || true
+        else
+            touch "$pvc_path/.gitconfig" 2>/dev/null || true
+        fi
+        chmod 664 "$pvc_path/.gitconfig" 2>/dev/null || true
+        chcon --reference="$pvc_path" "$pvc_path/.gitconfig" 2>/dev/null || true
+    fi
+    if [[ -f "$pvc_path/.gitconfig" ]]; then
+        export GIT_CONFIG_GLOBAL="$pvc_path/.gitconfig"
+    fi
+}
+
 # Set up credentials from tmpfs-based storage (/credentials)
 setup_credentials() {
     local config_path="/credentials"
 
-    # Only set up if synchronized credentials exist.
+    # Git config is handled for both local /credentials sync and remote
+    # read-only home mounts. Other credentials only exist in /credentials.
+    setup_gitconfig "$config_path" "$HOME" "/pvc"
+
+    # Only set up the remaining synchronized credentials if they exist.
     if [[ ! -d "$config_path" ]]; then
         return 0
     fi
@@ -94,19 +132,6 @@ setup_credentials() {
         mkdir -p "$HOME/.config"
         rm -rf "$HOME/.config/gcloud" 2>/dev/null || true
         ln -sf "$config_path/gcloud" "$HOME/.config/gcloud"
-    fi
-
-    # Unlike gcloud/gitignore (symlinked read-only), gitconfig must be
-    # writable — tools like GasCity add entries via `git config --global`.
-    # Seed once to PVC so additions survive pod restarts. To force a
-    # re-seed from host config, delete /pvc/.gitconfig before restarting.
-    if [[ -f "$config_path/gitconfig" ]] && [[ ! -f /pvc/.gitconfig ]]; then
-        cp -f "$config_path/gitconfig" /pvc/.gitconfig 2>/dev/null || true
-        chmod 664 /pvc/.gitconfig 2>/dev/null || true
-        chcon --reference=/pvc /pvc/.gitconfig 2>/dev/null || true
-    fi
-    if [[ -f /pvc/.gitconfig ]]; then
-        export GIT_CONFIG_GLOBAL=/pvc/.gitconfig
     fi
 
     # Set up global gitignore via symlink

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -9,7 +9,7 @@ The container intentionally restricts certain operations:
 | Host working directory | not mounted | Code lives in a separate named volume, synced via git (see [Code Synchronization](SESSIONS.md#code-synchronization)) — the agent never touches host files directly |
 | gcloud credentials | never enter the agent's container; a non-functional stub ADC file is injected instead | Real credentials live only on the network-filtering proxy sidecar, which signs Vertex AI requests on the container's behalf |
 | Agent config and session state | copied in, then stored on the private session volume | Prevents host config poisoning while preserving settings and history across container upgrades |
-| `~/.gitconfig` | writable copy, persisted on the session volume (read-only bind mount only for `--host` remote sessions) | Git identity |
+| `~/.gitconfig` | host config is read-only; a writable copy is persisted at `/pvc/.gitconfig` for local and `--host` remote sessions | Git identity |
 | SSH keys | not mounted | Prevents git push via SSH |
 | GitHub CLI config | not mounted | Prevents cached host credentials |
 | `GH_TOKEN` (host) | never propagated | Set `PAUDE_GITHUB_TOKEN` before `create`/`start`; the real token goes only to the proxy sidecar, never the agent's container |

--- a/src/paude/backends/session_env.py
+++ b/src/paude/backends/session_env.py
@@ -155,6 +155,12 @@ def build_session_env(
             env[var] = PROXY_MANAGED_CREDENTIAL
         env["GH_TOKEN"] = PROXY_MANAGED_CREDENTIAL
 
+    # Set this at container creation time so every process, including later
+    # docker/podman exec commands, uses the persistent writable config.
+    from paude.constants import CONTAINER_GIT_CONFIG
+
+    env["GIT_CONFIG_GLOBAL"] = CONTAINER_GIT_CONFIG
+
     return env, agent_args
 
 

--- a/src/paude/cli/help.py
+++ b/src/paude/cli/help.py
@@ -165,6 +165,8 @@ _SECTIONS: tuple[HelpSection, ...] = (
             " is maximum risk mode.\n"
             "Codex ChatGPT settings are merged into persistent config;"
             " Apps are disabled and standalone MCP servers are unchanged.\n"
+            "Git config is writable persistent session state for all processes;"
+            " host Git config remains read-only.\n"
             "PAUDE_GITHUB_TOKEN is explicit only;"
             " host GH_TOKEN is never auto-propagated."
         ),

--- a/src/paude/constants.py
+++ b/src/paude/constants.py
@@ -2,6 +2,7 @@
 
 CONTAINER_WORKSPACE = "/pvc/workspace"
 CONTAINER_HOME = "/home/paude"
+CONTAINER_GIT_CONFIG = "/pvc/.gitconfig"
 CONTAINER_ENTRYPOINT = "/usr/local/bin/entrypoint.sh"
 BASE_REF_NAME = "refs/paude/base"
 GCP_ADC_FILENAME = "application_default_credentials.json"

--- a/tests/integration/test_podman_backend.py
+++ b/tests/integration/test_podman_backend.py
@@ -359,6 +359,24 @@ class TestPodmanRunningSession:
         assert returncode == 0
         assert "hello" in stdout
 
+    def test_exec_in_session_uses_persistent_git_config(
+        self, running_session: tuple[PodmanBackend, str, Path]
+    ) -> None:
+        """Later exec processes write global Git settings to the PVC."""
+        backend, name, _workspace = running_session
+
+        returncode, _stdout, stderr = backend.exec_in_session(
+            name, "git config --global paude.integration enabled"
+        )
+
+        assert returncode == 0, stderr
+        returncode, stdout, stderr = backend.exec_in_session(
+            name,
+            "git config --file /pvc/.gitconfig --get paude.integration",
+        )
+        assert returncode == 0, stderr
+        assert stdout.strip() == "enabled"
+
     def test_copy_to_and_from_session(
         self,
         running_session: tuple[PodmanBackend, str, Path],

--- a/tests/test_entrypoint_seed_copy.py
+++ b/tests/test_entrypoint_seed_copy.py
@@ -737,6 +737,20 @@ class TestPersistAgentConfigContract:
             "so host config is merged into PVC without clobbering runtime state"
         )
 
+    def test_gitconfig_setup_is_shared_by_local_and_remote_paths(self) -> None:
+        """Git config setup must run before the session starts tmux."""
+        credentials = ENTRYPOINT_LIB_CREDENTIALS_PATH.read_text()
+        entrypoint = ENTRYPOINT_PATH.read_text()
+
+        assert "setup_gitconfig()" in credentials
+        assert 'setup_gitconfig "$config_path" "$HOME" "/pvc"' in credentials
+        setup_pos = entrypoint.find("\nsetup_credentials\n")
+        tmux_pos = entrypoint.find('tmux send-keys -t "$AGENT_SESSION_NAME"')
+        assert setup_pos != -1
+        assert tmux_pos != -1
+        assert setup_pos < tmux_pos
+        assert "GIT_CONFIG_GLOBAL" in entrypoint[tmux_pos:]
+
     def test_sandbox_config_python_uses_cp_for_claude_json(self) -> None:
         """Claude agent's apply_sandbox_config must use cp+rm, not mv."""
         from paude.agents.claude import ClaudeAgent
@@ -749,6 +763,102 @@ class TestPersistAgentConfigContract:
         assert 'rm -f "${claude_json}.tmp"' in script, (
             "Claude sandbox config must remove temp file after cp"
         )
+
+
+def _build_gitconfig_setup_script(
+    home: Path,
+    pvc: Path,
+    credentials: Path,
+) -> str:
+    """Build a script that exercises the real setup_gitconfig function."""
+    return textwrap.dedent(
+        f"""\
+        #!/bin/bash
+        set -e
+        source "{ENTRYPOINT_LIB_CREDENTIALS_PATH}"
+        setup_gitconfig "{credentials}" "{home}" "{pvc}"
+        git config --global beads.role maintainer
+        """
+    )
+
+
+class TestGitconfigPersistence:
+    """Tests for the common writable Git config setup."""
+
+    def test_seedless_session_creates_persistent_config(self, tmp_path: Path) -> None:
+        """A session without host credentials still persists global Git writes."""
+        home = tmp_path / "home"
+        pvc = tmp_path / "pvc"
+        credentials = tmp_path / "credentials"
+        home.mkdir()
+        pvc.mkdir()
+
+        result = _run_script(_build_gitconfig_setup_script(home, pvc, credentials))
+
+        assert result.returncode == 0, result.stderr
+        assert "role = maintainer" in (pvc / ".gitconfig").read_text()
+        assert not (home / ".gitconfig").exists()
+
+    def test_remote_read_only_home_config_is_copied_to_pvc(
+        self, tmp_path: Path
+    ) -> None:
+        """Remote bind-mounted config is never modified by global Git writes."""
+        home = tmp_path / "home"
+        pvc = tmp_path / "pvc"
+        credentials = tmp_path / "credentials"
+        home.mkdir()
+        pvc.mkdir()
+        credentials.mkdir()
+        host_gitconfig = home / ".gitconfig"
+        host_gitconfig.write_text("[user]\n\tname = Host User\n")
+        host_gitconfig.chmod(0o444)
+
+        result = _run_script(_build_gitconfig_setup_script(home, pvc, credentials))
+
+        assert result.returncode == 0, result.stderr
+        assert "role = maintainer" in (pvc / ".gitconfig").read_text()
+        assert (pvc / ".gitconfig").stat().st_mode & 0o222
+        assert "beads.role" not in host_gitconfig.read_text()
+
+    def test_local_credentials_config_is_preferred(self, tmp_path: Path) -> None:
+        """Local /credentials sync remains the preferred seed source."""
+        home = tmp_path / "home"
+        pvc = tmp_path / "pvc"
+        credentials = tmp_path / "credentials"
+        home.mkdir()
+        pvc.mkdir()
+        credentials.mkdir()
+        (home / ".gitconfig").write_text("[user]\n\tname = Home User\n")
+        credential_gitconfig = credentials / "gitconfig"
+        credential_gitconfig.write_text("[user]\n\tname = Credential User\n")
+
+        result = _run_script(_build_gitconfig_setup_script(home, pvc, credentials))
+
+        assert result.returncode == 0, result.stderr
+        content = (pvc / ".gitconfig").read_text()
+        assert "Credential User" in content
+        assert "Home User" not in content
+        assert "beads.role" not in credential_gitconfig.read_text()
+
+    def test_existing_pvc_config_is_preserved(self, tmp_path: Path) -> None:
+        """Reconnects retain the persistent config instead of reseeding it."""
+        home = tmp_path / "home"
+        pvc = tmp_path / "pvc"
+        credentials = tmp_path / "credentials"
+        home.mkdir()
+        pvc.mkdir()
+        credentials.mkdir()
+        (home / ".gitconfig").write_text("[user]\n\tname = New Host User\n")
+        existing = pvc / ".gitconfig"
+        existing.write_text("[user]\n\tname = Existing User\n")
+
+        result = _run_script(_build_gitconfig_setup_script(home, pvc, credentials))
+
+        assert result.returncode == 0, result.stderr
+        content = existing.read_text()
+        assert "Existing User" in content
+        assert "New Host User" not in content
+        assert "role = maintainer" in content
 
 
 def _build_persist_config_dir_script(

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -52,6 +52,18 @@ class TestBuildSessionEnv:
 
         assert env["PAUDE_SUPPRESS_PROMPTS"] == "1"
 
+    def test_global_git_config_is_inherited_by_container_processes(self) -> None:
+        """Every process uses the writable session-volume Git config."""
+        config = SessionConfig(
+            name="test",
+            workspace=Path("/home/user/project"),
+            image="test-image",
+        )
+
+        env, _args = build_session_env(config, ClaudeAgent(), proxy_name="proxy")
+
+        assert env["GIT_CONFIG_GLOBAL"] == "/pvc/.gitconfig"
+
     def test_composition_exports_all_runtime_metadata(self) -> None:
         composition = get_agents(
             ["gascity", "claude", "codex"],


### PR DESCRIPTION
Seed a writable persistent Git config for local credential sync and SSH home mounts so global Git writes update settings without touching host configuration. Set GIT_CONFIG_GLOBAL for every container process. Create the PVC file without a host seed. Add regression coverage and document the behavior.