### PR TITLE
Add agents and swap providers via paude upgrade

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -56,6 +56,19 @@ The same "parse a `user@host[:port]` string with `parse_ssh_host()`, then constr
 
 The third occurrence was added while fixing SEC-003 rather than reusing `_build_transport()`, because `_build_transport()` lives in `src/paude/cli/` and importing it from `src/paude/git_remote/` (a lower-level package) would invert the existing dependency direction. Consolidating all three requires first giving this logic a home that both `cli/` and `git_remote/`/`backends/` can depend on without a layering inversion (e.g. a small helper in `src/paude/transport/ssh.py` itself, alongside `parse_ssh_host()`). Until then, any change to `SshTransport`'s constructor or `parse_ssh_host()`'s contract needs to be checked against all three call sites.
 
+### REFACTOR-006: Credential-provider reconciliation duplicated between upgrade and resolver
+
+**Status**: Open
+**Priority**: Low (drift-prone; identical user-facing error string in two places)
+**Discovered**: 2026-08-08 during a cleanup review of the `paude upgrade --add-agent` work
+
+`_apply_overrides()` in `src/paude/cli/upgrade.py` and `_resolve_agents_and_providers()` in `src/paude/config/resolver.py` independently implement the same "reconcile credential providers against the agent→provider mapping" logic:
+
+1. Deriving the mapped-provider set from a composition (`mapped_providers = list(dict.fromkeys(a.config.provider for a in composition.agents if a.config.provider))` in `upgrade.py` vs `_dedupe(provider for _, provider in result.agent_providers)` at `resolver.py:315`). The same idiom also appears as the fallback in `get_session_credential_providers()` at `src/paude/backends/podman/helpers.py:306-312`.
+2. Validating an explicit `--providers` set covers every mapped provider, including the **verbatim** error string `"Credential providers must include every mapped provider; missing: "` (`upgrade.py` ↔ `resolver.py:324`).
+
+This predates the `--add-agent` work (the `--providers` validation branch was already in `upgrade.py`); the cleanup pass left it in place because a proper fix reaches outside the changed code and is entangled with the resolver's `SettingValue`/provenance tracking. Consider extracting a shared `reconcile_credential_providers(agent_providers, explicit_providers) -> list[str]` (plus a `providers_from_composition(composition)` helper) next to `_derive_agent_providers` in `resolver.py`, and calling it from both `create` and `upgrade` so the invariant and error wording can't drift.
+
 ## Correctness Backlog
 
 Lower-severity correctness/robustness issues surfaced during code review.
@@ -75,6 +88,27 @@ Lower-severity correctness/robustness issues surfaced during code review.
 **Discovered**: 2026-08-07 during code review of the `--container-path`/`--repo` harvest work
 
 `build_podman_remote_url()` / `build_ssh_remote_url()` in `src/paude/git_remote/utils.py` interpolate `workspace_path` into the remote URL as `ext::… %S <workspace_path>`. Git's `ext::` helper splits its command line on whitespace and `exec`s the program directly (no shell is involved, so shell metacharacters are *not* an injection vector), but a `workspace_path` containing spaces would be word-split into separate argv entries and every fetch/push would fail. Now that `--container-path` accepts arbitrary paths (previously always the space-free `/pvc/workspace`), this is reachable, though container paths with spaces are highly unusual. Note that shell-quoting does not help here — there is no shell — so a fix would need `ext::`'s own (limited) escaping or a validation/rejection of whitespace in container paths.
+
+### UPGRADE-001: pure provider remap prunes deliberately-provisioned credential-only providers
+
+**Status**: Open
+**Severity**: Low
+**Discovered**: 2026-08-08 during code review of the `paude upgrade --add-agent` work
+
+`_apply_overrides()` in `src/paude/cli/upgrade.py` treats a *pure* remap
+(`--provider NEW` / `--agent-provider AGENT=NEW` with no `--add-agent`/`--agents`)
+by replacing the credential set with only the providers still referenced by an
+agent (the `elif remap` branch). This correctly drops the swapped agent's *old*
+provider (the intended "swap in place" behavior asserted by
+`test_swap_codex_provider_in_place`), but it also drops any **other**
+credential-only provider that was deliberately provisioned and is not mapped to a
+current agent (e.g. `--provider vertex` on a session created with
+`--providers vertex,openai` where `openai` was reserved for later use). The
+combined add+remap path was fixed to union instead (so it preserves such
+providers), but the pure-remap path still over-prunes because it cannot
+distinguish "displaced by this swap" from "provisioned on purpose." A fix would
+track which provider each remap displaces and prune only that, rather than
+pruning every unreferenced provider.
 
 ## Agent Limitations
 
@@ -178,6 +212,53 @@ The failure is timing/resource-contention related (SIGTERM delivery and socket
 teardown racing under concurrent full-suite load), not a product defect. Consider
 adding an explicit wait/retry on the shutdown assertion or isolating the test's
 port/socket allocation so it is deterministic under load.
