### PR TITLE
Fix codex auth reset on upgrade; add upgrade integration tests

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -183,6 +183,25 @@ silent-degradation path remains. Consider surfacing a warning when a mount
 source that existed locally fails to transfer, or when a remapped source is
 missing on the remote.
 
+### RUNTIME-003: Agent install scripts have no curl timeout — headless start can hang on a blocked network
+
+**Status**: Open
+**Priority**: Low
+**Discovered**: 2026-08-10 while designing podman integration tests for `paude upgrade`
+
+The codex install script (`src/paude/agents/codex.py` — the two `curl -fsSL`
+GitHub-release fetches) sets no `--connect-timeout`/`--max-time`. `install_agent`
+(`containers/paude/entrypoint-lib-install.sh`) runs the *primary* agent's install
+script synchronously at headless start. On a host where the target domain is not
+merely refused but silently dropped (e.g. a restrictive egress policy), curl can
+block on the TCP connect for a long OS-default timeout instead of failing fast,
+stalling `start_session_no_attach`. This surfaced while designing
+`tests/integration/test_upgrade_podman.py`: making codex the *primary* agent
+risked hanging CI, so those tests keep codex a secondary agent (only the primary
+is installed at headless start). Add `--connect-timeout`/`--max-time` to the
+agent install curls (codex, and any other curl-based installer) so a blocked
+network fails fast with a clear error rather than hanging startup.
+
 ## Test Suite
 
 ### TEST-002: Single-file branch of `_transfer_path` is untested
@@ -213,26 +232,34 @@ teardown racing under concurrent full-suite load), not a product defect. Conside
 adding an explicit wait/retry on the shutdown assertion or isolating the test's
 port/socket allocation so it is deterministic under load.
 
-### TEST-003: No integration coverage for in-place agent-set / provider upgrades
+### TEST-003: In-place agent-set / provider upgrades — integration coverage
 
-**Status**: Open (investigation task)
-**Priority**: Medium
+**Status**: Partially resolved (2026-08-10)
+**Priority**: Low
 **Discovered**: 2026-08-08 while adding `--add-agent`/`--agents` to `paude upgrade`
 
-The new `paude upgrade` agent-set and provider-swap paths are covered by unit
-tests in `tests/test_upgrade.py` (`TestUpgradePodmanAddAgent`), but those mock
-the image build, container recreation, and start — so the *end-to-end* behavior
-is unverified: that a rebuilt image actually installs the added agent's binaries
-(e.g. `codex` + `codex-code-mode-host`), that `configure_codex` rewrites
-`config.toml` / clears `auth.json` on a chatgpt→openai swap at start, that the
-`/pvc` volume and existing agent state survive, and that labels/registry reflect
-the new set on a live container. These require a real container engine and only
-run in CI (`tests/integration/`, gated by the `integration`/`podman` markers;
-see `make test-integration` / `make test-podman`). Investigate what the existing
-podman integration suite covers for `upgrade` and add scenarios for: adding an
-agent in place, swapping a provider in place, and verifying persisted state is
-retained across the rebuild. (These cannot be run in the sandboxed dev
-environment — no container engine — so they must be authored against CI.)
+**Resolved (2026-08-10):** `tests/integration/test_upgrade_podman.py`
+(`TestPodmanUpgradeReconfigure`) now covers the in-place reconfiguration paths
+end-to-end on a real container (gated by the `integration`/`podman` markers; run
+in CI via `make test-podman`): adding an agent in place (`--add-agent`, primary
+preserved, credential providers unioned), swapping a provider in place
+(chatgpt→openai and the reverse via `--agent-provider`), that `configure_codex`
+rewrites `config.toml` and clears `auth.json` at start, that the `/pvc` volume
+and existing agent state survive the recreate, and that labels reflect the new
+set. The image build is mocked (the CI base image ships no agents), and codex is
+kept a *secondary* agent to avoid its no-timeout install curl at headless start
+(see RUNTIME-003).
+
+**Still open (deliberately deferred):** verifying the *physical* agent-binary
+install from a real image rebuild — that a rebuilt layer actually places `codex`
++ `codex-code-mode-host` on `$PATH`. This needs an unmocked
+`ensure_default_image(force_rebuild=True)`, which downloads from GitHub's
+`latest` release (multi-minute, network/rate-limit flaky) — too costly for the
+PR-blocking `podman-integration` job. It is already enforced at image-build time
+by codex's own `test -x` verification (`agents/codex.py`, `agents/base.py`) and
+covered by image-build unit tests, so this is low-value to add to CI. If ever
+added, gate it behind an opt-in env var (e.g. `PAUDE_TEST_REAL_REBUILD=1`) so it
+stays out of the default `-m podman` run.
 
 ## Feature Backlog
 

