### PR TITLE
Install Node.js for Codex docs tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Run AI coding agents in secure containers. They make commits, you pull them back
 
 Paude-managed agent containers include common development utilities, including
 `rg` (ripgrep) for fast code search.
+The Codex CLI image also includes Node.js for documentation tooling, using the
+custom base image's package manager or an existing Node.js installation.
 
 Agent installation, credential setup, and provider selection are independent.
 `--agents` is the exact install set and its first entry launches as the primary.

--- a/src/paude/agents/base.py
+++ b/src/paude/agents/base.py
@@ -199,15 +199,33 @@ def pipefail_install_lines(config: AgentConfig, container_home: str) -> list[str
 
 
 def nodejs_prereq_install_lines() -> list[str]:
-    """Return canonical Dockerfile lines to install the Node.js runtime as root.
+    """Return portable Dockerfile lines to ensure Node.js and npm as root.
 
     Emitted verbatim by every agent that needs Node.js (e.g. Gemini CLI, the
     Gas City core) so that compose_dockerfile_install_lines() can collapse the
-    repeated install down to a single layer.
+    repeated install down to a single layer. Existing Node.js installations are
+    reused, which keeps custom Debian, Alpine, and Node-based images portable.
     """
     return [
         "USER root",
-        "RUN dnf install -y nodejs npm && dnf clean all",
+        (
+            "RUN if command -v node >/dev/null 2>&1 && "
+            "command -v npm >/dev/null 2>&1; then "
+            "echo 'Node.js and npm already installed'; "
+            "elif command -v apt-get >/dev/null 2>&1; then "
+            "apt-get update && apt-get install -y --no-install-recommends "
+            "nodejs npm && rm -rf /var/lib/apt/lists/*; "
+            "elif command -v apk >/dev/null 2>&1; then "
+            "apk add --no-cache nodejs npm; "
+            "elif command -v dnf >/dev/null 2>&1; then "
+            "dnf install -y nodejs npm && dnf clean all; "
+            "elif command -v yum >/dev/null 2>&1; then "
+            "yum install -y nodejs npm && yum clean all; "
+            "else "
+            "echo 'Error: Node.js and npm require a supported package manager' "
+            ">&2; exit 1; "
+            "fi"
+        ),
     ]
 
 

--- a/src/paude/agents/codex.py
+++ b/src/paude/agents/codex.py
@@ -8,6 +8,7 @@ from paude.agents.base import (
     AgentConfig,
     build_environment_from_config,
     build_provider_credentials,
+    nodejs_prereq_install_lines,
     pipefail_install_lines,
 )
 from paude.constants import CONTAINER_HOME
@@ -61,6 +62,9 @@ class CodexAgent:
 
     def dockerfile_install_lines(self, container_home: str) -> list[str]:
         return [
+            "",
+            "# Install Node.js for Codex documentation tooling",
+            *nodejs_prereq_install_lines(),
             "",
             "# Install Codex CLI",
             "USER paude",

--- a/src/paude/cli/help.py
+++ b/src/paude/cli/help.py
@@ -73,6 +73,9 @@ _SECTIONS: tuple[HelpSection, ...] = (
         text=(
             "Paude-managed agent containers include common development"
             " utilities, including rg (ripgrep) for fast code search."
+            " The Codex CLI image also includes Node.js for documentation"
+            " tooling, using the custom base image's package manager or an"
+            " existing Node.js installation."
         ),
     ),
     HelpSection(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -200,7 +200,17 @@ class TestComposeDockerfileInstallLines:
     def test_dedups_shared_node_prereq(self) -> None:
         agents = [get_agent("gemini"), get_agent("gascity")]
         lines = compose_dockerfile_install_lines(agents, "/home/paude")
-        node_installs = [line for line in lines if "dnf install -y nodejs npm" in line]
+        node_installs = [
+            line for line in lines if line.startswith("RUN if command -v node")
+        ]
+        assert len(node_installs) == 1
+
+    def test_dedups_codex_and_gemini_node_prereq(self) -> None:
+        agents = [get_agent("codex"), get_agent("gemini")]
+        lines = compose_dockerfile_install_lines(agents, "/home/paude")
+        node_installs = [
+            line for line in lines if line.startswith("RUN if command -v node")
+        ]
         assert len(node_installs) == 1
 
     def test_preserves_distinct_tool_installs(self) -> None:
@@ -232,6 +242,26 @@ class TestNodejsPrereqInstallLines:
         assert lines[0] == "USER root"
         assert "nodejs" in lines[1]
         assert "npm" in lines[1]
+
+    def test_reuses_existing_node_and_npm(self) -> None:
+        install = nodejs_prereq_install_lines()[1]
+        assert "command -v node" in install
+        assert "command -v npm" in install
+        assert "already installed" in install
+
+    def test_dispatches_supported_package_managers(self) -> None:
+        install = nodejs_prereq_install_lines()[1]
+        for package_manager in ("apt-get", "apk", "dnf", "yum"):
+            assert f"command -v {package_manager}" in install
+        assert "apt-get update" in install
+        assert "apk add --no-cache nodejs npm" in install
+        assert "dnf install -y nodejs npm" in install
+        assert "yum install -y nodejs npm" in install
+
+    def test_fails_without_supported_package_manager(self) -> None:
+        install = nodejs_prereq_install_lines()[1]
+        assert "require a supported package manager" in install
+        assert "exit 1" in install
 
     def test_identical_across_calls(self) -> None:
         # Dedup relies on byte-identical output.
@@ -551,6 +581,15 @@ class TestCodexAgentDockerfile:
         lines = CodexAgent().dockerfile_install_lines("/home/paude")
         text = "\n".join(lines)
         assert "openai/codex" in text
+
+    def test_installs_nodejs_for_documentation_tooling(self) -> None:
+        lines = CodexAgent().dockerfile_install_lines("/home/paude")
+        text = "\n".join(lines)
+        assert "Node.js for Codex documentation tooling" in text
+        assert "command -v apt-get" in text
+        assert "command -v apk" in text
+        assert "command -v dnf" in text
+        assert "command -v yum" in text
 
     def test_contains_version(self) -> None:
         lines = CodexAgent().dockerfile_install_lines("/home/paude")

--- a/tests/test_gascity.py
+++ b/tests/test_gascity.py
@@ -305,7 +305,9 @@ class TestGascityComposedInstall:
         lines = compose_dockerfile_install_lines(
             get_agents(["gascity"]).agents, "/home/paude"
         )
-        node_installs = [line for line in lines if "dnf install -y nodejs npm" in line]
+        node_installs = [
+            line for line in lines if line.startswith("RUN if command -v node")
+        ]
         assert len(node_installs) == 1
 
     def test_ends_with_canonical_layout(self) -> None:


### PR DESCRIPTION
Reuse the shared Node.js prerequisite in Codex runtime layers so the agent can run its documentation helper scripts. Dispatch installation across supported package managers and reuse existing Node.js installations for custom base images. Add generation and composition coverage and document the runtime dependency.