+
+### TEST-003: No integration coverage for in-place agent-set / provider upgrades
+
+**Status**: Open (investigation task)
+**Priority**: Medium
+**Discovered**: 2026-08-08 while adding `--add-agent`/`--agents` to `paude upgrade`
+
+The new `paude upgrade` agent-set and provider-swap paths are covered by unit
+tests in `tests/test_upgrade.py` (`TestUpgradePodmanAddAgent`), but those mock
+the image build, container recreation, and start — so the *end-to-end* behavior
+is unverified: that a rebuilt image actually installs the added agent's binaries
+(e.g. `codex` + `codex-code-mode-host`), that `configure_codex` rewrites
+`config.toml` / clears `auth.json` on a chatgpt→openai swap at start, that the
+`/pvc` volume and existing agent state survive, and that labels/registry reflect
+the new set on a live container. These require a real container engine and only
+run in CI (`tests/integration/`, gated by the `integration`/`podman` markers;
+see `make test-integration` / `make test-podman`). Investigate what the existing
+podman integration suite covers for `upgrade` and add scenarios for: adding an
+agent in place, swapping a provider in place, and verifying persisted state is
+retained across the rebuild. (These cannot be run in the sandboxed dev
+environment — no container engine — so they must be authored against CI.)
+
+## Feature Backlog
+
+### FEATURE-001: `paude upgrade` cannot remove agents (only add)
+
+**Status**: Open (deferred follow-up)
+**Priority**: Low
+**Discovered**: 2026-08-08 while adding `--add-agent`/`--agents` to `paude upgrade`
+
+`paude upgrade` can now add agents to an existing session in place
+(`--add-agent AGENT`, or `--agents A,B` to redefine/reorder the set), but it
+cannot *remove* an agent. `_apply_overrides()` in `src/paude/cli/upgrade.py`
+rejects any `--agents` set that drops a currently-installed agent. Removal was
+deferred because it needs decisions/guards that additive changes don't:
+
+- Forbid removing the current primary agent (or require reassigning it), and
+  forbid emptying the agent set entirely.
+- Decide what happens to the removed agent's persisted state on `/pvc` (e.g.
+  `.codex`, `.agents`). `persistent_state_paths()` in
+  `src/paude/cli/upgrade_persistence.py` only enumerates agents still in the
+  composition, so a removed agent's directory is left orphaned (harmless but
+  confusing) rather than cleaned up.
+
+Implement a `--remove-agent AGENT` option (additive delta, symmetric with
+`--add-agent`) that enforces the guards above and decides the orphaned-state
+policy.
 
 ## Documentation Gaps
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,25 @@ Pass `--provider openai` to use the plain `OPENAI_API_KEY` provider instead
 — no ChatGPT plan, no proxy-managed auth. The default Codex network policy
 allows `chatgpt.com` and `auth.openai.com` for the ChatGPT API and OAuth
 exchange.
+
+You can also switch an **existing** session's Codex auth in place with
+`paude upgrade` — no need to recreate it. Use `--agent-provider` to remap
+Codex's provider (or `--provider` if Codex is the session's primary agent):
+
+```bash
+# Swap Codex from ChatGPT-plan OAuth to the OpenAI API key
+export OPENAI_API_KEY=your-api-key
+paude upgrade my-project --agent-provider codex=openai
+```
+
+Export `OPENAI_API_KEY` **before** upgrading: it is read from your host
+environment and injected into the session's proxy (the same key must be present
+on later `start`/`connect`). The upgrade drops the `chatgpt` credential
+provider, clears the old ChatGPT `auth.json`, and reconfigures Codex's
+`config.toml` for the OpenAI API. To go back, run
+`paude upgrade my-project --agent-provider codex=chatgpt` and `codex login`
+inside the session again.
+
 Paude merges the required HTTP/SSE provider settings into the session's
 persistent Codex `config.toml` because the local MITM proxy does not support
 the Responses WebSocket transport. Existing model, MCP, project trust, and
@@ -191,7 +210,8 @@ The command performs a fresh build with the latest stable agent tooling and
 migrates state from older containers before replacing them. Upgrades are
 crash-safe: your `/pvc` data volume is reused in place and never removed, and if
 an upgrade is interrupted (e.g. `Ctrl-C`) you can simply re-run
-`paude upgrade SESSION` to finish it. See
+`paude upgrade SESSION` to finish it. `upgrade` can also add an agent to an
+existing session in place, e.g. `paude upgrade SESSION --add-agent codex`. See
 [Session Management](docs/SESSIONS.md) for the per-agent persistence paths.
 
 ### Your First Session

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -144,6 +144,13 @@ paude create --dry-run
 
 > **Backend values**: `podman` (default) or `docker`.
 