--- a/src/paude/agents/codex_config.py
+++ b/src/paude/agents/codex_config.py
@@ -12,6 +12,12 @@ from tomlkit.exceptions import ParseError
 
 CODEX_CONFIG_TARGET = "/pvc/.codex/config.toml"
 LEGACY_CODEX_PROFILE_TARGET = "/pvc/.codex/paude-chatgpt-http.config.toml"
+# The on-volume auth.json that paude clears when a session leaves ChatGPT mode.
+# Target the /pvc path (not /home/paude/.codex) so the reset works even before
+# the entrypoint recreates the $HOME/.codex -> /pvc/.codex symlink: configure_codex()
+# runs before that symlink exists on a freshly recreated container (e.g. during
+# `paude upgrade`), so a $HOME-relative rm would miss the real file.
+CODEX_AUTH_TARGET = "/pvc/.codex/auth.json"
 CODEX_CHATGPT_PROVIDER_NAME = "paude-chatgpt-http"
 
 _MANAGED_PROVIDER_VALUES: dict[str, object] = {

--- a/src/paude/backends/podman/session_setup.py
+++ b/src/paude/backends/podman/session_setup.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from paude.agents.base import AgentComposition
 from paude.agents.codex_config import (
+    CODEX_AUTH_TARGET,
     CODEX_CONFIG_TARGET,
     LEGACY_CODEX_PROFILE_TARGET,
     reconcile_codex_config,
@@ -39,7 +40,6 @@ from paude.backends.podman.helpers import (
     volume_name,
 )
 from paude.backends.proxy_config import (
-    CODEX_AUTH_TARGET,
     ProxyCredentials,
     derive_agent_ip,
 )

--- a/src/paude/backends/proxy_config.py
+++ b/src/paude/backends/proxy_config.py
@@ -52,11 +52,12 @@ PROXY_GCP_ADC_ENV = "GCP_ADC_JSON"
 # paude never pre-seeds `codex login` state either: doing so made Codex
 # believe it was already authenticated on a fresh session (skipping its own
 # login prompt) while paude-proxy had no real tokens yet for that session.
-# Codex's own login flow writes CODEX_AUTH_TARGET itself; paude-proxy swaps
+# Codex's own login flow writes its auth.json itself (under CODEX_HOME,
+# i.e. /home/paude/.codex, which is symlinked onto /pvc); paude-proxy swaps
 # in synthetic values at the token exchange so real tokens never land in the
-# agent container.
+# agent container. paude's reset of that auth.json lives with the other codex
+# on-volume paths as CODEX_AUTH_TARGET in agents/codex_config.py.
 PROXY_CHATGPT_AUTH_STATE_ENV = "PAUDE_PROXY_CHATGPT_AUTH_STATE_FILE"
-CODEX_AUTH_TARGET = "/home/paude/.codex/auth.json"
 
 
 @dataclass

--- a/tests/integration/test_upgrade_podman.py
+++ b/tests/integration/test_upgrade_podman.py
@@ -26,6 +26,80 @@ pytestmark = [pytest.mark.integration, pytest.mark.podman]
 OLD_VERSION = "0.12.0"
 
 
+def _exec(container: str, *argv: str) -> subprocess.CompletedProcess[str]:
+    """Run ``podman exec`` in the session container and capture output."""
+    return subprocess.run(
+        ["podman", "exec", container, *argv],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _file_present(container: str, path: str) -> bool:
+    """Return True if ``path`` exists inside the container."""
+    return _exec(container, "test", "-e", path).returncode == 0
+
+
+def _run_upgrade(
+    name: str,
+    backend: PodmanBackend,
+    overrides: UpgradeOverrides,
+    image: str,
+    proxy_image: str,
+) -> None:
+    """Drive an in-place upgrade with the image build mocked (real recreate).
+
+    Stubs only the network-heavy image rebuild so the container recreation,
+    label writes, state migration, and start all run for real.
+    """
+    mock_im = MagicMock()
+    mock_im.ensure_default_image.return_value = image
+    mock_im.ensure_proxy_image.return_value = proxy_image
+
+    with (
+        patch("paude.container.ImageManager", return_value=mock_im),
+        patch("paude.mounts.build_mounts", return_value=[]),
+    ):
+        from paude.cli.upgrade import _upgrade_podman
+
+        _upgrade_podman(name, backend, rebuild=False, overrides=overrides)
+
+
+def _create_and_start(
+    backend: PodmanBackend,
+    name: str,
+    workspace: Path,
+    image: str,
+    proxy_image: str,
+    *,
+    agent_providers: list[tuple[str, str]],
+    credential_providers: list[str],
+) -> str:
+    """Create + start a gemini-primary session and return the container name.
+
+    Gemini stays primary because it is already proven to start cleanly on the
+    bare test image by ``test_upgrade_preserves_volume_and_labels``. Codex, when
+    present, is a secondary agent — only the primary agent's binary is installed
+    at headless start, so these tests exercise host-side reconcile (config
+    rewrite, auth reset, labels), not the physical binary install.
+    """
+    config = SessionConfig(
+        name=name,
+        workspace=workspace,
+        image=image,
+        allowed_domains=["redhat.com"],
+        proxy_image=proxy_image,
+        agent="gemini",
+        provider="google",
+        agent_providers=agent_providers,
+        credential_providers=credential_providers,
+    )
+    backend.create_session(config)
+    backend.start_session_no_attach(name)
+    time.sleep(1)
+    return f"paude-{name}"
+
+
 class TestPodmanUpgrade:
     """Test upgrade preserves volume content and session labels."""
 
@@ -86,22 +160,13 @@ class TestPodmanUpgrade:
             assert session.version == OLD_VERSION
 
             # 3. Run upgrade with mocked image building
-            mock_im = MagicMock()
-            mock_im.ensure_default_image.return_value = podman_test_image
-            mock_im.ensure_proxy_image.return_value = podman_proxy_image
-
-            with (
-                patch("paude.container.ImageManager", return_value=mock_im),
-                patch("paude.mounts.build_mounts", return_value=[]),
-            ):
-                from paude.cli.upgrade import _upgrade_podman
-
-                _upgrade_podman(
-                    unique_session_name,
-                    backend,
-                    rebuild=False,
-                    overrides=UpgradeOverrides(),
-                )
+            _run_upgrade(
+                unique_session_name,
+                backend,
+                UpgradeOverrides(),
+                podman_test_image,
+                podman_proxy_image,
+            )
 
             # 4. Verify session is running with updated version
             session = backend.get_session(unique_session_name)
@@ -164,5 +229,206 @@ class TestPodmanUpgrade:
             )
             assert result.returncode == 0, "Proxy container should exist"
 
+        finally:
+            cleanup_session(backend, unique_session_name)
+
+
+class TestPodmanUpgradeReconfigure:
+    """Integration coverage for `paude upgrade` add-agent / provider-swap.
+
+    Exercises the in-place reconfiguration paths (KNOWN_ISSUES TEST-003) against
+    a real container. The per-session image build is mocked (the CI base image
+    ships no agents), so assertions target the recreate/label/state/config
+    behavior that runs host-side — not the physical agent-binary install, which
+    needs a real rebuild. See ``_create_and_start`` for why codex is kept a
+    secondary agent.
+    """
+
+    def test_upgrade_add_agent_in_place(
+        self,
+        require_podman: None,
+        require_test_image: None,
+        require_proxy_image: None,
+        temp_workspace: Path,
+        unique_session_name: str,
+        podman_test_image: str,
+        podman_proxy_image: str,
+    ) -> None:
+        """`--add-agent codex` keeps the primary, unions providers, keeps state."""
+        backend = PodmanBackend()
+
+        try:
+            container = _create_and_start(
+                backend,
+                unique_session_name,
+                temp_workspace,
+                podman_test_image,
+                podman_proxy_image,
+                agent_providers=[("gemini", "google")],
+                credential_providers=["google"],
+            )
+
+            # Seed prior workspace + agent state on the volume.
+            seed = _exec(
+                container,
+                "sh",
+                "-c",
+                "mkdir -p /pvc/workspace /pvc/.gemini && "
+                "echo keep > /pvc/workspace/marker.txt && "
+                "echo gem-state > /pvc/.gemini/settings.json",
+            )
+            assert seed.returncode == 0, seed.stderr
+
+            _run_upgrade(
+                unique_session_name,
+                backend,
+                UpgradeOverrides(add_agents=["codex"]),
+                podman_test_image,
+                podman_proxy_image,
+            )
+
+            session = backend.get_session(unique_session_name)
+            assert session is not None
+            assert session.status == "running"
+
+            # Primary unchanged; codex added as a secondary agent.
+            assert session.agent == "gemini"
+            assert ("gemini", "google") in session.agent_providers
+            assert ("codex", "chatgpt") in session.agent_providers
+            # Credential providers unioned (add-agent path), not replaced.
+            assert set(session.credential_providers) == {"google", "chatgpt"}
+
+            # Prior state survived the recreate.
+            assert "keep" in _exec(container, "cat", "/pvc/workspace/marker.txt").stdout
+            assert (
+                "gem-state"
+                in _exec(container, "cat", "/pvc/.gemini/settings.json").stdout
+            )
+
+            # The newly-added codex triggered its config side-effect (chatgpt
+            # default), written to the absolute /pvc path.
+            config_toml = _exec(container, "cat", "/pvc/.codex/config.toml")
+            assert config_toml.returncode == 0
+            assert "paude-chatgpt-http" in config_toml.stdout
+        finally:
+            cleanup_session(backend, unique_session_name)
+
+    def test_upgrade_swap_codex_chatgpt_to_openai(
+        self,
+        require_podman: None,
+        require_test_image: None,
+        require_proxy_image: None,
+        temp_workspace: Path,
+        unique_session_name: str,
+        podman_test_image: str,
+        podman_proxy_image: str,
+    ) -> None:
+        """Swapping codex chatgpt->openai strips config and clears auth.json."""
+        backend = PodmanBackend()
+
+        try:
+            container = _create_and_start(
+                backend,
+                unique_session_name,
+                temp_workspace,
+                podman_test_image,
+                podman_proxy_image,
+                agent_providers=[("gemini", "google"), ("codex", "chatgpt")],
+                credential_providers=["google", "chatgpt"],
+            )
+
+            # First start (chatgpt mode) writes the managed provider block.
+            precheck = _exec(container, "cat", "/pvc/.codex/config.toml")
+            assert precheck.returncode == 0
+            assert "paude-chatgpt-http" in precheck.stdout
+
+            # Seed a ChatGPT auth.json on the volume; the swap must clear it.
+            seed = _exec(
+                container,
+                "sh",
+                "-c",
+                "mkdir -p /pvc/.codex && echo seeded > /pvc/.codex/auth.json",
+            )
+            assert seed.returncode == 0, seed.stderr
+
+            _run_upgrade(
+                unique_session_name,
+                backend,
+                UpgradeOverrides(agent_providers={"codex": "openai"}),
+                podman_test_image,
+                podman_proxy_image,
+            )
+
+            session = backend.get_session(unique_session_name)
+            assert session is not None
+            assert session.status == "running"
+            assert ("codex", "openai") in session.agent_providers
+            # Pure remap drops the old provider; google stays (still mapped).
+            assert "chatgpt" not in session.credential_providers
+            assert "openai" in session.credential_providers
+
+            # openai reconcile strips the managed provider block.
+            config_toml = _exec(container, "cat", "/pvc/.codex/config.toml")
+            assert "paude-chatgpt-http" not in config_toml.stdout
+            assert "model_provider" not in config_toml.stdout
+
+            # The swap cleared the stale auth.json (regression guard for the
+            # $HOME-vs-/pvc reset-path fix).
+            assert not _file_present(container, "/pvc/.codex/auth.json")
+        finally:
+            cleanup_session(backend, unique_session_name)
+
+    def test_upgrade_swap_codex_openai_to_chatgpt(
+        self,
+        require_podman: None,
+        require_test_image: None,
+        require_proxy_image: None,
+        temp_workspace: Path,
+        unique_session_name: str,
+        podman_test_image: str,
+        podman_proxy_image: str,
+    ) -> None:
+        """Reverse swap re-adds the managed block and preserves auth.json."""
+        backend = PodmanBackend()
+
+        try:
+            container = _create_and_start(
+                backend,
+                unique_session_name,
+                temp_workspace,
+                podman_test_image,
+                podman_proxy_image,
+                agent_providers=[("gemini", "google"), ("codex", "openai")],
+                credential_providers=["google", "openai"],
+            )
+
+            # Seed auth.json after first start (openai mode would have rm'd it).
+            seed = _exec(
+                container,
+                "sh",
+                "-c",
+                "mkdir -p /pvc/.codex && echo seeded > /pvc/.codex/auth.json",
+            )
+            assert seed.returncode == 0, seed.stderr
+
+            _run_upgrade(
+                unique_session_name,
+                backend,
+                UpgradeOverrides(agent_providers={"codex": "chatgpt"}),
+                podman_test_image,
+                podman_proxy_image,
+            )
+
+            session = backend.get_session(unique_session_name)
+            assert session is not None
+            assert ("codex", "chatgpt") in session.agent_providers
+            assert "chatgpt" in session.credential_providers
+
+            # chatgpt reconcile re-adds the managed provider block ...
+            config_toml = _exec(container, "cat", "/pvc/.codex/config.toml")
+            assert config_toml.returncode == 0
+            assert "paude-chatgpt-http" in config_toml.stdout
+            # ... and does not delete auth.json (only openai mode clears it).
+            assert _file_present(container, "/pvc/.codex/auth.json")
         finally:
             cleanup_session(backend, unique_session_name)

--- a/tests/test_docker_compat.py
+++ b/tests/test_docker_compat.py
@@ -500,6 +500,6 @@ class TestCodexConfigReconciliation:
 
         backend._setup._runner.exec_in_container.assert_called_once_with(
             "paude-test",
-            ["rm", "-f", "/home/paude/.codex/auth.json"],
+            ["rm", "-f", "/pvc/.codex/auth.json"],
             check=False,
         )


### PR DESCRIPTION
The chatgpt->openai provider swap during `paude upgrade` left a stale /pvc/.codex/auth.json behind. configure_codex() runs host-side before the entrypoint recreates the $HOME/.codex -> /pvc/.codex symlink on a freshly recreated container, so the $HOME-relative `rm -f` missed the real file on the volume (it only worked on a stop->start of the same container). Point CODEX_AUTH_TARGET at the /pvc path and move it beside its sibling codex path constants in codex_config.py so all codex on-volume paths share the /pvc-rooted convention; the reset now works in every start scenario.

Add podman integration coverage for the in-place reconfiguration paths (KNOWN_ISSUES TEST-003): add-agent, provider swap both directions, config.toml rewrite, auth.json clearing, state persistence, and label updates -- all against a real container with the image build mocked. Codex is kept a secondary agent so only gemini (proven to start cleanly on the bare image) installs at headless start.

Narrow TEST-003 to the remaining, deliberately deferred binary-install gap, and file RUNTIME-003 for the missing curl timeout in agent install scripts.