### PR TITLE
Support harvesting repos at non-default container paths

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -56,6 +56,26 @@ The same "parse a `user@host[:port]` string with `parse_ssh_host()`, then constr
 
 The third occurrence was added while fixing SEC-003 rather than reusing `_build_transport()`, because `_build_transport()` lives in `src/paude/cli/` and importing it from `src/paude/git_remote/` (a lower-level package) would invert the existing dependency direction. Consolidating all three requires first giving this logic a home that both `cli/` and `git_remote/`/`backends/` can depend on without a layering inversion (e.g. a small helper in `src/paude/transport/ssh.py` itself, alongside `parse_ssh_host()`). Until then, any change to `SshTransport`'s constructor or `parse_ssh_host()`'s contract needs to be checked against all three call sites.
 
+## Correctness Backlog
+
+Lower-severity correctness/robustness issues surfaced during code review.
+
+### HARVEST-001: `harvest` diff summary hardcodes `main` as the base ref
+
+**Status**: Open
+**Severity**: Low (cosmetic — harvest still succeeds)
+**Discovered**: 2026-08-07 during code review of the `--container-path`/`--repo` harvest work
+
+`harvest_session()` in `src/paude/workflow.py` prints a post-harvest change summary via `git_diff_stat("main", branch_name, cwd=workspace)` (workflow.py:~230). The base ref is hardcoded to `main`. With the new `--repo` option a user can harvest into a host repo whose default branch is `master`/`trunk`/etc.; there `git diff --stat main...<branch>` fails and `git_diff_stat()` returns `""` (`src/paude/git_remote/utils.py` — non-zero return yields empty string), so the summary line is silently omitted. Harvest itself still completes correctly. Fix by resolving the base branch the way `get_upstream_url()` does (iterate `DEFAULT_BRANCHES`, fall back to the tracking branch) instead of assuming `main`.
+
+### HARVEST-002: container path with whitespace breaks the `ext::` remote URL
+
+**Status**: Open
+**Severity**: Low (exotic input; no injection risk)
+**Discovered**: 2026-08-07 during code review of the `--container-path`/`--repo` harvest work
+
+`build_podman_remote_url()` / `build_ssh_remote_url()` in `src/paude/git_remote/utils.py` interpolate `workspace_path` into the remote URL as `ext::… %S <workspace_path>`. Git's `ext::` helper splits its command line on whitespace and `exec`s the program directly (no shell is involved, so shell metacharacters are *not* an injection vector), but a `workspace_path` containing spaces would be word-split into separate argv entries and every fetch/push would fail. Now that `--container-path` accepts arbitrary paths (previously always the space-free `/pvc/workspace`), this is reachable, though container paths with spaces are highly unusual. Note that shell-quoting does not help here — there is no shell — so a fix would need `ext::`'s own (limited) escaping or a validation/rejection of whitespace in container paths.
+
 ## Agent Limitations
 
 Issues caused by upstream agent behavior, not paude bugs.

--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Or just start the session and type your request in the agent interface.
 - [Session Management](docs/SESSIONS.md) — commands, lifecycle, code sync
 - [Configuration](docs/CONFIGURATION.md) — defaults, network domains, GitHub CLI, custom environments
 - [Security Model](docs/SECURITY.md) — attack vectors, `--yolo` safety, residual risks
-- [Orchestration](docs/ORCHESTRATION.md) — fire-and-forget workflow, harvest, PRs
+- [Orchestration](docs/ORCHESTRATION.md) — fire-and-forget workflow, harvest (including containers holding multiple repos), PRs
 - [Remote Hosts & Docker](docs/REMOTE.md) — SSH remotes, Docker backend, GPU passthrough
 
 ## How It Works

--- a/docs/ORCHESTRATION.md
+++ b/docs/ORCHESTRATION.md
@@ -46,6 +46,19 @@ This creates a local `feature/auth-refactor` branch with all of the agent's comm
 
 Protected branches (`main`, `master`, `release`, `release-*`, `release/*`) cannot be used as harvest targets.
 