+> **Adding agents after create**: the agent set is normally fixed at create time,
+> but `paude upgrade` can add agents to an existing session in place with
+> `--add-agent AGENT` (additive; keeps the current primary) or `--agents A,B`
+> (redefines the full set; first is primary; removal not yet supported). Combine
+> with `--agent-provider AGENT=PROVIDER` to set a new agent's provider; its
+> provider is added to the session's credential set automatically.
+
 > **Platform auto-detection**: when unset, paude auto-detects the target architecture — the remote host's architecture (via SSH) when `--host` is used, otherwise the local machine's. Use `--platform` (e.g. `linux/amd64`, `linux/arm64`) to override.
 
 ## Network Domains

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -21,7 +21,7 @@ paude
 | `stop` | Stops the container, preserves the volume |
 | `connect` | Attaches to running session |
 | `cp` | Copies files between local machine and session |
-| `upgrade` | Pulls current bases, rebuilds with the latest stable agent tooling, and recreates the session while preserving workspace and agent state; can also reconfigure options (`--otel-endpoint`, `--allowed-domains`, `--gpu`/`--no-gpu`, `--yolo`/`--no-yolo`, `--provider`) |
+| `upgrade` | Pulls current bases, rebuilds with the latest stable agent tooling, and recreates the session while preserving workspace and agent state; can also add agents (`--add-agent`, `--agents`) and reconfigure options (`--otel-endpoint`, `--allowed-domains`, `--gpu`/`--no-gpu`, `--yolo`/`--no-yolo`, `--provider`) |
 | `remote` | Manages git remotes for code sync |
 | `delete` | Removes all resources including volume |
 | `list` | Shows all sessions with version info |
@@ -60,6 +60,9 @@ pip install --upgrade paude
 paude list                         # Shows version and outdated indicator (*)
 paude upgrade my-project           # Rebuilds image, preserves all data
 
+# Add another agent to an existing session (preserves all data)
+paude upgrade my-project --add-agent codex
+
 # Delete session completely
 paude delete my-project --confirm
 
@@ -76,6 +79,32 @@ mutable state in addition to `/pvc/workspace`.
 
 The legacy `--rebuild` option is still accepted for compatibility, but is no
 longer necessary because upgrades always rebuild.
+
+### Adding agents to an existing session
+
+`upgrade` can add agents to a session that was created with a smaller set,
+without recreating it or losing the workspace and existing agent state:
+
+```bash
+# Add a codex agent to a session that only had claude
+paude upgrade my-project --add-agent codex
+
+# Pick the new agent's inference provider (default for codex is chatgpt)
+paude upgrade my-project --add-agent codex --agent-provider codex=openai
+
+# Redefine the full agent set (first is primary); can reorder to change which
+# agent launches by default
+paude upgrade my-project --agents claude,codex
+```
+
+`--add-agent` appends agents and always keeps the current primary agent (the one
+that launches by default). `--agents` redefines the whole set and makes the first
+entry primary; in this release it must still include every installed agent
+(removing agents is not yet supported). A newly added agent's provider defaults to
+that agent's usual provider unless you override it with `--agent-provider`; the
+provider is added to the session's credential set automatically. Provider logins
+that happen inside the container (for example codex's ChatGPT OAuth) still need to
+be completed on first use of the new agent.
 
 ### Crash-safe, resumable upgrades
 

--- a/src/paude/cli/help.py
+++ b/src/paude/cli/help.py
@@ -52,6 +52,10 @@ _SECTIONS: tuple[HelpSection, ...] = (
                 "paude upgrade NAME",
                 "Refresh agent tooling, preserving data; resumable if interrupted",
             ),
+            (
+                "paude upgrade NAME --add-agent codex",
+                "Add an agent to an existing session (preserves data)",
+            ),
             ("paude delete NAME --confirm", "Delete session permanently"),
             ("paude delete NAME --confirm --force", "Remove from local config only"),
         ),

--- a/src/paude/cli/upgrade.py
+++ b/src/paude/cli/upgrade.py
@@ -31,6 +31,8 @@ class UpgradeOverrides:
     provider: str | None = None
     providers: list[str] | None = None
     agent_providers: dict[str, str] | None = None
+    add_agents: list[str] | None = None  # additive: append, keep primary
+    agents: list[str] | None = None  # full-set replacement (first = primary)
 
     def has_changes(self) -> bool:
         """Return True if any override was specified."""
@@ -42,6 +44,8 @@ class UpgradeOverrides:
             or self.provider is not None
             or self.providers is not None
             or self.agent_providers is not None
+            or self.add_agents is not None
+            or self.agents is not None
         )
 
 
@@ -137,12 +141,42 @@ def session_upgrade(
             help="Replace mappings using AGENT=PROVIDER entries.",
         ),
     ] = None,
