### PR TITLE
Install ripgrep in agent containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Run AI coding agents in secure containers. They make commits, you pull them back
 
 > Agents are installed automatically inside the container — no local agent installation needed. You just need authentication credentials for your chosen provider.
 
+Paude-managed agent containers include common development utilities, including
+`rg` (ripgrep) for fast code search.
+
 Agent installation, credential setup, and provider selection are independent.
 `--agents` is the exact install set and its first entry launches as the primary.
 `--providers` selects credentials to configure, while `--agent-provider` maps

--- a/containers/paude/Dockerfile
+++ b/containers/paude/Dockerfile
@@ -35,6 +35,7 @@ RUN dnf install -y dnf-plugins-core && \
         unzip \
         zip \
         tree \
+        ripgrep \
     && dnf clean all && \
     alternatives --install /usr/bin/python python /usr/bin/python3.12 1 && \
     alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1

--- a/src/paude/cli/help.py
+++ b/src/paude/cli/help.py
@@ -69,6 +69,13 @@ _SECTIONS: tuple[HelpSection, ...] = (
         ),
     ),
     HelpSection(
+        title="Container Environment",
+        text=(
+            "Paude-managed agent containers include common development"
+            " utilities, including rg (ripgrep) for fast code search."
+        ),
+    ),
+    HelpSection(
         title="Copying Files (without git)",
         rows=(
             (

--- a/src/paude/config/dockerfile.py
+++ b/src/paude/config/dockerfile.py
@@ -131,24 +131,24 @@ def generate_workspace_dockerfile(
 RUN if command -v apt-get >/dev/null 2>&1; then \\
         apt-get update && \\
         apt-get install -y --no-install-recommends \\
-            git curl ca-certificates bash tmux locales socat jq \\
+            git curl ca-certificates bash tmux locales socat jq ripgrep \\
             coreutils findutils grep sed gawk diffutils less file \\
             tar gzip xz-utils unzip zip && \\
         rm -rf /var/lib/apt/lists/* && \\
         localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8; \\
     elif command -v apk >/dev/null 2>&1; then \\
-        apk add --no-cache git curl ca-certificates bash tmux socat jq \\
+        apk add --no-cache git curl ca-certificates bash tmux socat jq ripgrep \\
             coreutils findutils grep sed gawk diffutils less file \\
             tar gzip xz unzip zip; \\
     elif command -v dnf >/dev/null 2>&1; then \\
         dnf install -y --allowerasing \\
-            git curl ca-certificates bash glibc-langpack-en socat jq \\
+            git curl ca-certificates bash glibc-langpack-en socat jq ripgrep \\
             which coreutils findutils grep sed gawk diffutils less file \\
             tar gzip xz unzip zip && \\
         dnf clean all; \\
     elif command -v yum >/dev/null 2>&1; then \\
         yum install -y --allowerasing \\
-            git curl ca-certificates bash glibc-langpack-en socat jq \\
+            git curl ca-certificates bash glibc-langpack-en socat jq ripgrep \\
             which coreutils findutils grep sed gawk diffutils less file \\
             tar gzip xz unzip zip && \\
         yum clean all; \\

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -570,10 +570,15 @@ class TestGenerateWorkspaceDockerfile:
             "diffutils",
             "less",
             "file",
+            "ripgrep",
             "unzip",
             "zip",
         ]:
             assert pkg in dockerfile, f"Expected package '{pkg}' in Dockerfile"
+
+        # Keep ripgrep available regardless of which supported package manager
+        # the user's base image provides.
+        assert dockerfile.count("ripgrep") == 4
 
     def test_dnf_uses_allowerasing(self):
         """generate_workspace_dockerfile uses --allowerasing for dnf to replace coreutils-single."""

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -511,6 +511,18 @@ class TestProxyDockerfileCopyFiles:
             )
 
 
+class TestPaudeDockerfilePackages:
+    """Validate packages installed in the standard Paude image."""
+
+    def test_installs_ripgrep(self):
+        """The standard image includes the rg code-search command."""
+        dockerfile = (
+            Path(__file__).parent.parent / "containers" / "paude" / "Dockerfile"
+        )
+
+        assert "ripgrep" in dockerfile.read_text()
+
+
 class TestVolumeManager:
     """Tests for VolumeManager."""
 


### PR DESCRIPTION
Add ripgrep to standard and generated image package lists so every agent can use rg for code search.