### PR TITLE
Pin Gas City toolchain versions

### DIFF
--- a/src/paude/agents/gascity.py
+++ b/src/paude/agents/gascity.py
@@ -11,6 +11,10 @@ from paude.agents.base import (
     nodejs_prereq_install_lines,
 )
 
+GC_VERSION = "1.4.0"
+DOLT_VERSION = "2.1.10"
+BD_VERSION = "1.1.0"
+
 
 class GascityAgent:
     """Gas City agent — composite agent with gc, Claude Code, and Gemini CLI.
@@ -80,27 +84,18 @@ class GascityAgent:
             'aarch64) BIN_ARCH="arm64" ;; '
             '*) echo "Unsupported: $ARCH" && exit 1 ;; '
             "esac && "
-            "DOLT_URL=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "
-            "https://github.com/dolthub/dolt/releases/latest) && "
-            "DOLT_TAG=${DOLT_URL##*/} && DOLT_VERSION=${DOLT_TAG#v} && "
-            "BD_URL=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "
-            "https://github.com/gastownhall/beads/releases/latest) && "
-            "BD_TAG=${BD_URL##*/} && BD_VERSION=${BD_TAG#v} && "
-            "GC_URL=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "
-            "https://github.com/gastownhall/gascity/releases/latest) && "
-            "GC_TAG=${GC_URL##*/} && GC_VERSION=${GC_TAG#v} && "
             'curl -fsSL "https://github.com/dolthub/dolt'
-            "/releases/download/${DOLT_TAG}"
+            f"/releases/download/v{DOLT_VERSION}"
             '/dolt-linux-${BIN_ARCH}.tar.gz"'
             " | tar xz --strip-components=2"
             " -C $D dolt-linux-${BIN_ARCH}/bin/dolt && "
             'curl -fsSL "https://github.com/gastownhall'
-            "/beads/releases/download/${BD_TAG}"
-            '/beads_${BD_VERSION}_linux_${BIN_ARCH}.tar.gz"'
+            f"/beads/releases/download/v{BD_VERSION}"
+            f'/beads_{BD_VERSION}_linux_${{BIN_ARCH}}.tar.gz"'
             " | tar xz -C $D bd && "
             'curl -fsSL "https://github.com/gastownhall'
-            "/gascity/releases/download/${GC_TAG}"
-            "/gascity_${GC_VERSION}_linux_${BIN_ARCH}"
+            f"/gascity/releases/download/v{GC_VERSION}"
+            f"/gascity_{GC_VERSION}_linux_${{BIN_ARCH}}"
             '.tar.gz" | tar xz -C $D gc && '
             "$D/dolt config --global --set metrics.disabled true && "
             '$D/dolt config --global --set user.name "Paude Agent" && '

--- a/tests/test_gascity.py
+++ b/tests/test_gascity.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 from paude.agents import get_agents
 from paude.agents.base import compose_dockerfile_install_lines
-from paude.agents.gascity import GascityAgent
+from paude.agents.gascity import BD_VERSION, DOLT_VERSION, GC_VERSION, GascityAgent
 
 
 class TestGascityAgentConfig:
@@ -109,21 +109,24 @@ class TestGascityAgentDockerfile:
     def test_contains_dolt(self) -> None:
         text = "\n".join(GascityAgent().dockerfile_install_lines("/home/paude"))
         assert "dolthub/dolt" in text
-        assert "dolthub/dolt/releases/latest" in text
+        assert DOLT_VERSION in text
 
     def test_contains_bd(self) -> None:
         text = "\n".join(GascityAgent().dockerfile_install_lines("/home/paude"))
         assert "gastownhall/beads" in text
-        assert "gastownhall/beads/releases/latest" in text
+        assert BD_VERSION in text
 
     def test_contains_gc(self) -> None:
         text = "\n".join(GascityAgent().dockerfile_install_lines("/home/paude"))
         assert "gastownhall/gascity" in text
-        assert "gastownhall/gascity/releases/latest" in text
+        assert GC_VERSION in text
 
-    def test_latest_release_lookup_does_not_require_jq(self) -> None:
+    def test_uses_pinned_release_urls(self) -> None:
         text = "\n".join(GascityAgent().dockerfile_install_lines("/home/paude"))
-        assert "jq" not in text
+        assert f"/dolt/releases/download/v{DOLT_VERSION}" in text
+        assert f"/beads/releases/download/v{BD_VERSION}" in text
+        assert f"/gascity/releases/download/v{GC_VERSION}" in text
+        assert "releases/latest" not in text
 
     def test_contains_flock(self) -> None:
         text = "\n".join(GascityAgent().dockerfile_install_lines("/home/paude"))
@@ -277,11 +280,11 @@ class TestGascityComposedInstall:
     def test_contains_gc_dolt_bd(self) -> None:
         text = self._composed()
         assert "gastownhall/gascity" in text
-        assert "gastownhall/gascity/releases/latest" in text
+        assert GC_VERSION in text
         assert "dolthub/dolt" in text
-        assert "dolthub/dolt/releases/latest" in text
+        assert DOLT_VERSION in text
         assert "gastownhall/beads" in text
-        assert "gastownhall/beads/releases/latest" in text
+        assert BD_VERSION in text
 
     def test_contains_claude(self) -> None:
         text = self._composed()


### PR DESCRIPTION
Keep Gas City, Dolt, and Beads on a tested compatible release set instead of resolving latest releases during image builds.