+    add_agent: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--add-agent",
+            help=(
+                "Add one or more agents to the session (comma-separated and/or "
+                "repeatable), e.g. --add-agent codex. The primary agent is "
+                "unchanged; already-present agents are ignored."
+            ),
+        ),
+    ] = None,
+    agent: Annotated[
+        str | None,
+        typer.Option(
+            "--agent",
+            help="Redefine the session's single agent (alias for --agents X).",
+        ),
+    ] = None,
+    agents: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--agents",
+            help=(
+                "Redefine the full agent set (comma-separated and/or repeatable); "
+                "the first is primary. Must include every installed agent "
+                "(removing agents is not yet supported)."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Upgrade a session to the current paude version.
 
-    Can also reconfigure session options (e.g., --otel-endpoint, --gpu)
-    without losing workspace or agent data. Upgrades always pull and rebuild
-    agent tooling, including when the Paude version is unchanged.
+    Can also reconfigure session options (e.g., --otel-endpoint, --gpu) and add
+    agents (--add-agent, --agents) without losing workspace or agent data.
+    Upgrades always pull and rebuild agent tooling, including when the Paude
+    version is unchanged.
     """
     from paude import __version__
     from paude.backends.podman.backend import PodmanBackend
@@ -174,6 +208,18 @@ def session_upgrade(
         typer.echo("Error: Specify --provider or --agent-provider, not both.", err=True)
         raise typer.Exit(1)
 
+    # Resolve the agent-set options. --agent is a one-item alias for --agents.
+    cli_add_agents = _split_list_option(add_agent)
+    if agent is not None and agents is not None:
+        typer.echo("Error: Specify --agent or --agents, not both.", err=True)
+        raise typer.Exit(1)
+    cli_agents = _split_list_option([agent] if agent is not None else agents)
+    if cli_add_agents is not None and cli_agents is not None:
+        typer.echo(
+            "Error: Specify --add-agent or --agent/--agents, not both.", err=True
+        )
+        raise typer.Exit(1)
+
     overrides = UpgradeOverrides(
         otel_endpoint=otel_endpoint,
         allowed_domains=allowed_domains,
@@ -182,7 +228,32 @@ def session_upgrade(
         provider=provider,
         providers=_split_list_option(providers),
         agent_providers=cli_agent_providers,
+        add_agents=cli_add_agents,
+        agents=cli_agents,
     )
+
+    # Validate agent/provider names up front, before finding the session or
+    # stopping a running container, so a typo (e.g. --add-agent coddex) fails
+    # fast instead of tearing down the session and leaving it stopped with no
+    # manifest to resume. Reuse the registry lookups so the error text matches
+    # the deeper validation. Agent/provider *compatibility* is still checked
+    # later, once the composition is resolved.
+    from paude.agents import get_agent
+    from paude.providers import get_provider
+
+    try:
+        for agent_name in (cli_add_agents or []) + (cli_agents or []):
+            get_agent(agent_name)
+        provider_names = list(overrides.providers or [])
+        if provider is not None:
+            provider_names.append(provider)
+        if cli_agent_providers is not None:
+            provider_names.extend(cli_agent_providers.values())
+        for provider_name in provider_names:
+            get_provider(provider_name)
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1) from None
 
     from paude import upgrade_state
 
@@ -389,41 +460,74 @@ def _resolve_base_from_manifest(manifest: UpgradeManifest) -> _ResolvedUpgrade:
 
 
 def _apply_overrides(state: _ResolvedUpgrade, overrides: UpgradeOverrides) -> None:
-    """Apply CLI overrides to a resolved config in place, normalising provider."""
+    """Apply CLI overrides to a resolved config in place, normalising provider.
+
+    Agent-set changes (``--add-agent`` / ``--agents``) and provider remappings
+    (``--provider`` / ``--agent-provider``) funnel through a single composition
+    rebuild: a target name list is derived first, then a provider mapping seeded
+    from the existing per-agent providers and overlaid with CLI overrides, then
+    :func:`~paude.config.resolver._derive_agent_providers` validates and fills
+    defaults for any newly-added agent.
+    """
     from paude.agents import get_agents
+    from paude.config.resolver import _derive_agent_providers
 
-    if overrides.provider is not None:
-        state.provider_name = overrides.provider
-        specs = [
-            (item.config.name, item.config.provider or "")
-            for item in state.composition.agents
-        ]
-        specs[0] = (specs[0][0], state.provider_name)
-        state.composition = get_agents(
-            [agent for agent, _provider in specs],
-            providers={agent: provider for agent, provider in specs if provider},
-            include_bundled=False,
-        )
-    elif overrides.agent_providers is not None:
-        installed = [item.config.name for item in state.composition.agents]
-        unknown = [a for a in overrides.agent_providers if a not in installed]
-        if unknown:
+    existing_specs = [
+        (item.config.name, item.config.provider or "")
+        for item in state.composition.agents
+    ]
+    existing_names = [name for name, _provider in existing_specs]
+
+    if overrides.agents is not None:
+        # Full-set redefinition (first = primary). Removal is not yet supported,
+        # so the new set must retain every currently-installed agent.
+        target_names = list(dict.fromkeys(overrides.agents))
+        dropped = [name for name in existing_names if name not in target_names]
+        if dropped:
             raise ValueError(
-                "Provider mappings reference agents that are not installed: "
-                + ", ".join(unknown)
+                "Removing agents is not yet supported. --agents must include all "
+                f"installed agents ({', '.join(existing_names)}). "
+                "Use --add-agent to add agents."
             )
+    elif overrides.add_agents:
+        # Additive: preserve the existing order (and primary), append new agents.
+        target_names = list(existing_names)
+        for agent in overrides.add_agents:
+            if agent not in target_names:
+                target_names.append(agent)
+    else:
+        target_names = list(existing_names)
+
+    # Seed the provider mapping from current per-agent providers, then overlay
+    # CLI overrides so existing agents keep their resolved provider unless the
+    # user remaps them. Every existing agent is always in target_names (add
+    # appends to them; replace must retain them), so no membership filter is
+    # needed here.
+    mappings = {name: provider for name, provider in existing_specs if provider}
+    if overrides.provider is not None:
+        mappings[target_names[0]] = overrides.provider
+    if overrides.agent_providers is not None:
+        mappings.update(overrides.agent_providers)
+
+    remap = overrides.provider is not None or overrides.agent_providers is not None
+    agent_set_changed = overrides.agents is not None or bool(overrides.add_agents)
+    if remap or agent_set_changed:
+        # _derive_agent_providers validates every agent name and agent/provider
+        # combination, fills unmapped (e.g. newly-added) agents with their
+        # DEFAULT_PROVIDER, and raises "not installed" only for mappings that
+        # reference agents outside target_names — so a legitimately-added agent
+        # is accepted, while --agent-provider codex=... without --add-agent still
+        # correctly rejects codex.
+        agent_providers = _derive_agent_providers(target_names, mappings)
         state.composition = get_agents(
-            installed,
-            providers=overrides.agent_providers,
+            target_names,
+            providers=dict(agent_providers),
             include_bundled=False,
         )
 
-    mappings_changed = (
-        overrides.provider is not None or overrides.agent_providers is not None
-    )
     mapped_providers = list(
         dict.fromkeys(
-            item.config.provider or ""
+            item.config.provider
             for item in state.composition.agents
             if item.config.provider
         )
@@ -444,9 +548,24 @@ def _apply_overrides(state: _ResolvedUpgrade, overrides: UpgradeOverrides) -> No
                 "Credential providers must include every mapped provider; missing: "
                 + ", ".join(missing)
             )
-    elif mappings_changed:
+    elif agent_set_changed:
+        # Agent-set change (add, or reorder/redefine), possibly combined with a
+        # remap: union the composition's providers onto the existing credential
+        # set so a previously-provisioned provider is preserved. Checked before
+        # `remap` so the documented "add + set provider" workflow
+        # (--add-agent X --agent-provider X=P) does not drop credential-only
+        # providers.
+        state.credential_providers = list(
+            dict.fromkeys([*state.credential_providers, *mapped_providers])
+        )
+    elif remap:
+        # Pure remap (no agent-set change): replace the credential set with the
+        # mapped set, dropping any provider no longer referenced by an agent.
         state.credential_providers = mapped_providers
 
+    # Keep the primary-agent scalars in sync with the (possibly reordered or
+    # extended) composition, so a changed primary is reflected in labels/env.
+    state.agent_name = state.composition.primary.config.name
     state.provider_name = state.composition.primary.config.provider
     if overrides.gpu is not None:
         state.gpu = overrides.gpu if overrides.gpu != "" else None

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -12,10 +12,12 @@ from typer.testing import CliRunner
 from paude.backends.base import Session
 from paude.backends.labels import (
     PAUDE_LABEL_AGENT,
+    PAUDE_LABEL_AGENT_PROVIDERS,
     PAUDE_LABEL_CREATED,
     PAUDE_LABEL_DOMAINS,
     PAUDE_LABEL_GPU,
     PAUDE_LABEL_OTEL_ENDPOINT,
+    PAUDE_LABEL_PROVIDERS,
     PAUDE_LABEL_PROXY_IMAGE,
     PAUDE_LABEL_SESSION,
     PAUDE_LABEL_WORKSPACE,
@@ -160,6 +162,152 @@ class TestUpgradeCommand:
             "claude": "anthropic",
             "codex": "openai",
         }
+
+    def _mock_podman_backend(self, mock_find: MagicMock) -> MagicMock:
+        """Wire find_session_backend to return a stopped 0.1.0 podman session."""
+        from paude.backends.podman.backend import PodmanBackend
+
+        backend = MagicMock()
+        backend.get_session.return_value = _make_session(
+            "test-session", version="0.1.0"
+        )
+        backend.__class__ = PodmanBackend
+        mock_find.return_value = ("podman", backend)
+        return backend
+
+    @patch("paude.cli.upgrade._upgrade_podman")
+    @patch("paude.cli.upgrade.find_session_backend")
+    def test_upgrade_add_agent_sets_override(
+        self, mock_find: MagicMock, mock_upgrade_podman: MagicMock
+    ) -> None:
+        self._mock_podman_backend(mock_find)
+
+        result = runner.invoke(app, ["upgrade", "test-session", "--add-agent", "codex"])
+
+        assert result.exit_code == 0
+        overrides = mock_upgrade_podman.call_args.args[3]
+        assert overrides.add_agents == ["codex"]
+        assert overrides.agents is None
+
+    @patch("paude.cli.upgrade._upgrade_podman")
+    @patch("paude.cli.upgrade.find_session_backend")
+    def test_upgrade_add_agent_comma_and_repeatable(
+        self, mock_find: MagicMock, mock_upgrade_podman: MagicMock
+    ) -> None:
+        self._mock_podman_backend(mock_find)
+
+        result = runner.invoke(
+            app,
+            ["upgrade", "test-session", "--add-agent", "codex,cursor"],
+        )
+        assert result.exit_code == 0
+        assert mock_upgrade_podman.call_args.args[3].add_agents == ["codex", "cursor"]
+
+        result = runner.invoke(
+            app,
+            [
+                "upgrade",
+                "test-session",
+                "--add-agent",
+                "codex",
+                "--add-agent",
+                "cursor",
+            ],
+        )
+        assert result.exit_code == 0
+        assert mock_upgrade_podman.call_args.args[3].add_agents == ["codex", "cursor"]
+
+    @patch("paude.cli.upgrade._upgrade_podman")
+    @patch("paude.cli.upgrade.find_session_backend")
+    def test_upgrade_agents_full_set_and_agent_alias(
+        self, mock_find: MagicMock, mock_upgrade_podman: MagicMock
+    ) -> None:
+        self._mock_podman_backend(mock_find)
+
+        result = runner.invoke(
+            app, ["upgrade", "test-session", "--agents", "claude,codex"]
+        )
+        assert result.exit_code == 0
+        assert mock_upgrade_podman.call_args.args[3].agents == ["claude", "codex"]
+
+        result = runner.invoke(app, ["upgrade", "test-session", "--agent", "codex"])
+        assert result.exit_code == 0
+        assert mock_upgrade_podman.call_args.args[3].agents == ["codex"]
+
+    def test_upgrade_add_agent_conflicts_with_agents(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "upgrade",
+                "test-session",
+                "--add-agent",
+                "codex",
+                "--agents",
+                "claude,codex",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "--add-agent or --agent/--agents" in result.output
+
+    def test_upgrade_agent_conflicts_with_agents(self) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "upgrade",
+                "test-session",
+                "--agent",
+                "claude",
+                "--agents",
+                "claude,codex",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "--agent or --agents" in result.output
+
+    @patch("paude.cli.upgrade._upgrade_podman")
+    @patch("paude.cli.upgrade.find_session_backend")
+    def test_upgrade_unknown_add_agent_fails_before_stop(
+        self, mock_find: MagicMock, mock_upgrade_podman: MagicMock
+    ) -> None:
+        """A typo'd agent name is rejected before the container is stopped."""
+        mock_backend = MagicMock()
+        mock_backend.get_session.return_value = _make_session(
+            "test-session", status="running", version="0.1.0"
+        )
+        from paude.backends.podman.backend import PodmanBackend
+
+        mock_backend.__class__ = PodmanBackend
+        mock_find.return_value = ("podman", mock_backend)
+
+        result = runner.invoke(
+            app, ["upgrade", "test-session", "--add-agent", "coddex"]
+        )
+
+        assert result.exit_code == 1
+        assert "Unknown agent" in result.output
+        # The running session must not be torn down for an obvious typo.
+        mock_backend.stop_session.assert_not_called()
+        mock_upgrade_podman.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("extra_args", "expected"),
+        [
+            (["--add-agent", "coddex"], "Unknown agent"),
+            (["--agents", "claude,bogus"], "Unknown agent"),
+            (["--agent", "nope"], "Unknown agent"),
+            (["--provider", "nope"], "Unknown provider"),
+            (["--providers", "nope"], "Unknown provider"),
+            (["--agent-provider", "claude=nope"], "Unknown provider"),
+        ],
+    )
+    def test_upgrade_rejects_unknown_names(
+        self, extra_args: list[str], expected: str
+    ) -> None:
+        """Unknown agent/provider names fail fast with a clear message."""
+        result = runner.invoke(app, ["upgrade", "test-session", *extra_args])
+
+        assert result.exit_code == 1
+        assert expected in result.output
 
 
 class TestUpgradePodman:
