### PR TITLE
Install codex-code-mode-host companion binary

### DIFF
--- a/src/paude/agents/codex.py
+++ b/src/paude/agents/codex.py
@@ -25,7 +25,21 @@ _INSTALL_SCRIPT = (
     '"https://github.com/openai/codex/releases/latest/download/'
     'codex-${CODEX_ARCH}.tar.gz"'
     ' | tar xz -C "$HOME/.local/bin" "codex-${CODEX_ARCH}" && '
-    'mv "$HOME/.local/bin/codex-${CODEX_ARCH}" "$HOME/.local/bin/codex"'
+    'mv "$HOME/.local/bin/codex-${CODEX_ARCH}" "$HOME/.local/bin/codex" && '
+    # Recent Codex releases spawn a companion "code-mode host" binary via an
+    # absolute path next to the codex binary for every tool call. Install it
+    # alongside codex from the same (latest) release so the versioned handshake
+    # matches and tool calls work out of the box.
+    "curl -fsSL "
+    '"https://github.com/openai/codex/releases/latest/download/'
+    'codex-code-mode-host-${CODEX_ARCH}.tar.gz"'
+    ' | tar xz -C "$HOME/.local/bin" "codex-code-mode-host-${CODEX_ARCH}" && '
+    'mv "$HOME/.local/bin/codex-code-mode-host-${CODEX_ARCH}" '
+    '"$HOME/.local/bin/codex-code-mode-host" && '
+    # The build only verifies the primary codex binary (pipefail_install_lines),
+    # so verify the companion here too — a missing companion fails every tool
+    # call at runtime, the exact failure this install is meant to prevent.
+    'test -x "$HOME/.local/bin/codex-code-mode-host"'
 )
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -508,6 +508,12 @@ class TestCodexAgentConfig:
         cfg = CodexAgent().config
         assert "releases/latest/download" in cfg.install_script
 
+    def test_install_script_includes_code_mode_host(self) -> None:
+        cfg = CodexAgent().config
+        assert "codex-code-mode-host-${CODEX_ARCH}.tar.gz" in cfg.install_script
+        assert '"$HOME/.local/bin/codex-code-mode-host"' in cfg.install_script
+        assert 'test -x "$HOME/.local/bin/codex-code-mode-host"' in cfg.install_script
+
     def test_config_dir_name(self) -> None:
         assert CodexAgent().config.config_dir_name == ".codex"
 


### PR DESCRIPTION
Codex CLI v0.147.0+ spawns a companion binary, codex-code-mode-host, via an absolute path next to the codex binary for every tool call on recent code-mode models. When it is missing, Codex starts fine but every tool call fails with "failed to spawn code-mode host". Because the path is absolute, adding it elsewhere on PATH does not help.

paude installed only the bare codex binary, so tool calls failed until the helper was manually curled into place after each rebuild. Extend the Codex install script to download the companion from the same latest release (keeping the versioned handshake matched), extract and rename it next to codex, and verify it is executable -- the shared install helper only checks the primary binary.