+### Harvesting a repo at a non-default path
+
+By default, harvest targets the session's top-level workspace (`/pvc/workspace`) and the local repo the session was created from. If a session's container holds more than one git repo — for example a workspace with several repos checked out under sub-paths — you can harvest any of them:
+
+```bash
+paude harvest my-project -b fix/foo \
+  --container-path /pvc/workspace/repos/api \  # repo path inside the container
+  --remote rig-api \                           # git remote name to use
+  --repo ~/src/api                             # host repo to harvest into
+```
+
+`--container-path` selects which repo inside the container to fetch from, `--remote` names the git remote (default `paude-<session>`; use a non-`paude-` name so `paude remote cleanup` leaves it alone), and `--repo` chooses which host checkout to harvest into (default: the session's recorded workspace). Set up a matching remote up front with `paude remote add my-project --container-path <path> --remote <remote>` if you prefer, though harvest adds it automatically when missing.
+
 ## Open a PR
 
 Once you're satisfied with the changes, harvest again with `--pr` to push the branch and create a pull request:

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -168,3 +168,12 @@ paude remote remove my-project
 # Remove remotes whose sessions no longer exist
 paude remote cleanup
 ```
+
+By default a session exposes one repo at `/pvc/workspace` as the `paude-<session>` remote. If a container holds more than one git repo, point additional remotes at their sub-paths with `--container-path` and give each a distinct `--remote` name:
+
+```bash
+paude remote add my-project --container-path /pvc/workspace/repos/api --remote rig-api
+git -C ~/src/api fetch rig-api
+```
+
+Use a non-`paude-` remote name (as above) so `paude remote cleanup` doesn't remove it. See [Orchestration](ORCHESTRATION.md) for harvesting these sub-path repos.

--- a/src/paude/cli/help.py
+++ b/src/paude/cli/help.py
@@ -61,6 +61,10 @@ _SECTIONS: tuple[HelpSection, ...] = (
         rows=(
             ("paude remote add [NAME]", "Add git remote (requires running container)"),
             ("paude remote add --push [NAME]", "Add remote AND push current branch"),
+            (
+                "paude remote add NAME --container-path DIR --remote R",
+                "Expose a repo at DIR inside the box as remote R",
+            ),
             ("paude remote list", "List all paude git remotes"),
             ("paude remote remove [NAME]", "Remove git remote for session"),
             ("paude remote cleanup", "Remove remotes for deleted sessions"),

--- a/src/paude/cli/remote.py
+++ b/src/paude/cli/remote.py
@@ -14,6 +14,7 @@ from paude.backends.naming import (
 )
 from paude.cli.app import app
 from paude.cli.helpers import find_session_backend
+from paude.constants import CONTAINER_WORKSPACE
 
 if TYPE_CHECKING:
     from paude.backends.base import Backend, Session
@@ -37,6 +38,27 @@ def remote_command(
             help="Push current branch after adding remote (for 'add' action).",
         ),
     ] = False,
+    container_path: Annotated[
+        str,
+        typer.Option(
+            "--container-path",
+            help=(
+                "Path of the repo inside the container to expose "
+                "(for 'add'; default: the session workspace)."
+            ),
+        ),
+    ] = CONTAINER_WORKSPACE,
+    remote_name: Annotated[
+        str | None,
+        typer.Option(
+            "--remote",
+            help=(
+                "Name for the git remote (for 'add'; "
+                "default: paude-<session>). Use a non-'paude-' name for extra "
+                "remotes so 'paude remote cleanup' won't remove them."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Manage git remotes for paude sessions.
 
@@ -77,7 +99,12 @@ def remote_command(
             typer.echo("Initialize git first: git init", err=True)
             raise typer.Exit(1)
 
-        _remote_add(name, push=push)
+        _remote_add(
+            name,
+            push=push,
+            remote_name=remote_name,
+            container_path=container_path,
+        )
         return
 
     if action == "remove":
@@ -194,8 +221,16 @@ def _remote_add(
     name: str | None,
     push: bool = False,
     transport: Transport | None = None,
+    remote_name: str | None = None,
+    container_path: str = CONTAINER_WORKSPACE,
 ) -> None:
-    """Add a git remote for a session."""
+    """Add a git remote for a session.
+
+    ``remote_name`` overrides the git remote name (default ``paude-<session>``);
+    ``container_path`` selects which repo path inside the container to expose
+    (default: the top-level workspace). The container name is always
+    ``paude-<session>`` regardless of these.
+    """
     from paude.git_remote import (
         enable_ext_protocol,
         get_current_branch,
@@ -236,10 +271,12 @@ def _remote_add(
             typer.echo("Create one first: paude create", err=True)
         raise typer.Exit(1)
 
-    rname = resource_name(session.name)
+    rname = remote_name or resource_name(session.name)
     branch = get_current_branch() or "main"
 
-    remote_url, transport = _remote_add_local(session, rname, branch, transport)
+    remote_url, transport = _remote_add_local(
+        session, branch, transport, container_path
+    )
 
     # Add the remote
     if git_remote_add(rname, remote_url):
@@ -252,6 +289,7 @@ def _remote_add(
                 rname,
                 branch,
                 transport,
+                container_path,
             )
         else:
             typer.echo("")
@@ -265,9 +303,9 @@ def _remote_add(
 
 def _remote_add_local(
     session: Session,
-    rname: str,
     branch: str,
     transport: Transport | None,
+    container_path: str = CONTAINER_WORKSPACE,
 ) -> tuple[str, Transport | None]:
     """Handle local backend remote add: check container, init workspace, build URL."""
     from paude.cli.remote_git_setup import _prepare_session_git_remote
@@ -276,5 +314,10 @@ def _remote_add_local(
     engine = engine_binary_for_backend(session.backend_type)
 
     return _prepare_session_git_remote(
-        session.name, cname, engine, branch=branch, transport=transport
+        session.name,
+        cname,
+        engine,
+        branch=branch,
+        transport=transport,
+        workspace_path=container_path,
     )

--- a/src/paude/cli/remote_git_setup.py
+++ b/src/paude/cli/remote_git_setup.py
@@ -12,6 +12,7 @@ from paude.backends.naming import (
     engine_binary_for_backend,
     resource_name,
 )
+from paude.constants import CONTAINER_WORKSPACE
 
 if TYPE_CHECKING:
     from paude.backends.base import Session
@@ -73,10 +74,13 @@ def _prepare_session_git_remote(
     *,
     branch: str = "main",
     transport: Transport | None = None,
+    workspace_path: str = CONTAINER_WORKSPACE,
 ) -> tuple[str, Transport | None]:
     """Resolve a session's remote URL/transport and prepare its container workspace.
 
     Used by both `paude remote add` and `paude harvest` to auto-add a remote.
+    ``workspace_path`` selects which repo path inside the container the remote
+    points at (defaults to the top-level workspace).
     Raises typer.Exit(1) if the container isn't running or workspace init fails.
     """
     from paude.git_remote import (
@@ -87,7 +91,7 @@ def _prepare_session_git_remote(
     )
 
     remote_url, resolved_transport = resolve_session_remote(
-        session_name, container_name, engine
+        session_name, container_name, engine, workspace_path=workspace_path
     )
     effective_transport = transport if transport is not None else resolved_transport
 
@@ -102,7 +106,10 @@ def _prepare_session_git_remote(
     typer.echo("Initializing git repository in container...")
     exec_builder = podman_exec_builder(container_name, engine)
     if not initialize_container_workspace(
-        exec_builder, branch=branch, transport=effective_transport
+        exec_builder,
+        branch=branch,
+        transport=effective_transport,
+        workspace_path=workspace_path,
     ):
         raise typer.Exit(1)
 
@@ -295,6 +302,7 @@ def _push_after_add(
     rname: str,
     branch: str,
     transport: Transport | None,
+    workspace_path: str = CONTAINER_WORKSPACE,
 ) -> None:
     """Push branch and set base ref after adding a remote."""
     from paude.git_remote import git_push_to_remote, set_base_ref_in_container
@@ -307,5 +315,5 @@ def _push_after_add(
 
     ctx = GitSetupContext.from_session(session, transport)
     eb, tp = ctx.make_exec_context()
-    set_base_ref_in_container(eb, transport=tp)
+    set_base_ref_in_container(eb, transport=tp, workspace_path=workspace_path)
     typer.echo("Push complete.")

--- a/src/paude/cli/status.py
+++ b/src/paude/cli/status.py
@@ -7,6 +7,7 @@ from typing import Annotated
 import typer
 
 from paude.cli.app import app
+from paude.constants import CONTAINER_WORKSPACE
 
 
 @app.command("status")
@@ -71,6 +72,33 @@ def harvest_cmd(
         str | None,
         typer.Option("--pr-title", help="PR title (defaults to branch name)."),
     ] = None,
+    container_path: Annotated[
+        str,
+        typer.Option(
+            "--container-path",
+            help=(
+                "Path of the repo inside the container to harvest from "
+                "(default: the session workspace)."
+            ),
+        ),
+    ] = CONTAINER_WORKSPACE,
+    remote: Annotated[
+        str | None,
+        typer.Option(
+            "--remote",
+            help="Git remote name to use (default: paude-<session>).",
+        ),
+    ] = None,
+    repo: Annotated[
+        str | None,
+        typer.Option(
+            "--repo",
+            help=(
+                "Host git repo to harvest into "
+                "(default: the session's recorded workspace)."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Harvest changes from a running session into a local branch."""
     from paude.workflow import harvest_session
@@ -80,4 +108,7 @@ def harvest_cmd(
         branch_name=branch,
         create_pr=pr,
         pr_title=pr_title,
+        container_path=container_path,
+        remote_name=remote,
+        repo=repo,
     )

--- a/src/paude/git_remote/__init__.py
+++ b/src/paude/git_remote/__init__.py
@@ -5,8 +5,8 @@
 import subprocess as subprocess  # noqa: F811, PLC0414
 
 from paude.git_remote.container_ops import (
-    _SET_BASE_REF_CMD,
     _build_clone_from_origin_cmd,
+    _build_set_base_ref_cmd,
     _build_set_origin_cmd,
     _build_workspace_init_cmd,
     _exec_in_container,
@@ -34,6 +34,8 @@ from paude.git_remote.utils import (
     git_push_tags_to_remote,
     git_push_to_remote,
     git_remote_add,
+    git_remote_exists,
+    git_remote_get_url,
     git_remote_remove,
     is_container_running_podman,
     is_ext_protocol_allowed,
@@ -47,8 +49,8 @@ from paude.git_remote.utils import (
 
 __all__ = [
     "ExecCmdBuilder",
-    "_SET_BASE_REF_CMD",
     "_build_clone_from_origin_cmd",
+    "_build_set_base_ref_cmd",
     "_build_set_origin_cmd",
     "_build_workspace_init_cmd",
     "_exec_in_container",
@@ -66,6 +68,8 @@ __all__ = [
     "git_push_tags_to_remote",
     "git_push_to_remote",
     "git_remote_add",
+    "git_remote_exists",
+    "git_remote_get_url",
     "git_remote_remove",
     "initialize_container_workspace",
     "is_container_running_podman",

--- a/src/paude/git_remote/container_ops.py
+++ b/src/paude/git_remote/container_ops.py
@@ -41,13 +41,21 @@ def _exec_in_container(
     return result.returncode == 0
 
 
-def _build_workspace_init_cmd(branch: str) -> str:
-    """Build bash command to initialize a git workspace."""
+def _build_workspace_init_cmd(
+    branch: str, workspace_path: str = CONTAINER_WORKSPACE
+) -> str:
+    """Build bash command to initialize a git workspace.
+
+    Idempotent: if ``workspace_path`` already contains a git repo, ``git init``
+    is skipped and only ``receive.denyCurrentBranch updateInstead`` is (re)applied
+    so pushes into a checked-out repo update its working tree.
+    """
     quoted_branch = shlex.quote(branch)
+    ws = shlex.quote(workspace_path)
     return (
-        f"test -d {CONTAINER_WORKSPACE}/.git || "
-        f"git init -b {quoted_branch} {CONTAINER_WORKSPACE} && "
-        f"git -C {CONTAINER_WORKSPACE} config receive.denyCurrentBranch updateInstead"
+        f"test -d {ws}/.git || "
+        f"git init -b {quoted_branch} {ws} && "
+        f"git -C {ws} config receive.denyCurrentBranch updateInstead"
     )
 
 
@@ -67,7 +75,11 @@ _PRECOMMIT_CMD = (
 
 from paude.constants import BASE_REF_NAME  # noqa: E402
 
-_SET_BASE_REF_CMD = f"git -C {CONTAINER_WORKSPACE} update-ref {BASE_REF_NAME} HEAD"
+
+def _build_set_base_ref_cmd(workspace_path: str = CONTAINER_WORKSPACE) -> str:
+    """Build bash command to point refs/paude/base at HEAD."""
+    ws = shlex.quote(workspace_path)
+    return f"git -C {ws} update-ref {BASE_REF_NAME} HEAD"
 
 
 def _build_clone_from_origin_cmd(origin_https_url: str) -> str:
@@ -86,9 +98,10 @@ def initialize_container_workspace(
     exec_builder: ExecCmdBuilder,
     branch: str = "main",
     transport: Transport | None = None,
+    workspace_path: str = CONTAINER_WORKSPACE,
 ) -> bool:
     """Initialize git repository in a container's workspace."""
-    bash_cmd = _build_workspace_init_cmd(branch)
+    bash_cmd = _build_workspace_init_cmd(branch, workspace_path)
     exec_cmd = exec_builder(bash_cmd)
     return _exec_in_container(
         exec_cmd, error_msg="Failed to init workspace", transport=transport
@@ -111,9 +124,10 @@ def set_origin_in_container(
 def set_base_ref_in_container(
     exec_builder: ExecCmdBuilder,
     transport: Transport | None = None,
+    workspace_path: str = CONTAINER_WORKSPACE,
 ) -> bool:
     """Set refs/paude/base to HEAD in a container's workspace."""
-    exec_cmd = exec_builder(_SET_BASE_REF_CMD)
+    exec_cmd = exec_builder(_build_set_base_ref_cmd(workspace_path))
     return _exec_in_container(
         exec_cmd, error_msg="Failed to set base ref", transport=transport
     )

--- a/src/paude/git_remote/utils.py
+++ b/src/paude/git_remote/utils.py
@@ -44,12 +44,18 @@ def build_ssh_remote_url(
 
 
 def resolve_session_remote(
-    session_name: str, container_name: str, engine: str
+    session_name: str,
+    container_name: str,
+    engine: str,
+    workspace_path: str = CONTAINER_WORKSPACE,
 ) -> tuple[str, Transport | None]:
     """Resolve the git remote URL and transport for a session's container.
 
     SSH-host (--host) sessions get an ext::ssh-wrapped URL and a matching
     transport; local sessions get a plain ext::<engine> exec URL and no transport.
+
+    ``workspace_path`` selects which repo path inside the container the remote
+    points at; it defaults to the session's top-level workspace.
     """
     from paude.registry import SessionRegistry
 
@@ -67,10 +73,18 @@ def resolve_session_remote(
             engine=engine,
             ssh_key=registry_entry.ssh_key,
             ssh_port=ssh_port,
+            workspace_path=workspace_path,
         )
         return remote_url, transport
 
-    return build_podman_remote_url(container_name=container_name, engine=engine), None
+    return (
+        build_podman_remote_url(
+            container_name=container_name,
+            engine=engine,
+            workspace_path=workspace_path,
+        ),
+        None,
+    )
 
 
 def _git_config_value(key: str) -> str | None:
@@ -104,12 +118,13 @@ def resolve_local_git_identity() -> tuple[str | None, str | None]:
     return (_git_config_value("user.name"), _git_config_value("user.email"))
 
 
-def is_ext_protocol_allowed() -> bool:
+def is_ext_protocol_allowed(cwd: Path | None = None) -> bool:
     """Check if git ext:: protocol is allowed."""
     result = subprocess.run(
         ["git", "config", "--get", "protocol.ext.allow"],
         capture_output=True,
         text=True,
+        cwd=cwd,
     )
     if result.returncode == 0:
         value = result.stdout.strip().lower()
@@ -117,22 +132,24 @@ def is_ext_protocol_allowed() -> bool:
     return False
 
 
-def enable_ext_protocol() -> bool:
+def enable_ext_protocol(cwd: Path | None = None) -> bool:
     """Enable git ext:: protocol for the current repository."""
     result = subprocess.run(
         ["git", "config", "protocol.ext.allow", "always"],
         capture_output=True,
         text=True,
+        cwd=cwd,
     )
     return result.returncode == 0
 
 
-def git_remote_add(remote_name: str, remote_url: str) -> bool:
+def git_remote_add(remote_name: str, remote_url: str, cwd: Path | None = None) -> bool:
     """Add a git remote."""
     result = subprocess.run(
         ["git", "remote", "add", remote_name, remote_url],
         capture_output=True,
         text=True,
+        cwd=cwd,
     )
 
     if result.returncode != 0:
@@ -147,6 +164,30 @@ def git_remote_add(remote_name: str, remote_url: str) -> bool:
         return False
 
     return True
+
+
+def git_remote_exists(remote_name: str, cwd: Path | None = None) -> bool:
+    """Check whether a git remote with the given name exists."""
+    result = subprocess.run(
+        ["git", "remote", "get-url", remote_name],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    return result.returncode == 0
+
+
+def git_remote_get_url(remote_name: str, cwd: Path | None = None) -> str | None:
+    """Return a git remote's URL, or None if it doesn't exist or can't be read."""
+    result = subprocess.run(
+        ["git", "remote", "get-url", remote_name],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
 
 
 def git_remote_remove(remote_name: str, cwd: Path | None = None) -> bool:

--- a/src/paude/workflow.py
+++ b/src/paude/workflow.py
@@ -7,6 +7,7 @@ import shlex
 import shutil
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
 import typer
 
@@ -63,46 +64,123 @@ def _find_backend_and_session(
     return backend_type, backend, session
 
 
-def _ensure_remote_exists(session_name: str, backend_type: str) -> str:
-    """Ensure a paude git remote exists, auto-adding if needed."""
+def _remote_targets_container_path(remote_url: str, container_path: str) -> bool:
+    """Whether a paude ext:: remote URL points at ``container_path``.
+
+    paude remote URLs end with ``%S <container_path>``, so the container path is
+    the final whitespace-delimited token. URLs without the ``%S`` marker are not
+    paude ext:: remotes; treat those as a match so a manually configured remote
+    isn't blocked.
+    """
+    if "%S " not in remote_url:
+        return True
+    return remote_url.rsplit(" ", 1)[-1] == container_path
+
+
+def _ensure_remote_exists(
+    session_name: str,
+    backend_type: str,
+    remote_name: str | None = None,
+    container_path: str = CONTAINER_WORKSPACE,
+    cwd: Path | None = None,
+) -> str:
+    """Ensure a git remote exists in ``cwd``, auto-adding if needed.
+
+    ``remote_name`` defaults to ``paude-<session>``; ``container_path`` selects
+    which repo path inside the container the remote points at. The container name
+    is always ``paude-<session>`` regardless of the remote name.
+
+    If a remote by the resolved name already exists but points at a different
+    container path than requested, raise typer.Exit rather than silently
+    harvesting the wrong repo (the default remote name does not encode the path).
+    """
     from paude.cli.remote_git_setup import _prepare_session_git_remote
     from paude.git_remote import (
         enable_ext_protocol,
         git_remote_add,
+        git_remote_exists,
+        git_remote_get_url,
         is_ext_protocol_allowed,
-        list_paude_remotes,
     )
 
-    remote_name = resource_name(session_name)
+    container_name = resource_name(session_name)
+    resolved_remote = remote_name or container_name
 
-    for name, _url in list_paude_remotes():
-        if name == remote_name:
-            return remote_name
+    if git_remote_exists(resolved_remote, cwd=cwd):
+        existing_url = git_remote_get_url(resolved_remote, cwd=cwd)
+        if existing_url and not _remote_targets_container_path(
+            existing_url, container_path
+        ):
+            typer.echo(
+                f"Error: Remote '{resolved_remote}' already exists but points at "
+                f"a different container path than '{container_path}'.",
+                err=True,
+            )
+            typer.echo(f"  Existing remote: {existing_url}", err=True)
+            typer.echo(
+                "  Use --remote to pick a distinct remote name, or remove the "
+                "existing remote first.",
+                err=True,
+            )
+            raise typer.Exit(1)
+        return resolved_remote
 
-    typer.echo(f"Adding git remote '{remote_name}'...", err=True)
+    typer.echo(f"Adding git remote '{resolved_remote}'...", err=True)
 
-    if not is_ext_protocol_allowed():
-        if not enable_ext_protocol():
+    if not is_ext_protocol_allowed(cwd=cwd):
+        if not enable_ext_protocol(cwd=cwd):
             typer.echo("Error: Failed to enable git ext:: protocol.", err=True)
             raise typer.Exit(1)
 
     engine = engine_binary_for_backend(backend_type)
     remote_url, _transport = _prepare_session_git_remote(
-        session_name, remote_name, engine
+        session_name, container_name, engine, workspace_path=container_path
     )
 
-    if not git_remote_add(remote_name, remote_url):
-        typer.echo(f"Error: Failed to add remote '{remote_name}'.", err=True)
+    if not git_remote_add(resolved_remote, remote_url, cwd=cwd):
+        typer.echo(f"Error: Failed to add remote '{resolved_remote}'.", err=True)
         raise typer.Exit(1)
 
-    return remote_name
+    return resolved_remote
 
 
-def _get_container_branch(backend: Backend, session_name: str) -> str:
+def _verify_container_repo(
+    backend: Backend,
+    session_name: str,
+    container_path: str,
+) -> None:
+    """Ensure ``container_path`` is an existing git repo, else exit with an error.
+
+    Harvest reads from a repo the agent already created; without this guard a
+    mistyped ``--container-path`` would fall through to the workspace-init
+    ``git init`` and silently create a stray empty repo at the wrong path, then
+    fail later with a confusing ref error.
+    """
+    rc, _stdout, _stderr = backend.exec_in_session(
+        session_name,
+        f"git -C {shlex.quote(container_path)} rev-parse --is-inside-work-tree",
+    )
+    if rc != 0:
+        typer.echo(
+            f"Error: No git repository found at container path '{container_path}'.",
+            err=True,
+        )
+        typer.echo(
+            "  Check that the path is correct and the container is running.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+
+def _get_container_branch(
+    backend: Backend,
+    session_name: str,
+    container_path: str = CONTAINER_WORKSPACE,
+) -> str:
     """Query the current branch inside a session's container."""
     rc, stdout, stderr = backend.exec_in_session(
         session_name,
-        "git -C /pvc/workspace rev-parse --abbrev-ref HEAD",
+        f"git -C {shlex.quote(container_path)} rev-parse --abbrev-ref HEAD",
     )
     if rc != 0:
         typer.echo(
@@ -118,15 +196,24 @@ def harvest_session(
     branch_name: str,
     create_pr: bool = False,
     pr_title: str | None = None,
+    container_path: str = CONTAINER_WORKSPACE,
+    remote_name: str | None = None,
+    repo: str | None = None,
 ) -> None:
-    """Harvest changes from a running session into a local branch."""
+    """Harvest changes from a running session into a local branch.
+
+    ``container_path`` selects which repo path inside the container to harvest
+    from, ``remote_name`` the git remote to use, and ``repo`` the host repo to
+    harvest into. All default to the single-repo behavior (the session's
+    ``/pvc/workspace`` and recorded host workspace).
+    """
     from paude.git_remote import git_diff_stat, git_fetch_from_remote
 
     _validate_harvest_branch(branch_name)
 
     backend_type, backend, session = _find_backend_and_session(session_name)
 
-    workspace = session.workspace
+    workspace = Path(repo).expanduser().resolve() if repo else session.workspace
     if not (workspace / ".git").is_dir():
         typer.echo(
             f"Error: Workspace '{workspace}' is not a git repository "
@@ -135,9 +222,17 @@ def harvest_session(
         )
         raise typer.Exit(1)
 
-    remote_name = _ensure_remote_exists(session_name, backend_type)
+    _verify_container_repo(backend, session_name, container_path)
 
-    container_branch = _get_container_branch(backend, session_name)
+    remote_name = _ensure_remote_exists(
+        session_name,
+        backend_type,
+        remote_name=remote_name,
+        container_path=container_path,
+        cwd=workspace,
+    )
+
+    container_branch = _get_container_branch(backend, session_name, container_path)
     typer.echo(f"Container is on branch '{container_branch}'.", err=True)
 
     typer.echo(f"Fetching from '{remote_name}'...", err=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -954,6 +954,106 @@ class TestRemoteCommand:
         assert "Initializing git repository in container" in output
         mock_init.assert_called_once()
 
+    @patch("paude.cli.remote.find_session_backend")
+    @patch("paude.git_remote.is_git_repository")
+    @patch("paude.git_remote.is_ext_protocol_allowed")
+    @patch("paude.git_remote.is_container_running_podman")
+    @patch("paude.git_remote.initialize_container_workspace")
+    @patch("paude.git_remote.git_remote_add")
+    @patch("paude.git_remote.get_current_branch")
+    def test_remote_add_container_path_and_remote_name(
+        self,
+        mock_branch,
+        mock_add,
+        mock_init,
+        mock_running,
+        mock_ext,
+        mock_is_git,
+        mock_find,
+    ):
+        """--container-path/--remote expose a sub-path under a custom remote name."""
+        mock_is_git.return_value = True
+        mock_ext.return_value = True
+        mock_running.return_value = True
+        mock_init.return_value = True
+        mock_add.return_value = True
+        mock_branch.return_value = "main"
+
+        mock_session = MagicMock()
+        mock_session.name = "test-session"
+        mock_session.backend_type = "podman"
+        mock_backend = MagicMock()
+        mock_backend.get_session.return_value = mock_session
+        mock_find.return_value = (mock_session, mock_backend)
+
+        result = runner.invoke(
+            app,
+            [
+                "remote",
+                "add",
+                "test-session",
+                "--container-path",
+                "/pvc/workspace/rigs/vllm",
+                "--remote",
+                "rig-vllm",
+            ],
+        )
+
+        assert result.exit_code == 0
+        # container name stays paude-<session>; remote name + path are custom
+        mock_add.assert_called_once_with(
+            "rig-vllm",
+            "ext::podman exec -i paude-test-session %S /pvc/workspace/rigs/vllm",
+        )
+        assert mock_init.call_args.kwargs["workspace_path"] == (
+            "/pvc/workspace/rigs/vllm"
+        )
+
+
+class TestHarvestCommand:
+    """Tests for the harvest command CLI wiring."""
+
+    @patch("paude.workflow.harvest_session")
+    def test_harvest_passes_new_flags(self, mock_harvest):
+        """--container-path/--remote/--repo are forwarded to harvest_session."""
+        result = runner.invoke(
+            app,
+            [
+                "harvest",
+                "my-session",
+                "-b",
+                "fix/foo",
+                "--container-path",
+                "/pvc/workspace/rigs/vllm",
+                "--remote",
+                "rig-vllm",
+                "--repo",
+                "/host/vllm",
+            ],
+        )
+
+        assert result.exit_code == 0
+        mock_harvest.assert_called_once_with(
+            session_name="my-session",
+            branch_name="fix/foo",
+            create_pr=False,
+            pr_title=None,
+            container_path="/pvc/workspace/rigs/vllm",
+            remote_name="rig-vllm",
+            repo="/host/vllm",
+        )
+
+    @patch("paude.workflow.harvest_session")
+    def test_harvest_defaults_preserved(self, mock_harvest):
+        """Omitting the new flags keeps the single-repo defaults."""
+        result = runner.invoke(app, ["harvest", "my-session", "-b", "fix/foo"])
+
+        assert result.exit_code == 0
+        _args, kwargs = mock_harvest.call_args
+        assert kwargs["container_path"] == "/pvc/workspace"
+        assert kwargs["remote_name"] is None
+        assert kwargs["repo"] is None
+
 
 def test_subcommand_runs_without_main_execution():
     """Subcommands run without triggering main execution logic."""

--- a/tests/test_git_remote.py
+++ b/tests/test_git_remote.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from paude.git_remote import (
     _build_clone_from_origin_cmd,
+    _build_set_base_ref_cmd,
     _build_set_origin_cmd,
     _build_workspace_init_cmd,
     _exec_in_container,
@@ -19,6 +20,8 @@ from paude.git_remote import (
     git_fetch_from_remote,
     git_push_tags_to_remote,
     git_remote_add,
+    git_remote_exists,
+    git_remote_get_url,
     git_remote_remove,
     initialize_container_workspace,
     is_ext_protocol_allowed,
@@ -52,6 +55,75 @@ class TestBuildPodmanRemoteUrl:
         assert url == "ext::podman exec -i paude-my-session %S /custom/path"
 
 
+class TestGitRemoteExists:
+    """Tests for git_remote_exists."""
+
+    @patch("paude.git_remote.subprocess.run")
+    def test_true_when_present(self, mock_run) -> None:
+        """Returns True and queries by exact remote name."""
+        mock_run.return_value.returncode = 0
+
+        assert git_remote_exists("rig-vllm") is True
+        assert mock_run.call_args[0][0] == ["git", "remote", "get-url", "rig-vllm"]
+
+    @patch("paude.git_remote.subprocess.run")
+    def test_false_when_absent(self, mock_run) -> None:
+        """Returns False when the remote is unknown."""
+        mock_run.return_value.returncode = 2
+
+        assert git_remote_exists("rig-vllm") is False
+
+    @patch("paude.git_remote.subprocess.run")
+    def test_forwards_cwd(self, mock_run) -> None:
+        """Existence check runs in the given host repo."""
+        mock_run.return_value.returncode = 0
+
+        git_remote_exists("rig-vllm", cwd=Path("/host/vllm"))
+
+        assert mock_run.call_args.kwargs["cwd"] == Path("/host/vllm")
+
+
+class TestGitRemoteGetUrl:
+    """Tests for git_remote_get_url."""
+
+    @patch("paude.git_remote.subprocess.run")
+    def test_returns_url_when_present(self, mock_run) -> None:
+        """Returns the trimmed URL and queries by exact remote name."""
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "ext::podman exec -i c %S /pvc/workspace\n"
+
+        result = git_remote_get_url("rig-vllm")
+
+        assert result == "ext::podman exec -i c %S /pvc/workspace"
+        assert mock_run.call_args[0][0] == ["git", "remote", "get-url", "rig-vllm"]
+
+    @patch("paude.git_remote.subprocess.run")
+    def test_returns_none_when_absent(self, mock_run) -> None:
+        """Returns None when the remote is unknown."""
+        mock_run.return_value.returncode = 2
+        mock_run.return_value.stdout = ""
+
+        assert git_remote_get_url("rig-vllm") is None
+
+    @patch("paude.git_remote.subprocess.run")
+    def test_returns_none_on_empty_url(self, mock_run) -> None:
+        """Returns None rather than an empty string."""
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "\n"
+
+        assert git_remote_get_url("rig-vllm") is None
+
+    @patch("paude.git_remote.subprocess.run")
+    def test_forwards_cwd(self, mock_run) -> None:
+        """Lookup runs in the given host repo."""
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "url\n"
+
+        git_remote_get_url("rig-vllm", cwd=Path("/host/vllm"))
+
+        assert mock_run.call_args.kwargs["cwd"] == Path("/host/vllm")
+
+
 class TestGitRemoteAdd:
     """Tests for git_remote_add."""
 
@@ -73,6 +145,16 @@ class TestGitRemoteAdd:
             "paude-test",
             "ext::podman exec -i test %S /workspace",
         ]
+
+    @patch("paude.git_remote.subprocess.run")
+    def test_add_forwards_cwd(self, mock_run) -> None:
+        """Remote is added in the given host repo."""
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stderr = ""
+
+        git_remote_add("rig-vllm", "ext::...", cwd=Path("/host/vllm"))
+
+        assert mock_run.call_args.kwargs["cwd"] == Path("/host/vllm")
 
     @patch("paude.git_remote.subprocess.run")
     def test_remote_already_exists(self, mock_run) -> None:
@@ -257,6 +339,16 @@ class TestIsExtProtocolAllowed:
 
         assert result is False
 
+    @patch("paude.git_remote.subprocess.run")
+    def test_forwards_cwd(self, mock_run) -> None:
+        """The check runs in the given host repo."""
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "always\n"
+
+        is_ext_protocol_allowed(cwd=Path("/host/vllm"))
+
+        assert mock_run.call_args.kwargs["cwd"] == Path("/host/vllm")
+
 
 class TestEnableExtProtocol:
     """Tests for enable_ext_protocol."""
@@ -281,6 +373,15 @@ class TestEnableExtProtocol:
         result = enable_ext_protocol()
 
         assert result is False
+
+    @patch("paude.git_remote.subprocess.run")
+    def test_forwards_cwd(self, mock_run) -> None:
+        """ext:: is enabled in the given host repo."""
+        mock_run.return_value.returncode = 0
+
+        enable_ext_protocol(cwd=Path("/host/vllm"))
+
+        assert mock_run.call_args.kwargs["cwd"] == Path("/host/vllm")
 
 
 class TestInitializeContainerWorkspacePodman:
@@ -620,6 +721,24 @@ class TestBashCommandBuilders:
         assert "git init -b main" in cmd
         assert "receive.denyCurrentBranch updateInstead" in cmd
         assert "/pvc/workspace" in cmd
+
+    def test_build_workspace_init_cmd_custom_path(self) -> None:
+        """Init command targets a custom container repo path."""
+        cmd = _build_workspace_init_cmd("main", "/pvc/workspace/rigs/vllm")
+        assert "git init -b main /pvc/workspace/rigs/vllm" in cmd
+        assert "git -C /pvc/workspace/rigs/vllm config" in cmd
+
+    def test_build_set_base_ref_cmd(self) -> None:
+        """Base-ref command defaults to the top-level workspace."""
+        cmd = _build_set_base_ref_cmd()
+        assert cmd == "git -C /pvc/workspace update-ref refs/paude/base HEAD"
+
+    def test_build_set_base_ref_cmd_custom_path(self) -> None:
+        """Base-ref command targets a custom container repo path."""
+        cmd = _build_set_base_ref_cmd("/pvc/workspace/rigs/vllm")
+        assert cmd == (
+            "git -C /pvc/workspace/rigs/vllm update-ref refs/paude/base HEAD"
+        )
 
     def test_build_set_origin_cmd(self) -> None:
         """Build set origin command."""
@@ -1203,6 +1322,40 @@ class TestResolveSessionRemote:
         assert transport.host == "user@gpu-server"
         assert transport.port == 2222
         assert transport.key == "/home/user/.ssh/id_ed25519"
+
+    @patch("paude.registry.SessionRegistry")
+    def test_forwards_workspace_path_local(self, mock_registry_class) -> None:
+        """workspace_path selects the container repo path in the local URL."""
+        mock_registry_class.return_value.get.return_value = None
+
+        url, _transport = resolve_session_remote(
+            "my-session",
+            "paude-my-session",
+            "podman",
+            workspace_path="/pvc/workspace/rigs/vllm",
+        )
+
+        assert url == (
+            "ext::podman exec -i paude-my-session %S /pvc/workspace/rigs/vllm"
+        )
+
+    @patch("paude.registry.SessionRegistry")
+    def test_forwards_workspace_path_ssh(self, mock_registry_class) -> None:
+        """workspace_path is threaded into the SSH-wrapped URL too."""
+        mock_registry_class.return_value.get.return_value = MagicMock(
+            ssh_host="user@gpu-server", ssh_key=None
+        )
+
+        url, _transport = resolve_session_remote(
+            "my-session",
+            "paude-my-session",
+            "docker",
+            workspace_path="/pvc/workspace/rigs/vllm",
+        )
+
+        assert url.endswith(
+            "docker exec -i paude-my-session %S /pvc/workspace/rigs/vllm"
+        )
 
 
 class TestExecCmdBuilders:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -11,7 +11,9 @@ import pytest
 
 from paude.workflow import (
     _get_container_branch,
+    _remote_targets_container_path,
     _validate_harvest_branch,
+    _verify_container_repo,
     harvest_session,
     reset_session,
     status_sessions,
@@ -35,6 +37,24 @@ class TestGetContainerBranch:
 
         with pytest.raises(click.exceptions.Exit):
             _get_container_branch(mock_backend, "my-session")
+
+    def test_defaults_to_workspace_path(self) -> None:
+        mock_backend = MagicMock()
+        mock_backend.exec_in_session.return_value = (0, "main\n", "")
+
+        _get_container_branch(mock_backend, "my-session")
+
+        cmd = mock_backend.exec_in_session.call_args[0][1]
+        assert cmd == "git -C /pvc/workspace rev-parse --abbrev-ref HEAD"
+
+    def test_uses_custom_container_path(self) -> None:
+        mock_backend = MagicMock()
+        mock_backend.exec_in_session.return_value = (0, "feature\n", "")
+
+        _get_container_branch(mock_backend, "my-session", "/pvc/workspace/rigs/vllm")
+
+        cmd = mock_backend.exec_in_session.call_args[0][1]
+        assert cmd == ("git -C /pvc/workspace/rigs/vllm rev-parse --abbrev-ref HEAD")
 
 
 class TestValidateHarvestBranch:
@@ -74,19 +94,22 @@ class TestHarvestSession:
     @patch("paude.workflow.subprocess.run")
     @patch("paude.git_remote.git_diff_stat")
     @patch("paude.git_remote.git_fetch_from_remote")
-    @patch("paude.git_remote.list_paude_remotes")
+    @patch("paude.git_remote.git_remote_get_url")
+    @patch("paude.git_remote.git_remote_exists")
     @patch("paude.cli.find_session_backend")
     def test_harvest_success(
         self,
         mock_find: MagicMock,
-        mock_list: MagicMock,
+        mock_exists: MagicMock,
+        mock_get_url: MagicMock,
         mock_fetch: MagicMock,
         mock_diff: MagicMock,
         mock_run: MagicMock,
         tmp_path: Path,
     ) -> None:
         self._setup_mocks(mock_find, tmp_path)
-        mock_list.return_value = [("paude-test", "ext::...")]
+        mock_exists.return_value = True
+        mock_get_url.return_value = "ext::podman exec -i paude-test %S /pvc/workspace"
         mock_fetch.return_value = True
         mock_diff.return_value = " 2 files changed\n"
         # checkout -B succeeds
@@ -121,17 +144,17 @@ class TestHarvestSession:
             harvest_session("test", "my-branch")
 
     @patch("paude.git_remote.git_fetch_from_remote")
-    @patch("paude.git_remote.list_paude_remotes")
+    @patch("paude.git_remote.git_remote_exists")
     @patch("paude.cli.find_session_backend")
     def test_harvest_fetch_failure(
         self,
         mock_find: MagicMock,
-        mock_list: MagicMock,
+        mock_exists: MagicMock,
         mock_fetch: MagicMock,
         tmp_path: Path,
     ) -> None:
         self._setup_mocks(mock_find, tmp_path)
-        mock_list.return_value = [("paude-test", "ext::...")]
+        mock_exists.return_value = True
         mock_fetch.return_value = False
 
         with pytest.raises(click.exceptions.Exit):
@@ -140,19 +163,19 @@ class TestHarvestSession:
     @patch("paude.workflow.subprocess.run")
     @patch("paude.git_remote.git_diff_stat")
     @patch("paude.git_remote.git_fetch_from_remote")
-    @patch("paude.git_remote.list_paude_remotes")
+    @patch("paude.git_remote.git_remote_exists")
     @patch("paude.cli.find_session_backend")
     def test_harvest_checkout_failure(
         self,
         mock_find: MagicMock,
-        mock_list: MagicMock,
+        mock_exists: MagicMock,
         mock_fetch: MagicMock,
         mock_diff: MagicMock,
         mock_run: MagicMock,
         tmp_path: Path,
     ) -> None:
         self._setup_mocks(mock_find, tmp_path)
-        mock_list.return_value = [("paude-test", "ext::...")]
+        mock_exists.return_value = True
         mock_fetch.return_value = True
 
         mock_run.return_value = CompletedProcess(
@@ -169,19 +192,22 @@ class TestHarvestSession:
     @patch("paude.workflow.subprocess.run")
     @patch("paude.git_remote.git_diff_stat")
     @patch("paude.git_remote.git_fetch_from_remote")
-    @patch("paude.git_remote.list_paude_remotes")
+    @patch("paude.git_remote.git_remote_get_url")
+    @patch("paude.git_remote.git_remote_exists")
     @patch("paude.cli.find_session_backend")
     def test_harvest_with_pr_uses_force_with_lease(
         self,
         mock_find: MagicMock,
-        mock_list: MagicMock,
+        mock_exists: MagicMock,
+        mock_get_url: MagicMock,
         mock_fetch: MagicMock,
         mock_diff: MagicMock,
         mock_run: MagicMock,
         tmp_path: Path,
     ) -> None:
         self._setup_mocks(mock_find, tmp_path)
-        mock_list.return_value = [("paude-test", "ext::...")]
+        mock_exists.return_value = True
+        mock_get_url.return_value = "ext::podman exec -i paude-test %S /pvc/workspace"
         mock_fetch.return_value = True
         mock_diff.return_value = " 2 files changed\n"
         # checkout -B, fetch origin, push, pr view
@@ -206,12 +232,14 @@ class TestHarvestSession:
     @patch("paude.workflow.subprocess.run")
     @patch("paude.git_remote.git_diff_stat")
     @patch("paude.git_remote.git_fetch_from_remote")
-    @patch("paude.git_remote.list_paude_remotes")
+    @patch("paude.git_remote.git_remote_get_url")
+    @patch("paude.git_remote.git_remote_exists")
     @patch("paude.cli.find_session_backend")
     def test_harvest_creates_pr_when_previous_merged(
         self,
         mock_find: MagicMock,
-        mock_list: MagicMock,
+        mock_exists: MagicMock,
+        mock_get_url: MagicMock,
         mock_fetch: MagicMock,
         mock_diff: MagicMock,
         mock_run: MagicMock,
@@ -219,7 +247,8 @@ class TestHarvestSession:
     ) -> None:
         """harvest creates a new PR when previous PR for branch was merged."""
         self._setup_mocks(mock_find, tmp_path)
-        mock_list.return_value = [("paude-test", "ext::...")]
+        mock_exists.return_value = True
+        mock_get_url.return_value = "ext::podman exec -i paude-test %S /pvc/workspace"
         mock_fetch.return_value = True
         mock_diff.return_value = " 2 files changed\n"
         # checkout -B, fetch origin, push, pr list (no open PRs), pr create
@@ -241,7 +270,7 @@ class TestHarvestSession:
     def _setup_auto_add_mocks(
         self,
         mock_find: MagicMock,
-        mock_list: MagicMock,
+        mock_exists: MagicMock,
         mock_ext_allowed: MagicMock,
         mock_resolve: MagicMock,
         tmp_path: Path,
@@ -249,7 +278,7 @@ class TestHarvestSession:
     ) -> None:
         """Set up mocks for the harvest auto-add-remote path (no remote yet)."""
         self._setup_mocks(mock_find, tmp_path)
-        mock_list.return_value = []
+        mock_exists.return_value = False
         mock_ext_allowed.return_value = True
         mock_resolve.return_value = resolve_return
 
@@ -274,12 +303,12 @@ class TestHarvestSession:
     @patch("paude.git_remote.is_container_running_podman")
     @patch("paude.git_remote.resolve_session_remote")
     @patch("paude.git_remote.is_ext_protocol_allowed")
-    @patch("paude.git_remote.list_paude_remotes")
+    @patch("paude.git_remote.git_remote_exists")
     @patch("paude.cli.find_session_backend")
     def test_harvest_auto_adds_remote(
         self,
         mock_find: MagicMock,
-        mock_list: MagicMock,
+        mock_exists: MagicMock,
         mock_ext_allowed: MagicMock,
         mock_resolve: MagicMock,
         mock_running: MagicMock,
@@ -295,7 +324,7 @@ class TestHarvestSession:
         """No existing remote: auto-add uses whatever URL resolve_session_remote returns."""
         self._setup_auto_add_mocks(
             mock_find,
-            mock_list,
+            mock_exists,
             mock_ext_allowed,
             mock_resolve,
             tmp_path,
@@ -312,18 +341,100 @@ class TestHarvestSession:
 
         harvest_session("test", "my-branch")
 
-        mock_remote_add.assert_called_once_with("paude-test", remote_url)
+        mock_remote_add.assert_called_once_with("paude-test", remote_url, cwd=tmp_path)
+
+    @patch("paude.workflow.subprocess.run")
+    @patch("paude.git_remote.git_diff_stat")
+    @patch("paude.git_remote.git_fetch_from_remote")
+    @patch("paude.git_remote.git_remote_add")
+    @patch("paude.git_remote.initialize_container_workspace")
+    @patch("paude.git_remote.is_container_running_podman")
+    @patch("paude.git_remote.resolve_session_remote")
+    @patch("paude.git_remote.is_ext_protocol_allowed")
+    @patch("paude.git_remote.git_remote_exists")
+    @patch("paude.cli.find_session_backend")
+    def test_harvest_rig_path_remote_and_repo(
+        self,
+        mock_find: MagicMock,
+        mock_exists: MagicMock,
+        mock_ext_allowed: MagicMock,
+        mock_resolve: MagicMock,
+        mock_running: MagicMock,
+        mock_init: MagicMock,
+        mock_remote_add: MagicMock,
+        mock_fetch: MagicMock,
+        mock_diff: MagicMock,
+        mock_run: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """--container-path/--remote/--repo target a rig, not the session defaults."""
+        mock_backend = self._setup_mocks(mock_find, tmp_path)
+        host_repo = tmp_path / "vllm_host"
+        host_repo.mkdir()
+        (host_repo / ".git").mkdir()
+
+        rig_url = "ext::podman exec -i paude-test %S /pvc/workspace/rigs/vllm"
+        mock_exists.return_value = False
+        mock_ext_allowed.return_value = True
+        mock_resolve.return_value = (rig_url, None)
+        mock_running.return_value = True
+        mock_init.return_value = True
+        mock_remote_add.return_value = True
+        mock_fetch.return_value = True
+        mock_diff.return_value = ""
+        mock_run.return_value = CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+
+        harvest_session(
+            "test",
+            "fix/foo",
+            container_path="/pvc/workspace/rigs/vllm",
+            remote_name="rig-vllm",
+            repo=str(host_repo),
+        )
+
+        host_repo = host_repo.resolve()
+        # container name stays paude-test; URL points at the rig path
+        mock_resolve.assert_called_once_with(
+            "test",
+            "paude-test",
+            "podman",
+            workspace_path="/pvc/workspace/rigs/vllm",
+        )
+        # branch query targets the rig path in the container
+        branch_cmd = mock_backend.exec_in_session.call_args[0][1]
+        assert branch_cmd == (
+            "git -C /pvc/workspace/rigs/vllm rev-parse --abbrev-ref HEAD"
+        )
+        # workspace init targets the rig path
+        assert mock_init.call_args.kwargs["workspace_path"] == (
+            "/pvc/workspace/rigs/vllm"
+        )
+        # remote added under the custom name, in the --repo host checkout
+        mock_remote_add.assert_called_once_with("rig-vllm", rig_url, cwd=host_repo)
+        # fetch + checkout run in the host checkout, using the custom remote
+        mock_fetch.assert_called_once_with("rig-vllm", cwd=host_repo)
+        checkout_args = mock_run.call_args[0][0]
+        assert checkout_args == [
+            "git",
+            "checkout",
+            "-B",
+            "fix/foo",
+            "rig-vllm/main",
+        ]
+        assert mock_run.call_args.kwargs["cwd"] == host_repo
 
     @patch("paude.git_remote.initialize_container_workspace")
     @patch("paude.git_remote.is_container_running_podman")
     @patch("paude.git_remote.resolve_session_remote")
     @patch("paude.git_remote.is_ext_protocol_allowed")
-    @patch("paude.git_remote.list_paude_remotes")
+    @patch("paude.git_remote.git_remote_exists")
     @patch("paude.cli.find_session_backend")
     def test_harvest_auto_add_fails_when_container_not_running(
         self,
         mock_find: MagicMock,
-        mock_list: MagicMock,
+        mock_exists: MagicMock,
         mock_ext_allowed: MagicMock,
         mock_resolve: MagicMock,
         mock_running: MagicMock,
@@ -333,7 +444,7 @@ class TestHarvestSession:
         """Auto-add raises instead of silently using an unreachable container."""
         self._setup_auto_add_mocks(
             mock_find,
-            mock_list,
+            mock_exists,
             mock_ext_allowed,
             mock_resolve,
             tmp_path,
@@ -350,12 +461,12 @@ class TestHarvestSession:
     @patch("paude.git_remote.is_container_running_podman")
     @patch("paude.git_remote.resolve_session_remote")
     @patch("paude.git_remote.is_ext_protocol_allowed")
-    @patch("paude.git_remote.list_paude_remotes")
+    @patch("paude.git_remote.git_remote_exists")
     @patch("paude.cli.find_session_backend")
     def test_harvest_auto_add_fails_when_init_workspace_fails(
         self,
         mock_find: MagicMock,
-        mock_list: MagicMock,
+        mock_exists: MagicMock,
         mock_ext_allowed: MagicMock,
         mock_resolve: MagicMock,
         mock_running: MagicMock,
@@ -365,7 +476,7 @@ class TestHarvestSession:
         """Auto-add raises instead of silently proceeding when init fails."""
         self._setup_auto_add_mocks(
             mock_find,
-            mock_list,
+            mock_exists,
             mock_ext_allowed,
             mock_resolve,
             tmp_path,
@@ -376,6 +487,154 @@ class TestHarvestSession:
 
         with pytest.raises(click.exceptions.Exit):
             harvest_session("test", "my-branch")
+
+    @patch("paude.workflow.subprocess.run")
+    @patch("paude.git_remote.git_diff_stat")
+    @patch("paude.git_remote.git_fetch_from_remote")
+    @patch("paude.git_remote.git_remote_get_url")
+    @patch("paude.git_remote.git_remote_exists")
+    @patch("paude.cli.find_session_backend")
+    def test_harvest_verifies_container_repo_first(
+        self,
+        mock_find: MagicMock,
+        mock_exists: MagicMock,
+        mock_get_url: MagicMock,
+        mock_fetch: MagicMock,
+        mock_diff: MagicMock,
+        mock_run: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Harvest checks the container path is a git repo before anything else."""
+        mock_backend = self._setup_mocks(mock_find, tmp_path)
+        mock_exists.return_value = True
+        mock_get_url.return_value = "ext::podman exec -i paude-test %S /pvc/workspace"
+        mock_fetch.return_value = True
+        mock_diff.return_value = ""
+        mock_run.return_value = CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+
+        harvest_session("test", "my-branch")
+
+        first_cmd = mock_backend.exec_in_session.call_args_list[0][0][1]
+        assert first_cmd == "git -C /pvc/workspace rev-parse --is-inside-work-tree"
+
+    @patch("paude.git_remote.git_remote_exists")
+    @patch("paude.cli.find_session_backend")
+    def test_harvest_rejects_nonexistent_container_path(
+        self,
+        mock_find: MagicMock,
+        mock_exists: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """A mistyped --container-path fails before any remote/init work."""
+        mock_backend = self._setup_mocks(mock_find, tmp_path)
+        mock_backend.exec_in_session.return_value = (128, "", "fatal: not a git repo")
+
+        with pytest.raises(click.exceptions.Exit):
+            harvest_session("test", "my-branch", container_path="/pvc/wrokspace")
+
+        # Bails out before touching remotes, so no stray repo is created.
+        mock_exists.assert_not_called()
+
+    @patch("paude.git_remote.git_remote_get_url")
+    @patch("paude.git_remote.git_remote_exists")
+    @patch("paude.cli.find_session_backend")
+    def test_harvest_rejects_remote_targeting_different_path(
+        self,
+        mock_find: MagicMock,
+        mock_exists: MagicMock,
+        mock_get_url: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Reusing a default remote for a different --container-path is refused."""
+        self._setup_mocks(mock_find, tmp_path)
+        mock_exists.return_value = True
+        mock_get_url.return_value = "ext::podman exec -i paude-test %S /pvc/workspace"
+
+        with pytest.raises(click.exceptions.Exit):
+            harvest_session("test", "my-branch", container_path="/pvc/other")
+
+        assert "different container path" in capsys.readouterr().err
+
+    @patch("paude.workflow.subprocess.run")
+    @patch("paude.git_remote.git_diff_stat")
+    @patch("paude.git_remote.git_fetch_from_remote")
+    @patch("paude.git_remote.git_remote_get_url")
+    @patch("paude.git_remote.git_remote_exists")
+    @patch("paude.cli.find_session_backend")
+    def test_harvest_reuses_remote_matching_path(
+        self,
+        mock_find: MagicMock,
+        mock_exists: MagicMock,
+        mock_get_url: MagicMock,
+        mock_fetch: MagicMock,
+        mock_diff: MagicMock,
+        mock_run: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """An existing remote pointing at the requested path is reused."""
+        self._setup_mocks(mock_find, tmp_path)
+        mock_exists.return_value = True
+        mock_get_url.return_value = "ext::podman exec -i paude-test %S /pvc/ws/rig"
+        mock_fetch.return_value = True
+        mock_diff.return_value = ""
+        mock_run.return_value = CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+
+        harvest_session("test", "my-branch", container_path="/pvc/ws/rig")
+
+        mock_fetch.assert_called_once_with("paude-test", cwd=tmp_path)
+
+
+class TestVerifyContainerRepo:
+    """Tests for _verify_container_repo."""
+
+    def test_passes_for_existing_repo(self) -> None:
+        mock_backend = MagicMock()
+        mock_backend.exec_in_session.return_value = (0, "true\n", "")
+
+        _verify_container_repo(mock_backend, "sess", "/pvc/workspace/rigs/vllm")
+
+        cmd = mock_backend.exec_in_session.call_args[0][1]
+        assert cmd == (
+            "git -C /pvc/workspace/rigs/vllm rev-parse --is-inside-work-tree"
+        )
+
+    def test_raises_for_missing_repo(self) -> None:
+        mock_backend = MagicMock()
+        mock_backend.exec_in_session.return_value = (128, "", "fatal: ...")
+
+        with pytest.raises(click.exceptions.Exit):
+            _verify_container_repo(mock_backend, "sess", "/pvc/typo")
+
+
+class TestRemoteTargetsContainerPath:
+    """Tests for _remote_targets_container_path."""
+
+    def test_matches_default_path(self) -> None:
+        assert _remote_targets_container_path(
+            "ext::podman exec -i paude-test %S /pvc/workspace", "/pvc/workspace"
+        )
+
+    def test_detects_mismatch(self) -> None:
+        assert not _remote_targets_container_path(
+            "ext::podman exec -i paude-test %S /pvc/workspace", "/pvc/other"
+        )
+
+    def test_matches_ssh_url(self) -> None:
+        assert _remote_targets_container_path(
+            "ext::ssh user@host docker exec -i paude-test %S /pvc/ws/rig",
+            "/pvc/ws/rig",
+        )
+
+    def test_non_paude_url_treated_as_match(self) -> None:
+        # Not a paude ext:: remote (no %S marker) → don't block it.
+        assert _remote_targets_container_path(
+            "git@github.com:user/repo.git", "/pvc/workspace"
+        )
 
 
 class TestStatusSessions:


### PR DESCRIPTION
paude harvest and paude-managed remotes previously addressed only a single repo at the hardcoded /pvc/workspace. A container holding more than one git repo (e.g. several checkouts under sub-paths) had no way to expose or harvest the individual repos.

Add generic --container-path/--remote/--repo options to paude harvest, and --container-path/--remote to paude remote add, so both commands can target an arbitrary repo path inside the container, a custom git remote name, and (for harvest) a specific host checkout. Every option defaults to today's values, so existing single-repo usage is unchanged. paude stays domain-agnostic: it only knows "a path" and "a remote name".

Thread workspace_path through resolve_session_remote and the container workspace-init/base-ref builders, and add a cwd argument to the ext:: protocol and remote-add helpers so harvest can operate on a host repo other than the process directory. Replace the paude- prefix remote scan with a git_remote_exists lookup so custom remote names are detected.