@@ -1120,6 +1268,14 @@ class TestUpgradeOverrides:
         overrides = UpgradeOverrides(gpu="")
         assert overrides.has_changes() is True
 
+    def test_has_changes_add_agents(self) -> None:
+        overrides = UpgradeOverrides(add_agents=["codex"])
+        assert overrides.has_changes() is True
+
+    def test_has_changes_agents(self) -> None:
+        overrides = UpgradeOverrides(agents=["claude", "codex"])
+        assert overrides.has_changes() is True
+
 
 class TestUpgradePodmanWithOverrides:
     """Tests for _upgrade_podman with config overrides."""
@@ -1348,3 +1504,202 @@ class TestUpgradePodmanWithOverrides:
 
         config = backend.create_session.call_args[0][0]
         assert config.gpu is None
+
+
+class TestUpgradePodmanAddAgent:
+    """Tests for _upgrade_podman agent-set and provider mutation.
+
+    Covers ``--add-agent`` / ``--agents`` (agent-set changes) and
+    ``--provider`` / ``--agent-provider`` (provider swaps) on an existing
+    session, exercised through a single mocked ``_upgrade_podman`` harness.
+    """
+
+    def _labels(
+        self,
+        specs: list[tuple[str, str]] | None = None,
+        agent: str = "claude",
+        providers: list[str] | None = None,
+    ) -> dict[str, str]:
+        """Container labels for a session, optionally with a full composition.
+
+        ``providers`` seeds the credential-provider label (used to model a
+        provider that is provisioned for the session but not mapped to any agent).
+        """
+        from paude.backends.podman.helpers import (
+            encode_agent_providers,
+            encode_providers,
+        )
+
+        labels: dict[str, str] = {
+            PAUDE_LABEL_AGENT: agent,
+            PAUDE_LABEL_WORKSPACE: encode_path(
+                Path("/home/user/project"), url_safe=True
+            ),
+            PAUDE_LABEL_SESSION: "test-session",
+            PAUDE_LABEL_CREATED: "2026-01-01T00:00:00+00:00",
+        }
+        if specs is not None:
+            labels[PAUDE_LABEL_AGENT_PROVIDERS] = encode_agent_providers(specs)
+        if providers is not None:
+            labels[PAUDE_LABEL_PROVIDERS] = encode_providers(providers)
+        return labels
+
+    def _run(self, labels: dict[str, str], overrides: UpgradeOverrides) -> object:
+        """Run _upgrade_podman with all I/O mocked; return the created config."""
+        from paude.backends.podman.backend import PodmanBackend
+        from paude.cli.upgrade import _upgrade_podman
+
+        with (
+            patch("paude.mounts.build_mounts", return_value=[]),
+            patch(
+                "paude.cli.helpers._prepare_session_create",
+                return_value=([], [], {}, False),
+            ),
+            patch("paude.container.ImageManager") as mock_image_manager_class,
+            patch("paude.config.detector.detect_config", return_value=None),
+            patch(
+                "paude.backends.podman.helpers.find_container_by_session_name",
+                return_value={"Labels": labels},
+            ),
+        ):
+            mock_image_manager = MagicMock()
+            mock_image_manager.ensure_default_image.return_value = "paude:latest"
+            mock_image_manager.ensure_proxy_image.return_value = "proxy:latest"
+            mock_image_manager_class.return_value = mock_image_manager
+
+            backend = MagicMock(spec=PodmanBackend)
+            backend._runner = MagicMock()
+            backend._runner.container_exists.return_value = False
+            backend._network_manager = MagicMock()
+            backend._volume_manager = MagicMock()
+            backend._engine = MagicMock()
+
+            _upgrade_podman("test-session", backend, rebuild=False, overrides=overrides)
+            return backend.create_session.call_args[0][0]
+
+    def test_add_agent_merges_composition_preserves_primary(self) -> None:
+        """--add-agent codex appends codex, keeping claude primary."""
+        config = self._run(self._labels(), UpgradeOverrides(add_agents=["codex"]))
+
+        assert config.agent == "claude"
+        assert config.agent_providers == [("claude", "vertex"), ("codex", "chatgpt")]
+        # The new agent's provider is unioned onto the existing credential set.
+        assert "vertex" in config.credential_providers
+        assert "chatgpt" in config.credential_providers
+
+    def test_add_agent_derives_provider_override(self) -> None:
+        """--agent-provider selects the added agent's provider."""
+        config = self._run(
+            self._labels(),
+            UpgradeOverrides(add_agents=["codex"], agent_providers={"codex": "openai"}),
+        )
+
+        assert ("codex", "openai") in config.agent_providers
+        assert "openai" in config.credential_providers
+
+    def test_add_existing_agent_is_noop(self) -> None:
+        """Re-adding the primary agent does not duplicate it."""
+        config = self._run(self._labels(), UpgradeOverrides(add_agents=["claude"]))
+
+        assert config.agent_providers == [("claude", "vertex")]
+
+    def test_add_agent_with_mapping_preserves_unmapped_credential(self) -> None:
+        """--add-agent X --agent-provider X=P keeps credential-only providers.
+
+        Regression: the combined add+remap workflow used to take the pure-remap
+        branch and replace the credential set with only the mapped providers,
+        silently dropping a provider that was provisioned but not mapped to any
+        agent. It must union like a bare --add-agent instead.
+        """
+        config = self._run(
+            # claude->vertex is mapped; openai is provisioned but unmapped.
+            self._labels([("claude", "vertex")], providers=["vertex", "openai"]),
+            UpgradeOverrides(
+                add_agents=["gemini"], agent_providers={"gemini": "google"}
+            ),
+        )
+
+        assert ("gemini", "google") in config.agent_providers
+        assert "google" in config.credential_providers
+        assert "vertex" in config.credential_providers
+        # The unmapped, deliberately-provisioned provider survives.
+        assert "openai" in config.credential_providers
+
+    def test_add_agent_invalid_provider_rejected(self) -> None:
+        """An unsupported agent/provider combo raises a friendly error."""
+        with pytest.raises(ValueError, match="does not support provider"):
+            self._run(
+                self._labels(),
+                UpgradeOverrides(
+                    add_agents=["codex"], agent_providers={"codex": "vertex"}
+                ),
+            )
+
+    def test_agent_provider_without_add_still_rejects_uninstalled(self) -> None:
+        """--agent-provider for an agent that is neither installed nor added fails."""
+        with pytest.raises(ValueError, match="are not installed"):
+            self._run(
+                self._labels(),
+                UpgradeOverrides(agent_providers={"codex": "openai"}),
+            )
+
+    def test_agents_full_set_reorder_changes_primary(self) -> None:
+        """--agents can reorder an existing set to change the primary."""
+        config = self._run(
+            self._labels([("claude", "vertex"), ("codex", "chatgpt")]),
+            UpgradeOverrides(agents=["codex", "claude"]),
+        )
+
+        assert config.agent == "codex"
+        assert config.agent_providers == [("codex", "chatgpt"), ("claude", "vertex")]
+
+    def test_agents_dropping_installed_agent_rejected(self) -> None:
+        """--agents that omits an installed agent is rejected (removal deferred)."""
+        with pytest.raises(ValueError, match="Removing agents is not yet supported"):
+            self._run(
+                self._labels([("claude", "vertex"), ("codex", "chatgpt")]),
+                UpgradeOverrides(agents=["codex"]),
+            )
+
+    def test_add_agent_round_trips_through_manifest(self) -> None:
+        """The merged agent set is captured in the crash-recovery manifest."""
+        from paude import upgrade_state
+
+        self._run(self._labels(), UpgradeOverrides(add_agents=["codex"]))
+
+        manifest = upgrade_state.load("test-session")
+        assert manifest is not None
+        assert manifest.agent_providers == [("claude", "vertex"), ("codex", "chatgpt")]
+
+    @pytest.mark.parametrize(
+        ("old", "new"), [("chatgpt", "openai"), ("openai", "chatgpt")]
+    )
+    def test_swap_codex_provider_in_place(self, old: str, new: str) -> None:
+        """--agent-provider codex=NEW remaps codex and drops the OLD credential.
+
+        Dropping the old provider (e.g. chatgpt) from the credential set is what
+        turns off the proxy's ChatGPT-OAuth mode at next start.
+        """
+        config = self._run(
+            self._labels([("claude", "vertex"), ("codex", old)]),
+            UpgradeOverrides(agent_providers={"codex": new}),
+        )
+
+        assert config.agent == "claude"  # primary unchanged
+        assert config.agent_providers == [("claude", "vertex"), ("codex", new)]
+        assert new in config.credential_providers
+        assert "vertex" in config.credential_providers
+        assert old not in config.credential_providers
+
+    def test_swap_via_provider_when_codex_primary(self) -> None:
+        """--provider remaps the primary agent (codex here) from chatgpt to openai."""
+        config = self._run(
+            self._labels([("codex", "chatgpt")], agent="codex"),
+            UpgradeOverrides(provider="openai"),
+        )
+
+        assert config.agent == "codex"
+        assert config.agent_providers == [("codex", "openai")]
+        assert config.provider == "openai"
+        assert "openai" in config.credential_providers
+        assert "chatgpt" not in config.credential_providers


