### PR TITLE
Make paude upgrade crash-safe and resumable

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,10 @@ paude upgrade SESSION
 ```
 
 The command performs a fresh build with the latest stable agent tooling and
-migrates state from older containers before replacing them. See
+migrates state from older containers before replacing them. Upgrades are
+crash-safe: your `/pvc` data volume is reused in place and never removed, and if
+an upgrade is interrupted (e.g. `Ctrl-C`) you can simply re-run
+`paude upgrade SESSION` to finish it. See
 [Session Management](docs/SESSIONS.md) for the per-agent persistence paths.
 
 ### Your First Session

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -77,6 +77,27 @@ mutable state in addition to `/pvc/workspace`.
 The legacy `--rebuild` option is still accepted for compatibility, but is no
 longer necessary because upgrades always rebuild.
 
+### Crash-safe, resumable upgrades
+
+`upgrade` is safe to interrupt. Before tearing down the old container, it
+records the session's fully-resolved configuration to a durable manifest on the
+local host (`~/.config/paude/upgrades.json`, next to the session registry). The
+session's `/pvc` data volume is reused in place and never removed during an
+upgrade, so your workspace and agent state are never at risk.
+
+If an upgrade is interrupted (e.g. `Ctrl-C`) or fails part-way, the manifest is
+left in place and your data is intact. Simply re-run the same command to finish
+it:
+
+```bash
+paude upgrade SESSION   # resumes and completes an interrupted upgrade
+```
+
+Resuming works even if the old container was already removed (the config is
+read from the manifest instead of the container's labels) and for both local
+and remote/SSH sessions (the manifest always lives on the local host). The
+manifest is deleted automatically once the upgrade succeeds.
+
 ### Persisted agent state
 
 | Agent | PVC-backed home paths |

--- a/src/paude/cli/help.py
+++ b/src/paude/cli/help.py
@@ -50,7 +50,7 @@ _SECTIONS: tuple[HelpSection, ...] = (
             ("paude stop", "Stop session (preserves data)"),
             (
                 "paude upgrade NAME",
-                "Refresh agent tooling, preserving workspace and state",
+                "Refresh agent tooling, preserving data; resumable if interrupted",
             ),
             ("paude delete NAME --confirm", "Delete session permanently"),
             ("paude delete NAME --confirm --force", "Remove from local config only"),

--- a/src/paude/cli/helpers.py
+++ b/src/paude/cli/helpers.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
 def find_session_backend(
     session_name: str,
     connect_timeout: int | None = None,
+    *,
+    allow_offline: bool = False,
 ) -> tuple[BackendType, Backend] | None:
     """Find which backend contains the given session.
 
@@ -33,6 +35,10 @@ def find_session_backend(
 
     Args:
         session_name: Name of the session to find.
+        connect_timeout: Optional SSH connect timeout.
+        allow_offline: When True and the session can't be discovered live
+            (e.g. its container was removed mid-upgrade), reconstruct the
+            backend from the registry entry instead of returning None.
     Returns:
         Tuple of (backend_type, backend_instance) if found, None otherwise.
         The backend instance uses either Podman or Docker.
@@ -62,6 +68,21 @@ def find_session_backend(
             return (BackendType.docker, docker)
     except Exception:  # noqa: S110 - Docker may not be available
         pass
+
+    # Not discoverable live — rebuild from the registry entry if allowed. A
+    # malformed entry (unknown engine, unparseable ssh_host) must not escape as
+    # a traceback: honor the documented "returns None otherwise" contract.
+    if allow_offline and entry is not None:
+        try:
+            bt = BackendType(entry.engine)
+            return (
+                bt,
+                _get_backend_instance(
+                    bt, ssh_host=entry.ssh_host, ssh_key=entry.ssh_key
+                ),
+            )
+        except Exception:
+            return None
 
     return None
 

--- a/src/paude/cli/upgrade.py
+++ b/src/paude/cli/upgrade.py
@@ -13,7 +13,11 @@ from paude.cli.app import BackendType, app
 from paude.cli.helpers import find_session_backend
 
 if TYPE_CHECKING:
+    from paude.agents.base import AgentComposition
+    from paude.backends.base import Session
     from paude.backends.podman.backend import PodmanBackend
+    from paude.container.runner import ContainerRunner
+    from paude.upgrade_state import UpgradeManifest
 
 
 @dataclass
@@ -39,6 +43,20 @@ class UpgradeOverrides:
             or self.providers is not None
             or self.agent_providers is not None
         )
+
+
+def _finalize_upgrade(name: str, session: Session | None) -> None:
+    """Record a finished upgrade: refresh the registry entry, clear the marker.
+
+    Shared by the success path and the stale-marker fast-path so both stay in
+    sync. ``session`` is the live session used to refresh agent metadata (or
+    ``None`` when the container is already gone).
+    """
+    from paude import __version__, upgrade_state
+    from paude.registry import SessionRegistry
+
+    SessionRegistry().refresh_from_session(name, session, __version__)
+    upgrade_state.delete(name)
 
 
 @app.command("upgrade")
@@ -166,38 +184,71 @@ def session_upgrade(
         agent_providers=cli_agent_providers,
     )
 
-    # Find session backend
+    from paude import upgrade_state
+
+    # A leftover manifest means a previous upgrade was interrupted. Resume it,
+    # even if the container it was replacing is already gone.
+    manifest = upgrade_state.load(name)
+    resuming = manifest is not None
+
+    # Find session backend. When resuming, allow reconstruction from the
+    # registry entry even if the container was already removed by the
+    # interrupted run (so it can't be discovered live).
     if backend is not None:
         backend_obj = _get_backend_instance(backend)
     else:
-        result = find_session_backend(name)
+        result = find_session_backend(name, allow_offline=resuming)
         if result is None:
             typer.echo(f"Session '{name}' not found.", err=True)
             raise typer.Exit(1)
         backend, backend_obj = result
 
-    # Get session
+    # Get session — may be absent when resuming after the container was removed.
     session = backend_obj.get_session(name)
-    if session is None:
+    if session is None and not resuming:
         typer.echo(f"Session '{name}' not found.", err=True)
         raise typer.Exit(1)
 
+    session_version = session.version if session is not None else None
+
     has_overrides = overrides.has_changes()
 
-    if has_overrides and session.version == __version__:
+    # Stale marker: a prior upgrade finished (container running at the target
+    # version) but crashed before the manifest was cleared. Refresh the registry
+    # and drop the marker without a needless rebuild. Only `running` qualifies:
+    # any other status (e.g. a container created but never started, which podman
+    # reports as `stopped`) means the upgrade did not finish, so fall through and
+    # resume.
+    if (
+        resuming
+        and not has_overrides
+        and session is not None
+        and session.version == __version__
+        and session.status == "running"
+    ):
+        _finalize_upgrade(name, session)
+        typer.echo(
+            f"Session '{name}' is already at version {__version__}; "
+            "cleared stale upgrade marker.",
+        )
+        return
+
+    if resuming:
+        typer.echo(f"Resuming interrupted upgrade of '{name}'...", err=True)
+    elif has_overrides and session_version == __version__:
         typer.echo(
             f"Reconfiguring session '{name}' (version {__version__})...",
             err=True,
         )
     else:
-        old_version = session.version or "unknown"
+        old_version = session_version or "unknown"
         typer.echo(
             f"Upgrading session '{name}' from {old_version} to {__version__}...",
             err=True,
         )
 
     # Auto-stop if running
-    if session.status == "running":
+    if session is not None and session.status == "running":
         typer.echo(f"Stopping session '{name}'...", err=True)
         backend_obj.stop_session(name)
 
@@ -212,35 +263,58 @@ def session_upgrade(
         raise typer.Exit(1) from None
     except typer.Exit:
         raise
+    except KeyboardInterrupt:
+        typer.echo("", err=True)
+        typer.echo(
+            f"Upgrade of '{name}' interrupted before it finished. "
+            "Your workspace data is safe.",
+            err=True,
+        )
+        typer.echo(
+            f"Run 'paude upgrade {name}' again to finish the upgrade.",
+            err=True,
+        )
+        raise typer.Exit(130) from None
     except Exception as e:
         typer.echo(f"Error upgrading session: {e}", err=True)
+        typer.echo(
+            f"The upgrade did not finish. Your workspace data is safe. "
+            f"Run 'paude upgrade {name}' again to retry.",
+            err=True,
+        )
         raise typer.Exit(1) from None
 
-    # Update registry
-    from paude.registry import SessionRegistry
-
-    registry = SessionRegistry()
-    entries = registry.load()
-    if name in entries:
-        refreshed = backend_obj.get_session(name)
-        if refreshed is not None:
-            entries[name].agent = refreshed.agent
-            entries[name].agent_providers = refreshed.agent_providers
-            entries[name].credential_providers = refreshed.credential_providers
-        entries[name].paude_version = __version__
-        registry._save(entries)
-
+    # Update registry and clear the upgrade manifest (success path only).
+    # Re-probe: the container was rebuilt, so refresh from the new session.
+    _finalize_upgrade(name, backend_obj.get_session(name))
     typer.echo(f"Session '{name}' upgraded to version {__version__}.")
 
 
-def _upgrade_podman(
-    name: str,
-    backend: PodmanBackend,
-    rebuild: bool,
-    overrides: UpgradeOverrides,
-) -> None:
-    """Upgrade a Podman/Docker session in place."""
-    from paude.agents import get_agents
+@dataclass
+class _ResolvedUpgrade:
+    """Fully-resolved session configuration for a (re)build during upgrade.
+
+    Sourced either from the old container's labels (fresh upgrade) or from a
+    persisted :class:`~paude.cli.upgrade_state.UpgradeManifest` (resumed
+    upgrade), then normalised through :func:`_apply_overrides`.
+    """
+
+    agent_name: str
+    provider_name: str | None
+    composition: AgentComposition
+    credential_providers: list[str]
+    workspace: Path
+    gpu: str | None
+    yolo: bool
+    otel_endpoint: str | None
+    allowed_domains: list[str] | None
+    proxy_image_label: str | None
+
+
+def _resolve_base_from_labels(
+    runner: ContainerRunner, name: str, labels: dict[str, str]
+) -> _ResolvedUpgrade:
+    """Read the session's configuration from its container labels."""
     from paude.backends.labels import (
         PAUDE_LABEL_AGENT,
         PAUDE_LABEL_DOMAINS,
@@ -252,44 +326,17 @@ def _upgrade_podman(
         PAUDE_LABEL_YOLO,
     )
     from paude.backends.podman.helpers import (
-        container_name,
-        find_container_by_session_name,
         get_session_composition,
         get_session_credential_providers,
-        network_name,
-        proxy_container_name,
     )
     from paude.backends.session_env import decode_path
-    from paude.cli.helpers import (
-        _detect_dev_script_dir,
-        _prepare_session_create,
-    )
-    from paude.config.detector import detect_config
-    from paude.config.parser import parse_config
-    from paude.container import ImageManager
-    from paude.mounts import build_mounts
 
-    # Get container and extract labels
-    container = find_container_by_session_name(backend._runner, name)
-    if container is None:
-        typer.echo(f"Container for session '{name}' not found.", err=True)
-        raise typer.Exit(1)
-
-    labels = container.get("Labels", {}) or {}
-
-    agent_name = labels.get(PAUDE_LABEL_AGENT, "claude")
-    provider_name = labels.get(PAUDE_LABEL_PROVIDER)
-    composition = get_session_composition(backend._runner, name)
-    credential_providers = get_session_credential_providers(backend._runner, name)
     workspace_encoded = labels.get(PAUDE_LABEL_WORKSPACE, "")
     workspace = (
         decode_path(workspace_encoded, url_safe=True)
         if workspace_encoded
         else Path.cwd()
     )
-    gpu = labels.get(PAUDE_LABEL_GPU)
-    yolo = labels.get(PAUDE_LABEL_YOLO) == "1"
-    otel_endpoint = labels.get(PAUDE_LABEL_OTEL_ENDPOINT)
 
     # Domain config — old sessions may not have the label (no proxy).
     # On upgrade, all sessions get a proxy; default to None to trigger
@@ -299,54 +346,98 @@ def _upgrade_podman(
     if domains_str is not None:
         allowed_domains = domains_str.split(",") if domains_str else []
 
-    proxy_image_label = labels.get(PAUDE_LABEL_PROXY_IMAGE)
+    return _ResolvedUpgrade(
+        agent_name=labels.get(PAUDE_LABEL_AGENT, "claude"),
+        provider_name=labels.get(PAUDE_LABEL_PROVIDER),
+        composition=get_session_composition(runner, name),
+        credential_providers=get_session_credential_providers(runner, name),
+        workspace=workspace,
+        gpu=labels.get(PAUDE_LABEL_GPU),
+        yolo=labels.get(PAUDE_LABEL_YOLO) == "1",
+        otel_endpoint=labels.get(PAUDE_LABEL_OTEL_ENDPOINT),
+        allowed_domains=allowed_domains,
+        proxy_image_label=labels.get(PAUDE_LABEL_PROXY_IMAGE),
+    )
 
-    # Apply CLI overrides
+
+def _resolve_base_from_manifest(manifest: UpgradeManifest) -> _ResolvedUpgrade:
+    """Rebuild the session's configuration from a persisted upgrade manifest.
+
+    Used when resuming an interrupted upgrade whose original container (the
+    only other source of this config) has already been removed.
+    """
+    from paude.agents import get_agents
+
+    specs = manifest.agent_providers or [(manifest.agent, manifest.provider or "")]
+    composition = get_agents(
+        [agent for agent, _provider in specs],
+        providers={agent: provider for agent, provider in specs if provider},
+        include_bundled=False,
+    )
+    return _ResolvedUpgrade(
+        agent_name=manifest.agent,
+        provider_name=manifest.provider,
+        composition=composition,
+        credential_providers=list(manifest.credential_providers or []),
+        workspace=Path(manifest.workspace),
+        gpu=manifest.gpu,
+        yolo=manifest.yolo,
+        otel_endpoint=manifest.otel_endpoint,
+        allowed_domains=manifest.allowed_domains,
+        proxy_image_label=manifest.proxy_image,
+    )
+
+
+def _apply_overrides(state: _ResolvedUpgrade, overrides: UpgradeOverrides) -> None:
+    """Apply CLI overrides to a resolved config in place, normalising provider."""
+    from paude.agents import get_agents
+
     if overrides.provider is not None:
-        provider_name = overrides.provider
+        state.provider_name = overrides.provider
         specs = [
             (item.config.name, item.config.provider or "")
-            for item in composition.agents
+            for item in state.composition.agents
         ]
-        specs[0] = (specs[0][0], provider_name)
-        composition = get_agents(
+        specs[0] = (specs[0][0], state.provider_name)
+        state.composition = get_agents(
             [agent for agent, _provider in specs],
             providers={agent: provider for agent, provider in specs if provider},
             include_bundled=False,
         )
     elif overrides.agent_providers is not None:
-        installed = [item.config.name for item in composition.agents]
-        unknown = [name for name in overrides.agent_providers if name not in installed]
+        installed = [item.config.name for item in state.composition.agents]
+        unknown = [a for a in overrides.agent_providers if a not in installed]
         if unknown:
             raise ValueError(
                 "Provider mappings reference agents that are not installed: "
                 + ", ".join(unknown)
             )
-        composition = get_agents(
+        state.composition = get_agents(
             installed,
             providers=overrides.agent_providers,
             include_bundled=False,
         )
+
     mappings_changed = (
         overrides.provider is not None or overrides.agent_providers is not None
     )
     mapped_providers = list(
         dict.fromkeys(
             item.config.provider or ""
-            for item in composition.agents
+            for item in state.composition.agents
             if item.config.provider
         )
     )
     if overrides.providers is not None:
         from paude.providers import get_provider
 
-        credential_providers = list(dict.fromkeys(overrides.providers))
-        for provider in credential_providers:
+        state.credential_providers = list(dict.fromkeys(overrides.providers))
+        for provider in state.credential_providers:
             get_provider(provider)
         missing = [
             provider
             for provider in mapped_providers
-            if provider not in credential_providers
+            if provider not in state.credential_providers
         ]
         if missing:
             raise ValueError(
@@ -354,17 +445,105 @@ def _upgrade_podman(
                 + ", ".join(missing)
             )
     elif mappings_changed:
-        credential_providers = mapped_providers
-    provider_name = composition.primary.config.provider
+        state.credential_providers = mapped_providers
+
+    state.provider_name = state.composition.primary.config.provider
     if overrides.gpu is not None:
-        gpu = overrides.gpu if overrides.gpu != "" else None
+        state.gpu = overrides.gpu if overrides.gpu != "" else None
     if overrides.yolo is not None:
-        yolo = overrides.yolo
+        state.yolo = overrides.yolo
     if overrides.otel_endpoint is not None:
-        # Empty string means "remove OTEL"
-        otel_endpoint = overrides.otel_endpoint if overrides.otel_endpoint else None
+        # Empty string means "remove OTEL".
+        state.otel_endpoint = overrides.otel_endpoint or None
     if overrides.allowed_domains is not None:
-        allowed_domains = overrides.allowed_domains
+        state.allowed_domains = overrides.allowed_domains
+
+
+def _manifest_from_state(
+    name: str,
+    state: _ResolvedUpgrade,
+    to_version: str,
+    created_at: str,
+) -> UpgradeManifest:
+    """Capture a resolved config as a durable manifest for crash recovery."""
+    from paude.upgrade_state import UpgradeManifest
+
+    agent_specs = [
+        (item.config.name, item.config.provider or "")
+        for item in state.composition.agents
+    ]
+    return UpgradeManifest(
+        name=name,
+        to_version=to_version,
+        created_at=created_at,
+        workspace=str(state.workspace),
+        agent=state.agent_name,
+        provider=state.provider_name,
+        agent_providers=agent_specs,
+        credential_providers=list(state.credential_providers),
+        gpu=state.gpu,
+        yolo=state.yolo,
+        otel_endpoint=state.otel_endpoint,
+        allowed_domains=state.allowed_domains,
+        proxy_image=state.proxy_image_label,
+    )
+
+
+def _upgrade_podman(
+    name: str,
+    backend: PodmanBackend,
+    rebuild: bool,
+    overrides: UpgradeOverrides,
+) -> None:
+    """Upgrade a Podman/Docker session in place.
+
+    The whole flow is idempotent and resumable: the resolved configuration is
+    written to a durable manifest before anything is torn down, teardown uses
+    force/tolerant removals, and ``create_session(reuse_volume=True)`` rebuilds
+    from a clean slate while preserving the workspace volume. Re-running after
+    an interruption reads the manifest and converges to a single healthy
+    session.
+    """
+    from datetime import UTC, datetime
+
+    from paude import __version__, upgrade_state
+    from paude.backends.podman.helpers import (
+        container_name,
+        find_container_by_session_name,
+        network_name,
+        proxy_container_name,
+    )
+    from paude.cli.helpers import (
+        _detect_dev_script_dir,
+        _prepare_session_create,
+    )
+    from paude.config.detector import detect_config
+    from paude.config.parser import parse_config
+    from paude.container import ImageManager
+    from paude.mounts import build_mounts
+
+    # Resolve the session config from a manifest (resume) or labels (fresh).
+    manifest = upgrade_state.load(name)
+    if manifest is not None:
+        state = _resolve_base_from_manifest(manifest)
+        created_at = manifest.created_at
+    else:
+        container = find_container_by_session_name(backend._runner, name)
+        if container is None:
+            typer.echo(f"Container for session '{name}' not found.", err=True)
+            raise typer.Exit(1)
+        labels = container.get("Labels", {}) or {}
+        state = _resolve_base_from_labels(backend._runner, name, labels)
+        created_at = datetime.now(UTC).isoformat()
+
+    _apply_overrides(state, overrides)
+
+    # Persist the fully-resolved config BEFORE any destructive step, so an
+    # interrupt from here on can be finished by re-running the upgrade.
+    upgrade_state.save(_manifest_from_state(name, state, __version__, created_at))
+
+    composition = state.composition
+    workspace = state.workspace
 
     # Detect project config from workspace
     config = None
@@ -372,18 +551,21 @@ def _upgrade_podman(
     if config_file:
         config = parse_config(config_file)
 
-    # Build new image
     engine = backend._engine
     agent_instance = composition.primary
     agent_specs = [
         (item.config.name, item.config.provider or "") for item in composition.agents
     ]
 
-    # Salvage state written by older images before deleting their writable layer.
-    from paude.cli.upgrade_persistence import migrate_legacy_state
+    # Salvage state written by older images before deleting their writable
+    # layer. Skipped when resuming after the old container is already gone —
+    # its state was already copied into the workspace volume.
+    cname = container_name(name)
+    if backend._runner.container_exists(cname):
+        from paude.cli.upgrade_persistence import migrate_legacy_state
 
-    typer.echo("Migrating persistent agent state...", err=True)
-    migrate_legacy_state(backend._runner, container_name(name), composition)
+        typer.echo("Migrating persistent agent state...", err=True)
+        migrate_legacy_state(backend._runner, cname, composition)
 
     image_manager = ImageManager(
         script_dir=_detect_dev_script_dir(),
@@ -392,6 +574,11 @@ def _upgrade_podman(
         engine=engine,
     )
 
+    # A build failure here is transient and non-destructive: nothing has been
+    # torn down yet and the manifest is already saved. Raise a plain exception
+    # (not typer.Exit) so session_upgrade's generic handler reports it, tells
+    # the user their data is safe, and points them at re-running to retry — the
+    # bare `except typer.Exit: raise` path would swallow that guidance.
     try:
         if config is not None and config.has_customizations:
             image = image_manager.ensure_custom_image(
@@ -400,19 +587,18 @@ def _upgrade_podman(
         else:
             image = image_manager.ensure_default_image(force_rebuild=True)
     except Exception as e:
-        typer.echo(f"Error building image: {e}", err=True)
-        raise typer.Exit(1) from None
+        raise RuntimeError(f"building the agent image failed: {e}") from e
 
     # Build proxy image (always required — all sessions use proxy)
     proxy_image: str | None = None
     try:
         proxy_image = image_manager.ensure_proxy_image(force_rebuild=True)
     except Exception as e:
-        typer.echo(f"Error building proxy image: {e}", err=True)
-        raise typer.Exit(1) from None
+        raise RuntimeError(f"building the proxy image failed: {e}") from e
 
-    # Remove old container and proxy resources (but NOT the volume)
-    cname = container_name(name)
+    # Remove old container and proxy resources (but NOT the workspace volume).
+    # All removals are force/tolerant, so re-running after a partial teardown
+    # is safe.
     typer.echo(f"Removing old container {cname}...", err=True)
     backend._runner.remove_container(cname, force=True)
 
@@ -434,24 +620,24 @@ def _upgrade_podman(
     # allowed_domains=None (old sessions without proxy) is passed as-is to
     # _prepare_session_create, which defaults to ["default"].
     expanded_domains, parsed_args, env, unrestricted = _prepare_session_create(
-        allowed_domains,
-        yolo,
+        state.allowed_domains,
+        state.yolo,
         None,
         config,
-        agent_name=agent_name,
-        provider_name=provider_name,
-        otel_endpoint=otel_endpoint,
+        agent_name=state.agent_name,
+        provider_name=state.provider_name,
+        otel_endpoint=state.otel_endpoint,
         composition=composition,
-        credential_providers=credential_providers,
+        credential_providers=state.credential_providers,
     )
     session_domains = expanded_domains
 
     # Compute OTEL proxy ports
     otel_ports: list[int] = []
-    if otel_endpoint:
+    if state.otel_endpoint:
         from paude.otel import otel_proxy_ports
 
-        otel_ports = otel_proxy_ports(otel_endpoint)
+        otel_ports = otel_proxy_ports(state.otel_endpoint)
 
     # Create new session config with reuse_volume=True
     from paude.backends import SessionConfig
@@ -463,17 +649,17 @@ def _upgrade_podman(
         env=env,
         mounts=mounts,
         allowed_domains=session_domains,
-        yolo=yolo,
-        proxy_image=proxy_image or proxy_image_label,
-        agent=agent_name,
-        provider=provider_name,
+        yolo=state.yolo,
+        proxy_image=proxy_image or state.proxy_image_label,
+        agent=state.agent_name,
+        provider=state.provider_name,
         agent_providers=agent_specs,
-        credential_providers=credential_providers,
-        gpu=gpu,
+        credential_providers=state.credential_providers,
+        gpu=state.gpu,
         reuse_volume=True,
         ports=composition.exposed_ports,
         otel_ports=otel_ports,
-        otel_endpoint=otel_endpoint,
+        otel_endpoint=state.otel_endpoint,
     )
 
     backend.create_session(session_config)

--- a/src/paude/json_store.py
+++ b/src/paude/json_store.py
@@ -1,0 +1,42 @@
+"""Small shared helpers for durable JSON files under the paude config dir.
+
+Both the session registry (:mod:`paude.registry`) and the upgrade manifest
+store (:mod:`paude.upgrade_state`) persist a single JSON document atomically.
+This module holds the one copy of that durability-critical machinery.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def atomic_write_json(path: Path, data: Any) -> None:
+    """Write ``data`` as JSON to ``path`` atomically (tempfile + os.replace)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    """Return the parsed JSON object at ``path``, or ``{}`` if missing/corrupt."""
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError, TypeError):
+        # OSError covers a missing file (FileNotFoundError) as well as an
+        # unreadable one (PermissionError) or a path replaced by a directory
+        # (IsADirectoryError) — all treated as "no usable data" per contract.
+        return {}
+    return data if isinstance(data, dict) else {}

--- a/src/paude/registry.py
+++ b/src/paude/registry.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
-import tempfile
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -13,6 +11,7 @@ from typing import Any
 
 from paude.backends.base import Session
 from paude.config.user_config import _paude_config_dir
+from paude.json_store import atomic_write_json
 
 logger = logging.getLogger(__name__)
 
@@ -100,18 +99,7 @@ class SessionRegistry:
 
     def _write_raw(self, data: dict[str, Any]) -> None:
         """Write raw JSON data to the registry file atomically."""
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(dir=self._path.parent, suffix=".tmp")
-        try:
-            with os.fdopen(fd, "w") as f:
-                json.dump(data, f, indent=2)
-            os.replace(tmp, self._path)
-        except Exception:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
-            raise
+        atomic_write_json(self._path, data)
 
     def _save(self, entries: dict[str, RegistryEntry]) -> None:
         """Write entries to the registry file atomically."""
@@ -150,6 +138,30 @@ class SessionRegistry:
         )
         self._save(entries)
 
+    def refresh_from_session(
+        self, name: str, session: Session | None, paude_version: str
+    ) -> None:
+        """Update a registered session's live fields and version in place.
+
+        Unlike :meth:`register`, this preserves entry fields that ``Session``
+        does not carry (``ssh_host``, ``ssh_key``, ``remote_config_dir``,
+        ``engine``, ``created_at``). Does nothing if ``name`` is not registered.
+
+        Used to record an in-place upgrade: ``session`` is the live session whose
+        agent metadata should overwrite the entry's, or ``None`` when the
+        container could not be probed (only the version is updated then).
+        """
+        entries = self.load()
+        entry = entries.get(name)
+        if entry is None:
+            return
+        if session is not None:
+            entry.agent = session.agent
+            entry.agent_providers = session.agent_providers
+            entry.credential_providers = session.credential_providers
+        entry.paude_version = paude_version
+        self._save(entries)
+
     def unregister(self, name: str) -> bool:
         """Remove a session from the registry by name.
 
@@ -158,6 +170,12 @@ class SessionRegistry:
 
         Returns True if an entry was removed, False if not found.
         """
+        # A session's upgrade manifest is local-host state that shadows its
+        # registry entry; remove it whenever the entry is removed so a stale
+        # manifest can't outlive its session and trigger a bogus resume.
+        from paude import upgrade_state
+
+        upgrade_state.delete(name)
         try:
             data = json.loads(self._path.read_text())
         except (FileNotFoundError, json.JSONDecodeError):

--- a/src/paude/upgrade_state.py
+++ b/src/paude/upgrade_state.py
@@ -1,0 +1,98 @@
+"""Durable manifest for crash-safe (resumable) session upgrades.
+
+``paude upgrade`` tears down a session's container before recreating it, and
+that container's labels are the only place the session's configuration lives.
+If the upgrade is interrupted (e.g. ``CTRL+C``) after the container is removed
+but before the replacement exists, the configuration is gone and the upgrade
+cannot be retried.
+
+To avoid that, upgrade writes the fully-resolved configuration here *before*
+any teardown and deletes it only once the upgrade succeeds. A leftover manifest
+means an upgrade was interrupted; re-running ``paude upgrade <name>`` reads the
+manifest and finishes the job.
+
+The manifest lives on the *local* host (alongside the session registry) even
+for remote/SSH sessions, so recovery works even if the connection drops.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from paude.config.user_config import _paude_config_dir
+from paude.json_store import atomic_write_json, read_json
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class UpgradeManifest:
+    """Everything needed to recreate a session without its container labels.
+
+    Mirrors the configuration derived from container labels in
+    :func:`paude.cli.upgrade._upgrade_podman` so a resumed upgrade can rebuild
+    the session even after the original container (and its labels) are gone.
+    """
+
+    name: str
+    to_version: str
+    created_at: str
+    workspace: str
+    agent: str = "claude"
+    provider: str | None = None
+    agent_providers: list[tuple[str, str]] = field(default_factory=list)
+    credential_providers: list[str] = field(default_factory=list)
+    gpu: str | None = None
+    yolo: bool = False
+    otel_endpoint: str | None = None
+    allowed_domains: list[str] | None = None
+    proxy_image: str | None = None
+
+
+def _manifests_path() -> Path:
+    """Return the path to the upgrade manifests file."""
+    return _paude_config_dir() / "upgrades.json"
+
+
+def _load_all(path: Path) -> dict[str, dict[str, Any]]:
+    """Load all manifests, returning an empty dict when missing or corrupt."""
+    manifests = read_json(path).get("upgrades", {})
+    return manifests if isinstance(manifests, dict) else {}
+
+
+def save(manifest: UpgradeManifest, path: Path | None = None) -> None:
+    """Persist (or overwrite) the upgrade manifest for a session atomically."""
+    target = path or _manifests_path()
+    manifests = _load_all(target)
+    manifests[manifest.name] = asdict(manifest)
+    atomic_write_json(target, {"upgrades": manifests})
+
+
+def load(name: str, path: Path | None = None) -> UpgradeManifest | None:
+    """Return the in-progress upgrade manifest for a session, or None."""
+    target = path or _manifests_path()
+    raw = _load_all(target).get(name)
+    if raw is None:
+        return None
+    try:
+        entry = dict(raw)
+        # JSON stores tuples as lists; normalise agent_providers back to tuples.
+        entry["agent_providers"] = [
+            tuple(item) for item in (entry.get("agent_providers") or [])
+        ]
+        return UpgradeManifest(**entry)
+    except (TypeError, ValueError):
+        logger.warning("Ignoring corrupt upgrade manifest for '%s'", name)
+        return None
+
+
+def delete(name: str, path: Path | None = None) -> None:
+    """Remove a session's upgrade manifest if present (no error if absent)."""
+    target = path or _manifests_path()
+    manifests = _load_all(target)
+    if name in manifests:
+        del manifests[name]
+        atomic_write_json(target, {"upgrades": manifests})

--- a/tests/test_json_store.py
+++ b/tests/test_json_store.py
@@ -1,0 +1,53 @@
+"""Tests for the durable JSON store helpers (paude.json_store)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from paude.json_store import atomic_write_json, read_json
+
+
+def test_read_json_round_trip(tmp_path: Path) -> None:
+    path = tmp_path / "data.json"
+    atomic_write_json(path, {"a": 1})
+    assert read_json(path) == {"a": 1}
+
+
+def test_read_json_missing_returns_empty(tmp_path: Path) -> None:
+    assert read_json(tmp_path / "nope.json") == {}
+
+
+def test_read_json_corrupt_returns_empty(tmp_path: Path) -> None:
+    path = tmp_path / "data.json"
+    path.write_text("{ not valid json")
+    assert read_json(path) == {}
+
+
+def test_read_json_non_object_returns_empty(tmp_path: Path) -> None:
+    path = tmp_path / "data.json"
+    path.write_text(json.dumps([1, 2, 3]))
+    assert read_json(path) == {}
+
+
+def test_read_json_directory_returns_empty(tmp_path: Path) -> None:
+    """A path replaced by a directory (IsADirectoryError) degrades to {}."""
+    path = tmp_path / "adir"
+    path.mkdir()
+    assert read_json(path) == {}
+
+
+def test_read_json_unreadable_returns_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreadable file (PermissionError) degrades to {} rather than raising."""
+    path = tmp_path / "data.json"
+    path.write_text("{}")
+
+    def _boom(*_args: object, **_kwargs: object) -> str:
+        raise PermissionError("nope")
+
+    monkeypatch.setattr(Path, "read_text", _boom)
+    assert read_json(path) == {}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -87,6 +87,57 @@ class TestSessionRegistry:
         assert entry is not None
         assert entry.remote_config_dir is None
 
+    def test_refresh_from_session_updates_version_preserving_ssh(
+        self, tmp_path: Path
+    ) -> None:
+        """refresh_from_session updates version + agent metadata but preserves
+        fields Session doesn't carry (the reason it's not just register())."""
+        path = tmp_path / "sessions.json"
+        registry = SessionRegistry(path=path)
+        registry.register(
+            _make_session("s1", agent="claude"),
+            ssh_host="host",
+            ssh_key="/key",
+            remote_config_dir="/cfg",
+            paude_version="0.1.0",
+        )
+
+        registry.refresh_from_session(
+            "s1", _make_session("s1", agent="gemini"), "0.2.0"
+        )
+
+        entry = registry.get("s1")
+        assert entry is not None
+        assert entry.paude_version == "0.2.0"
+        assert entry.agent == "gemini"
+        assert entry.ssh_host == "host"
+        assert entry.ssh_key == "/key"
+        assert entry.remote_config_dir == "/cfg"
+
+    def test_refresh_from_session_none_updates_version_only(
+        self, tmp_path: Path
+    ) -> None:
+        """With session=None (container gone), only the version is updated."""
+        path = tmp_path / "sessions.json"
+        registry = SessionRegistry(path=path)
+        registry.register(_make_session("s1", agent="claude"), paude_version="0.1.0")
+
+        registry.refresh_from_session("s1", None, "0.2.0")
+
+        entry = registry.get("s1")
+        assert entry is not None
+        assert entry.paude_version == "0.2.0"
+        assert entry.agent == "claude"
+
+    def test_refresh_from_session_missing_is_noop(self, tmp_path: Path) -> None:
+        """Refreshing an unregistered session neither errors nor creates an entry."""
+        path = tmp_path / "sessions.json"
+        registry = SessionRegistry(path=path)
+
+        registry.refresh_from_session("nope", _make_session("nope"), "0.2.0")
+
+        assert registry.get("nope") is None
+
     def test_unregister(self, tmp_path: Path) -> None:
         path = tmp_path / "sessions.json"
         registry = SessionRegistry(path=path)

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 from typer.testing import CliRunner
 
 from paude.backends.base import Session
@@ -406,6 +407,573 @@ class TestUpgradePodman:
         backend._network_manager.remove_network.assert_called_once_with(
             "paude-net-test-session"
         )
+
+    @patch("paude.mounts.build_mounts", return_value=[])
+    @patch("paude.cli.helpers._prepare_session_create")
+    @patch("paude.container.ImageManager")
+    @patch("paude.config.detector.detect_config", return_value=None)
+    @patch("paude.backends.podman.helpers.find_container_by_session_name")
+    def test_upgrade_podman_build_failure_is_retryable(
+        self,
+        mock_find_container: MagicMock,
+        mock_detect_config: MagicMock,
+        mock_image_manager_class: MagicMock,
+        mock_prepare: MagicMock,
+        mock_build_mounts: MagicMock,
+    ) -> None:
+        """A failed image build raises a plain exception (not typer.Exit), so the
+        caller reports it as retryable; the manifest survives and nothing is torn
+        down."""
+        from paude import upgrade_state
+        from paude.cli.upgrade import _upgrade_podman
+
+        mock_find_container.return_value = {"Labels": self._make_container_labels()}
+
+        mock_image_manager = MagicMock()
+        mock_image_manager.ensure_default_image.side_effect = RuntimeError("boom")
+        mock_image_manager_class.return_value = mock_image_manager
+
+        mock_prepare.return_value = ([], [], {}, True)
+
+        from paude.backends.podman.backend import PodmanBackend
+
+        backend = MagicMock(spec=PodmanBackend)
+        backend._runner = MagicMock()
+        backend._runner.container_exists.return_value = False
+        backend._network_manager = MagicMock()
+        backend._volume_manager = MagicMock()
+        backend._engine = MagicMock()
+
+        # A plain error (typer.Exit is not a RuntimeError), so this asserts the
+        # failure is routed to session_upgrade's "data is safe / retry" handler.
+        with pytest.raises(RuntimeError):
+            _upgrade_podman(
+                "test-session", backend, rebuild=False, overrides=_NO_OVERRIDES
+            )
+
+        # The manifest (written before the build) survives, so a re-run resumes.
+        assert upgrade_state.load("test-session") is not None
+        backend.create_session.assert_not_called()
+
+
+class TestUpgradeResume:
+    """Tests for crash-safe, resumable upgrade behaviour."""
+
+    def _labels(
+        self,
+        agent: str = "claude",
+        gpu: str | None = None,
+        yolo: bool = False,
+    ) -> dict[str, str]:
+        labels: dict[str, str] = {
+            PAUDE_LABEL_AGENT: agent,
+            PAUDE_LABEL_WORKSPACE: encode_path(
+                Path("/home/user/project"), url_safe=True
+            ),
+            PAUDE_LABEL_SESSION: "test-session",
+            PAUDE_LABEL_CREATED: "2026-01-01T00:00:00+00:00",
+        }
+        if gpu is not None:
+            labels[PAUDE_LABEL_GPU] = gpu
+        if yolo:
+            labels[PAUDE_LABEL_YOLO] = "1"
+        return labels
+
+    @patch("paude.mounts.build_mounts", return_value=[])
+    @patch("paude.cli.helpers._prepare_session_create")
+    @patch("paude.container.ImageManager")
+    @patch("paude.config.detector.detect_config", return_value=None)
+    @patch("paude.backends.podman.helpers.find_container_by_session_name")
+    def test_manifest_written_before_teardown(
+        self,
+        mock_find_container: MagicMock,
+        mock_detect_config: MagicMock,
+        mock_image_manager_class: MagicMock,
+        mock_prepare: MagicMock,
+        mock_build_mounts: MagicMock,
+    ) -> None:
+        """A manifest is persisted before any destructive step, so an interrupt
+        during teardown leaves a recoverable session."""
+        from paude import upgrade_state
+        from paude.cli.upgrade import _upgrade_podman
+
+        mock_find_container.return_value = {
+            "Labels": self._labels(gpu="all", yolo=True)
+        }
+
+        mock_image_manager = MagicMock()
+        mock_image_manager.ensure_default_image.return_value = "paude:latest"
+        mock_image_manager.ensure_proxy_image.return_value = "proxy:rebuilt"
+        mock_image_manager_class.return_value = mock_image_manager
+        mock_prepare.return_value = ([], [], {}, True)
+
+        from paude.backends.podman.backend import PodmanBackend
+
+        backend = MagicMock(spec=PodmanBackend)
+        backend._runner = MagicMock()
+        backend._runner.container_exists.return_value = False
+        # Interrupt exactly at the first destructive removal.
+        backend._runner.remove_container.side_effect = KeyboardInterrupt
+        backend._network_manager = MagicMock()
+        backend._volume_manager = MagicMock()
+        backend._engine = MagicMock()
+
+        with pytest.raises(KeyboardInterrupt):
+            _upgrade_podman(
+                "test-session", backend, rebuild=False, overrides=_NO_OVERRIDES
+            )
+
+        # Config was captured durably before teardown was attempted.
+        manifest = upgrade_state.load("test-session")
+        assert manifest is not None
+        assert manifest.agent == "claude"
+        assert manifest.gpu == "all"
+        assert manifest.yolo is True
+        # The replacement was never created (we were interrupted first).
+        backend.create_session.assert_not_called()
+
+    @patch("paude.mounts.build_mounts", return_value=[])
+    @patch("paude.cli.helpers._prepare_session_create")
+    @patch("paude.container.ImageManager")
+    @patch("paude.config.detector.detect_config", return_value=None)
+    @patch("paude.backends.podman.helpers.find_container_by_session_name")
+    def test_resume_uses_manifest_when_container_gone(
+        self,
+        mock_find_container: MagicMock,
+        mock_detect_config: MagicMock,
+        mock_image_manager_class: MagicMock,
+        mock_prepare: MagicMock,
+        mock_build_mounts: MagicMock,
+    ) -> None:
+        """With a manifest present and the old container gone, config is rebuilt
+        from the manifest (not container labels) and the volume is reused."""
+        from paude import upgrade_state
+        from paude.cli.upgrade import _upgrade_podman
+        from paude.upgrade_state import UpgradeManifest
+
+        upgrade_state.save(
+            UpgradeManifest(
+                name="test-session",
+                to_version="0.20.0",
+                created_at="2026-01-01T00:00:00+00:00",
+                workspace="/home/user/project",
+                agent="gemini",
+                gpu="all",
+                yolo=True,
+                allowed_domains=[".googleapis.com"],
+            )
+        )
+        mock_find_container.return_value = None  # container already removed
+
+        mock_image_manager = MagicMock()
+        mock_image_manager.ensure_default_image.return_value = "paude:latest"
+        mock_image_manager.ensure_proxy_image.return_value = "proxy:rebuilt"
+        mock_image_manager_class.return_value = mock_image_manager
+        mock_prepare.return_value = ([".googleapis.com"], [], {}, False)
+
+        from paude.backends.podman.backend import PodmanBackend
+
+        backend = MagicMock(spec=PodmanBackend)
+        backend._runner = MagicMock()
+        backend._runner.container_exists.return_value = False
+        backend._network_manager = MagicMock()
+        backend._volume_manager = MagicMock()
+        backend._engine = MagicMock()
+
+        _upgrade_podman("test-session", backend, rebuild=False, overrides=_NO_OVERRIDES)
+
+        config = backend.create_session.call_args[0][0]
+        assert config.agent == "gemini"
+        assert config.gpu == "all"
+        assert config.yolo is True
+        assert config.reuse_volume is True
+        # Config came from the manifest, never from the (gone) container labels.
+        mock_find_container.assert_not_called()
+        backend.start_session_no_attach.assert_called_once_with("test-session")
+
+    @patch("paude.cli.upgrade._upgrade_podman")
+    @patch("paude.cli.upgrade.find_session_backend")
+    def test_success_deletes_manifest(
+        self, mock_find: MagicMock, mock_upgrade_podman: MagicMock
+    ) -> None:
+        """A completed upgrade clears the manifest."""
+        from paude import upgrade_state
+        from paude.backends.podman.backend import PodmanBackend
+        from paude.upgrade_state import UpgradeManifest
+
+        upgrade_state.save(
+            UpgradeManifest(
+                name="test-session",
+                to_version="0.20.0",
+                created_at="t",
+                workspace="/w",
+            )
+        )
+        mock_backend = MagicMock()
+        mock_backend.__class__ = PodmanBackend
+        mock_backend.get_session.return_value = _make_session(
+            "test-session", version="0.1.0"
+        )
+        mock_find.return_value = ("podman", mock_backend)
+
+        result = runner.invoke(app, ["upgrade", "test-session"])
+
+        assert result.exit_code == 0
+        mock_upgrade_podman.assert_called_once()
+        assert upgrade_state.load("test-session") is None
+
+    @patch("paude.cli.upgrade._upgrade_podman")
+    @patch("paude.cli.upgrade.find_session_backend")
+    def test_stale_marker_cleared_when_already_current(
+        self, mock_find: MagicMock, mock_upgrade_podman: MagicMock
+    ) -> None:
+        """A leftover manifest for an already-current session is just cleared."""
+        from paude import __version__, upgrade_state
+        from paude.backends.podman.backend import PodmanBackend
+        from paude.upgrade_state import UpgradeManifest
+
+        upgrade_state.save(
+            UpgradeManifest(
+                name="test-session",
+                to_version=__version__,
+                created_at="t",
+                workspace="/w",
+            )
+        )
+        mock_backend = MagicMock()
+        mock_backend.__class__ = PodmanBackend
+        mock_backend.get_session.return_value = _make_session(
+            "test-session", status="running", version=__version__
+        )
+        mock_find.return_value = ("podman", mock_backend)
+
+        result = runner.invoke(app, ["upgrade", "test-session"])
+
+        assert result.exit_code == 0
+        mock_upgrade_podman.assert_not_called()
+        assert upgrade_state.load("test-session") is None
+        output = result.stdout + (result.stderr or "")
+        assert "already at version" in output
+
+    @patch("paude.cli.upgrade._upgrade_podman")
+    @patch("paude.cli.upgrade.find_session_backend")
+    def test_interrupted_between_create_and_start_resumes(
+        self, mock_find: MagicMock, mock_upgrade_podman: MagicMock
+    ) -> None:
+        """A manifest plus a target-version container left in 'stopped' state
+        (created but never started) must resume, not silently clear the marker.
+
+        _upgrade_podman creates the container before starting it; a
+        created-but-not-started container reports podman state 'created', which
+        maps to session status 'stopped'. The fast-path must not treat that as a
+        finished upgrade.
+        """
+        from paude import __version__, upgrade_state
+        from paude.backends.podman.backend import PodmanBackend
+        from paude.upgrade_state import UpgradeManifest
+
+        upgrade_state.save(
+            UpgradeManifest(
+                name="test-session",
+                to_version=__version__,
+                created_at="t",
+                workspace="/w",
+            )
+        )
+        mock_backend = MagicMock()
+        mock_backend.__class__ = PodmanBackend
+        mock_backend.get_session.return_value = _make_session(
+            "test-session", status="stopped", version=__version__
+        )
+        mock_find.return_value = ("podman", mock_backend)
+
+        result = runner.invoke(app, ["upgrade", "test-session"])
+
+        assert result.exit_code == 0
+        # The fast-path must NOT fire: the upgrade must actually resume.
+        mock_upgrade_podman.assert_called_once()
+        assert upgrade_state.load("test-session") is None
+        output = result.stdout + (result.stderr or "")
+        assert "cleared stale upgrade marker" not in output
+
+    @patch("paude.cli.upgrade._upgrade_podman")
+    @patch("paude.cli.upgrade.find_session_backend")
+    def test_stale_marker_degraded_resumes(
+        self, mock_find: MagicMock, mock_upgrade_podman: MagicMock
+    ) -> None:
+        """A degraded session (running container, missing proxy) with a lingering
+        manifest means the upgrade did not finish, so it must resume."""
+        from paude import __version__, upgrade_state
+        from paude.backends.podman.backend import PodmanBackend
+        from paude.upgrade_state import UpgradeManifest
+
+        upgrade_state.save(
+            UpgradeManifest(
+                name="test-session",
+                to_version=__version__,
+                created_at="t",
+                workspace="/w",
+            )
+        )
+        mock_backend = MagicMock()
+        mock_backend.__class__ = PodmanBackend
+        mock_backend.get_session.return_value = _make_session(
+            "test-session", status="degraded", version=__version__
+        )
+        mock_find.return_value = ("podman", mock_backend)
+
+        result = runner.invoke(app, ["upgrade", "test-session"])
+
+        assert result.exit_code == 0
+        mock_upgrade_podman.assert_called_once()
+        assert upgrade_state.load("test-session") is None
+
+    @patch("paude.cli.upgrade._upgrade_podman")
+    @patch("paude.cli.upgrade.find_session_backend")
+    def test_stale_marker_refreshes_registry_version(
+        self, mock_find: MagicMock, mock_upgrade_podman: MagicMock
+    ) -> None:
+        """The running fast-path refreshes the registry paude_version before
+        clearing the marker, so a crash between _upgrade_podman finishing and the
+        registry update doesn't leave the recorded version stale."""
+        from paude import __version__, upgrade_state
+        from paude.backends.base import Session
+        from paude.backends.podman.backend import PodmanBackend
+        from paude.upgrade_state import UpgradeManifest
+
+        SessionRegistry().register(
+            Session(
+                name="test-session",
+                status="running",
+                workspace=Path("/w"),
+                created_at="t",
+                backend_type="podman",
+            ),
+            paude_version="0.1.0",
+        )
+        upgrade_state.save(
+            UpgradeManifest(
+                name="test-session",
+                to_version=__version__,
+                created_at="t",
+                workspace="/w",
+            )
+        )
+        mock_backend = MagicMock()
+        mock_backend.__class__ = PodmanBackend
+        mock_backend.get_session.return_value = _make_session(
+            "test-session", status="running", version=__version__
+        )
+        mock_find.return_value = ("podman", mock_backend)
+
+        result = runner.invoke(app, ["upgrade", "test-session"])
+
+        assert result.exit_code == 0
+        # Fast-path fired (no rebuild) ...
+        mock_upgrade_podman.assert_not_called()
+        # ... but the registry version was refreshed and the marker cleared.
+        entry = SessionRegistry().get("test-session")
+        assert entry is not None
+        assert entry.paude_version == __version__
+        assert upgrade_state.load("test-session") is None
+
+    @patch("paude.cli.helpers._get_backend_instance")
+    @patch("paude.cli.helpers.PodmanBackend")
+    def test_find_session_backend_offline_reconstructs(
+        self, mock_podman_cls: MagicMock, mock_get_backend: MagicMock
+    ) -> None:
+        """find_session_backend(allow_offline=True) rebuilds from the registry
+        when the session can't be discovered live."""
+        from paude.backends.base import Session
+        from paude.cli.helpers import find_session_backend
+        from paude.registry import SessionRegistry
+
+        SessionRegistry().register(
+            Session(
+                name="gone-session",
+                status="stopped",
+                workspace=Path("/w"),
+                created_at="t",
+                backend_type="podman",
+            )
+        )
+        # Live probes find nothing (container gone).
+        mock_podman_cls.return_value.get_session.return_value = None
+        sentinel = object()
+        mock_get_backend.return_value = sentinel
+
+        # Without allow_offline the session is simply not found.
+        assert find_session_backend("gone-session") is None
+
+        # With allow_offline it is reconstructed from the registry entry.
+        result = find_session_backend("gone-session", allow_offline=True)
+        assert result is not None
+        backend_type, backend = result
+        assert backend is sentinel
+        mock_get_backend.assert_called_with(backend_type, ssh_host=None, ssh_key=None)
+
+    @patch("paude.cli.helpers._get_backend_instance")
+    @patch("paude.cli.helpers.PodmanBackend")
+    def test_find_session_backend_offline_returns_none_on_bad_entry(
+        self, mock_podman_cls: MagicMock, mock_get_backend: MagicMock
+    ) -> None:
+        """A malformed registry entry must not escape as a traceback: the
+        offline reconstruction honors the documented 'returns None' contract."""
+        from paude.backends.base import Session
+        from paude.cli.helpers import find_session_backend
+        from paude.registry import SessionRegistry
+
+        SessionRegistry().register(
+            Session(
+                name="broken-session",
+                status="stopped",
+                workspace=Path("/w"),
+                created_at="t",
+                backend_type="podman",
+            )
+        )
+        # Live probes find nothing (container gone).
+        mock_podman_cls.return_value.get_session.return_value = None
+        # Reconstruction blows up (e.g. parse_ssh_host on a malformed host).
+        mock_get_backend.side_effect = ValueError("bad ssh host")
+
+        assert find_session_backend("broken-session", allow_offline=True) is None
+
+    @patch("paude.cli.upgrade._upgrade_podman")
+    @patch("paude.cli.upgrade.find_session_backend")
+    def test_resume_allows_offline_backend_lookup(
+        self, mock_find: MagicMock, mock_upgrade_podman: MagicMock
+    ) -> None:
+        """A resume passes allow_offline=True and completes even when the
+        container is gone (get_session returns None)."""
+        from paude import upgrade_state
+        from paude.backends.podman.backend import PodmanBackend
+        from paude.upgrade_state import UpgradeManifest
+
+        upgrade_state.save(
+            UpgradeManifest(
+                name="test-session",
+                to_version="0.20.0",
+                created_at="t",
+                workspace="/w",
+            )
+        )
+        mock_backend = MagicMock()
+        mock_backend.__class__ = PodmanBackend
+        mock_backend.get_session.return_value = None  # container gone
+        mock_find.return_value = ("podman", mock_backend)
+
+        result = runner.invoke(app, ["upgrade", "test-session"])
+
+        assert result.exit_code == 0
+        assert mock_find.call_args.kwargs.get("allow_offline") is True
+        mock_upgrade_podman.assert_called_once()
+        assert upgrade_state.load("test-session") is None
+
+    @patch("paude.cli.upgrade._upgrade_podman")
+    @patch("paude.cli.upgrade.find_session_backend")
+    def test_interrupt_preserves_manifest_and_reports(
+        self, mock_find: MagicMock, mock_upgrade_podman: MagicMock
+    ) -> None:
+        """An interrupted upgrade keeps the manifest and tells the user how to
+        finish it."""
+        from paude import upgrade_state
+        from paude.backends.podman.backend import PodmanBackend
+        from paude.upgrade_state import UpgradeManifest
+
+        upgrade_state.save(
+            UpgradeManifest(
+                name="test-session",
+                to_version="0.20.0",
+                created_at="t",
+                workspace="/w",
+            )
+        )
+        mock_upgrade_podman.side_effect = KeyboardInterrupt
+
+        mock_backend = MagicMock()
+        mock_backend.__class__ = PodmanBackend
+        mock_backend.get_session.return_value = _make_session(
+            "test-session", version="0.1.0"
+        )
+        mock_find.return_value = ("podman", mock_backend)
+
+        result = runner.invoke(app, ["upgrade", "test-session"])
+
+        assert result.exit_code == 130
+        assert upgrade_state.load("test-session") is not None
+        output = result.stdout + (result.stderr or "")
+        assert "interrupted" in output.lower()
+        assert "paude upgrade test-session" in output
+
+    @patch("paude.cli.upgrade._upgrade_podman")
+    @patch("paude.cli.upgrade.find_session_backend")
+    def test_build_failure_reports_retry_and_keeps_manifest(
+        self, mock_find: MagicMock, mock_upgrade_podman: MagicMock
+    ) -> None:
+        """A failed upgrade (e.g. image build error) tells the user their data is
+        safe and how to retry, and keeps the manifest so the resume can finish."""
+        from paude import upgrade_state
+        from paude.backends.podman.backend import PodmanBackend
+        from paude.upgrade_state import UpgradeManifest
+
+        upgrade_state.save(
+            UpgradeManifest(
+                name="test-session",
+                to_version="0.20.0",
+                created_at="t",
+                workspace="/w",
+            )
+        )
+        mock_upgrade_podman.side_effect = RuntimeError(
+            "building the agent image failed: boom"
+        )
+
+        mock_backend = MagicMock()
+        mock_backend.__class__ = PodmanBackend
+        mock_backend.get_session.return_value = _make_session(
+            "test-session", version="0.1.0"
+        )
+        mock_find.return_value = ("podman", mock_backend)
+
+        result = runner.invoke(app, ["upgrade", "test-session"])
+
+        assert result.exit_code == 1
+        # Manifest is preserved (cleared only on success), so a re-run resumes.
+        assert upgrade_state.load("test-session") is not None
+        output = result.stdout + (result.stderr or "")
+        assert "safe" in output.lower()
+        assert "retry" in output.lower()
+        assert "paude upgrade test-session" in output
+
+    def test_unregister_clears_manifest(self) -> None:
+        """Deleting a session (via registry.unregister) removes its manifest,
+        so a stale marker can't outlive the session."""
+        from paude import upgrade_state
+        from paude.backends.base import Session
+        from paude.registry import SessionRegistry
+        from paude.upgrade_state import UpgradeManifest
+
+        registry = SessionRegistry()
+        registry.register(
+            Session(
+                name="doomed",
+                status="stopped",
+                workspace=Path("/w"),
+                created_at="t",
+                backend_type="podman",
+            )
+        )
+        upgrade_state.save(
+            UpgradeManifest(
+                name="doomed", to_version="0.20.0", created_at="t", workspace="/w"
+            )
+        )
+        assert upgrade_state.load("doomed") is not None
+
+        registry.unregister("doomed")
+
+        assert upgrade_state.load("doomed") is None
 
 
 class TestListShowsVersion:

--- a/tests/test_upgrade_state.py
+++ b/tests/test_upgrade_state.py
@@ -1,0 +1,93 @@
+"""Tests for the durable upgrade manifest (crash-safe upgrade recovery)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from paude import upgrade_state
+from paude.upgrade_state import UpgradeManifest
+
+
+def _manifest(name: str = "test-session") -> UpgradeManifest:
+    return UpgradeManifest(
+        name=name,
+        to_version="0.20.0",
+        created_at="2026-01-01T00:00:00+00:00",
+        workspace="/home/user/project",
+        agent="claude",
+        provider="anthropic",
+        agent_providers=[("claude", "anthropic"), ("codex", "openai")],
+        credential_providers=["anthropic", "openai"],
+        gpu="all",
+        yolo=True,
+        otel_endpoint="http://collector:4318",
+        allowed_domains=[".googleapis.com", ".pypi.org"],
+        proxy_image="proxy:latest",
+    )
+
+
+class TestUpgradeState:
+    def test_load_missing_returns_none(self, tmp_path: Path) -> None:
+        path = tmp_path / "upgrades.json"
+        assert upgrade_state.load("nope", path=path) is None
+
+    def test_save_load_round_trip(self, tmp_path: Path) -> None:
+        path = tmp_path / "upgrades.json"
+        manifest = _manifest()
+        upgrade_state.save(manifest, path=path)
+
+        loaded = upgrade_state.load("test-session", path=path)
+        assert loaded == manifest
+
+    def test_agent_providers_normalised_to_tuples(self, tmp_path: Path) -> None:
+        """JSON stores tuples as lists; load restores tuples for get_agents()."""
+        path = tmp_path / "upgrades.json"
+        upgrade_state.save(_manifest(), path=path)
+
+        loaded = upgrade_state.load("test-session", path=path)
+        assert loaded is not None
+        assert loaded.agent_providers == [("claude", "anthropic"), ("codex", "openai")]
+        assert all(isinstance(item, tuple) for item in loaded.agent_providers)
+
+    def test_save_is_atomic_no_temp_left(self, tmp_path: Path) -> None:
+        path = tmp_path / "upgrades.json"
+        upgrade_state.save(_manifest(), path=path)
+
+        # No stray .tmp files remain from the atomic write.
+        assert list(tmp_path.glob("*.tmp")) == []
+        assert path.exists()
+
+    def test_multiple_sessions_coexist(self, tmp_path: Path) -> None:
+        path = tmp_path / "upgrades.json"
+        upgrade_state.save(_manifest("session-a"), path=path)
+        upgrade_state.save(_manifest("session-b"), path=path)
+
+        assert upgrade_state.load("session-a", path=path) is not None
+        assert upgrade_state.load("session-b", path=path) is not None
+
+    def test_delete_removes_only_target(self, tmp_path: Path) -> None:
+        path = tmp_path / "upgrades.json"
+        upgrade_state.save(_manifest("session-a"), path=path)
+        upgrade_state.save(_manifest("session-b"), path=path)
+
+        upgrade_state.delete("session-a", path=path)
+
+        assert upgrade_state.load("session-a", path=path) is None
+        assert upgrade_state.load("session-b", path=path) is not None
+
+    def test_delete_absent_is_noop(self, tmp_path: Path) -> None:
+        path = tmp_path / "upgrades.json"
+        # Should not raise even when the file does not exist.
+        upgrade_state.delete("nope", path=path)
+        assert not path.exists()
+
+    def test_corrupt_file_returns_none(self, tmp_path: Path) -> None:
+        path = tmp_path / "upgrades.json"
+        path.write_text("{ this is not valid json")
+        assert upgrade_state.load("test-session", path=path) is None
+
+    def test_corrupt_entry_returns_none(self, tmp_path: Path) -> None:
+        """An entry with unexpected fields is treated as corrupt, not crashed."""
+        path = tmp_path / "upgrades.json"
+        path.write_text('{"upgrades": {"test-session": {"unexpected": "field"}}}')
+        assert upgrade_state.load("test-session", path=path) is None


### PR DESCRIPTION
Interrupting `paude upgrade` (e.g. Ctrl+C) could leave a session unrecoverable: the old container held the only copy of the session config in its labels, and upgrade force-removed it before building the replacement, with KeyboardInterrupt never caught.

Upgrade now records the fully-resolved config to a durable local manifest (~/.config/paude/upgrades.json) before any teardown, catches interrupts and errors without discarding it, and resumes from the manifest on re-run -- rebuilding the backend from the registry when the container is already gone. The manifest is deleted only on success and whenever a session is unregistered. The /pvc data volume is reused in place and never removed, so workspace and agent state are never at risk. Works across Podman/Docker and local/remote SSH sessions.

Adds a shared json_store helper (atomic write + tolerant load) reused by the registry and the new manifest store, and an allow_offline flag on find_session_backend for registry-based backend reconstruction.