### PR DESCRIPTION
paude upgrade could reconfigure providers but not change the set of installed agents, forcing a full session recreate (losing workspace and agent state) just to add an agent. Extend upgrade to mutate the agent set in place, reusing the existing rebuild machinery that preserves the /pvc volume.

Add two options:
- --add-agent AGENT: additive merge; appends agents and keeps the current primary.
- --agent/--agents A,B: full-set redefinition; first is primary and can reorder. Removing an installed agent is rejected for now (tracked as FEATURE-001).

_apply_overrides now derives a target agent list, seeds the provider mapping from the current per-agent providers, overlays --provider / --agent-provider, and rebuilds the composition through the shared _derive_agent_providers validator. A newly added agent's provider defaults to its usual provider and is unioned into the credential set, so adding codex (chatgpt) or swapping it to openai works in place. No host credential is needed at upgrade time: chatgpt stays in-container OAuth and openai reads OPENAI_API_KEY from the host env, matching create.

Add unit tests for the agent-set merge, provider swaps, primary handling, removal rejection, and manifest round-trip. Update README, docs/SESSIONS.md, docs/CONFIGURATION.md, and CLI help. Note the deferred --remove-agent work (FEATURE-001), the integration-coverage gap (TEST-003), and credential-reconciliation duplication (REFACTOR-006) in KNOWN_ISSUES.md.