### PR TITLE
Pin container runtime UID/GID to survive image rebuilds

### DIFF
--- a/containers/paude/Dockerfile
+++ b/containers/paude/Dockerfile
@@ -73,12 +73,17 @@ RUN curl -fsSL https://cli.github.com/packages/rpm/gh-cli.repo -o /etc/yum.repos
     dnf install -y gh && \
     dnf clean all
 
-# Create the fixed non-root runtime user
-RUN groupadd --system paude && \
-    useradd --system -M -d /home/paude -s /bin/bash -g paude paude && \
+# Create the fixed non-root runtime user.
+# UID/GID are pinned (1000:0) so the runtime identity is stable across image
+# rebuilds. A `paude upgrade` rebuilds this image; if the UID drifted, the
+# existing /pvc volume (owned by the original UID) would become unwritable and
+# the agent would fail with EACCES. gid 0 (root) matches volumes created before
+# the runtime user was pinned, and always exists so no groupadd is needed.
+# Keep these in sync with CONTAINER_RUNTIME_UID/GID in src/paude/constants.py.
+RUN useradd --uid 1000 -M -d /home/paude -s /bin/bash -g 0 paude && \
     umask 0002 && \
     mkdir -p /home/paude/.claude /home/paude/.config && \
-    chown -R paude:paude /home/paude
+    chown -R paude:0 /home/paude
 
 # NOTE: Claude Code is NOT installed here due to licensing restrictions.
 # It gets installed at user-side build time via a runtime layer.

--- a/containers/paude/entrypoint-lib-config.sh
+++ b/containers/paude/entrypoint-lib-config.sh
@@ -17,6 +17,14 @@ persist_config_dir() {
     fi
 
     mkdir -p "$pvc_dir" 2>/dev/null || true
+    # If the PVC target could not be created (e.g. /pvc is not writable by this
+    # user because the runtime UID drifted from the volume's owner), do NOT
+    # remove the seeded $home_dir or point a symlink at a nonexistent target —
+    # that leaves a broken symlink. Leave $home_dir in place and warn instead.
+    if [[ ! -d "$pvc_dir" ]]; then
+        echo "persist_config_dir: cannot create $pvc_dir (is /pvc writable by $(id -un)?); leaving $home_dir in place" >&2
+        return 0
+    fi
     chmod g+rwX "$pvc_dir" 2>/dev/null || true
     chcon -R --reference=/pvc "$pvc_dir" 2>/dev/null || true
 

--- a/src/paude/backends/podman/backend.py
+++ b/src/paude/backends/podman/backend.py
@@ -190,10 +190,13 @@ class PodmanBackend:
             self._volume_manager.remove_volume(vname, force=True)
 
     def start_session_no_attach(self, name: str) -> None:
-        """Start containers without attaching (for git setup, etc.)."""
+        """Start containers without attaching (used by create and upgrade)."""
         cname = require_session(self._runner, name)
         if self._runner.container_running(cname):
             return
+        # Balance create_session's "created (stopped)" line so it isn't the last
+        # status shown for a container that is in fact left running.
+        print(f"Starting session '{name}'...", file=sys.stderr)
         agent = self._setup.start_session_containers(name, cname, self._proxy)
         self._setup.start_agent_headless_in_container(cname, agent)
 

--- a/src/paude/config/dockerfile.py
+++ b/src/paude/config/dockerfile.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from paude.config.models import PaudeConfig
-from paude.constants import CONTAINER_ENTRYPOINT, CONTAINER_HOME
+from paude.constants import (
+    CONTAINER_ENTRYPOINT,
+    CONTAINER_HOME,
+    CONTAINER_RUNTIME_GID,
+    CONTAINER_RUNTIME_UID,
+)
 
 if TYPE_CHECKING:
     from paude.agents.base import Agent, AgentComposition
@@ -195,11 +200,20 @@ RUN if ! command -v tini >/dev/null 2>&1; then \\
             for directory in item.config.persistent_dir_names
         )
     )
+    # Pin the runtime user to CONTAINER_RUNTIME_UID:GID so the identity stays
+    # stable across rebuilds (see constants.py for why). Reuse a pre-existing
+    # `paude` user when the base image already ships one; fall back to adduser
+    # (busybox) if useradd is unavailable or the UID is already taken.
+    useradd = (
+        f"useradd --uid {CONTAINER_RUNTIME_UID} -M -d {CONTAINER_HOME} "
+        f"-s /bin/bash -g {CONTAINER_RUNTIME_GID} paude"
+    )
     lines.append(
-        "RUN (id paude >/dev/null 2>&1 || (groupadd paude 2>/dev/null && useradd -M -d /home/paude -s /bin/bash -g paude paude 2>/dev/null) || adduser -D -s /bin/bash paude) && "
+        f"RUN (id paude >/dev/null 2>&1 || {useradd} 2>/dev/null || "
+        "adduser -D -s /bin/bash paude) && "
         "umask 0002 && "
         f"mkdir -p {' '.join(f'{CONTAINER_HOME}/{directory}' for directory in config_dirs)} {CONTAINER_HOME}/.config {CONTAINER_HOME}/.paude && "
-        f"chown -R paude {CONTAINER_HOME}"
+        f"chown -R paude:{CONTAINER_RUNTIME_GID} {CONTAINER_HOME}"
     )
 
     # Copy patch script before agent install lines (agents may RUN it)

--- a/src/paude/constants.py
+++ b/src/paude/constants.py
@@ -2,6 +2,13 @@
 
 CONTAINER_WORKSPACE = "/pvc/workspace"
 CONTAINER_HOME = "/home/paude"
+# Runtime user identity. Pinned so an image rebuild (e.g. `paude upgrade`) never
+# drifts the UID out from under an existing /pvc volume, which would make the
+# volume unwritable (EACCES). gid 0 (root) matches volumes created before the
+# user was pinned and always exists. The static containers/paude/Dockerfile
+# hardcodes these same values (it can't import Python) — keep them in sync.
+CONTAINER_RUNTIME_UID = 1000
+CONTAINER_RUNTIME_GID = 0
 CONTAINER_GIT_CONFIG = "/pvc/.gitconfig"
 CONTAINER_ENTRYPOINT = "/usr/local/bin/entrypoint.sh"
 BASE_REF_NAME = "refs/paude/base"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -330,6 +330,21 @@ class TestGenerateWorkspaceDockerfile:
 
         assert "--allowerasing" in dockerfile
 
+    def test_pins_runtime_user_uid_gid(self):
+        """The runtime user is pinned to uid 1000 / gid 0 so a rebuild never
+        drifts the UID out from under an existing /pvc volume (which would make
+        the volume unwritable and break the agent with EACCES)."""
+        config = PaudeConfig()
+        dockerfile = generate_workspace_dockerfile(config)
+
+        assert "useradd --uid 1000 -M -d /home/paude -s /bin/bash -g 0 paude" in (
+            dockerfile
+        )
+        # The volume/home must be group-root so it matches gid 0 ownership.
+        assert "chown -R paude:0 /home/paude" in dockerfile
+        # A pre-existing base-image user is reused rather than recreated.
+        assert "id paude >/dev/null 2>&1" in dockerfile
+
     def test_dnf_and_yum_install_tmux_from_the_distribution(self):
         """dnf/yum images use the fixed distribution tmux package."""
         config = PaudeConfig()

--- a/tests/test_entrypoint_seed_copy.py
+++ b/tests/test_entrypoint_seed_copy.py
@@ -111,6 +111,34 @@ class TestEntrypointContract:
             "chcon must use --reference=/pvc to inherit PVC SELinux context"
         )
 
+    def test_persist_config_dir_guards_against_dangling_symlink(self) -> None:
+        """The shipped persist_config_dir must contain the bail-out guard.
+
+        The behavioural test exercises a reimplementation (the real function
+        hardcodes /pvc), so this contract check is what catches the guard
+        regressing out of the actual entrypoint script.
+        """
+        content = ENTRYPOINT_LIB_CONFIG_PATH.read_text()
+        assert 'if [[ ! -d "$pvc_dir" ]]; then' in content, (
+            "persist_config_dir must guard on the PVC dir existing after mkdir"
+        )
+
+    def test_dockerfile_pins_runtime_user_uid_gid(self) -> None:
+        """The base image must pin the runtime user to uid 1000 / gid 0.
+
+        A `paude upgrade` rebuilds this image; an unpinned (e.g. `--system`)
+        useradd assigns a different UID than the one that owns the existing /pvc
+        volume, making the volume unwritable (EACCES on transcript writes).
+        """
+        content = DOCKERFILE_PATH.read_text()
+        assert "useradd --uid 1000 -M -d /home/paude -s /bin/bash -g 0 paude" in (
+            content
+        ), "base Dockerfile must pin the paude user to uid 1000 / gid 0"
+        assert "chown -R paude:0 /home/paude" in content
+        assert "useradd --system" not in content, (
+            "the runtime UID must be pinned, not assigned from the system range"
+        )
+
     def test_entrypoint_persists_composed_agent_configs(self) -> None:
         """Every configured agent directory/file is persisted to the PVC."""
         content = ENTRYPOINT_PATH.read_text()
@@ -467,6 +495,10 @@ def _persist_config_dir_bash_function(pvc_dir: str) -> str:
             fi
 
             mkdir -p "$pvc_dir" 2>/dev/null || true
+            if [[ ! -d "$pvc_dir" ]]; then
+                echo "persist_config_dir: cannot create $pvc_dir (is /pvc writable by $(id -un)?); leaving $home_dir in place" >&2
+                return 0
+            fi
             chmod g+rwX "$pvc_dir" 2>/dev/null || true
             chcon -R --reference="{pvc_dir}" "$pvc_dir" 2>/dev/null || true
 
@@ -625,6 +657,35 @@ class TestPersistAgentConfig:
         assert (home / ".claude").is_symlink()
         # Baked content was merged into PVC
         assert (pvc / ".claude" / "settings.json").read_text() == '{"baked": true}'
+
+    def test_leaves_home_dir_when_pvc_target_uncreatable(self, tmp_path: Path) -> None:
+        """When the PVC target can't be created (unwritable /pvc), the seeded
+        HOME dir survives and no dangling symlink is produced — the failure mode
+        behind the reported ~/.config/opencode -> /pvc/.config/opencode after an
+        upgrade that drifted the runtime UID."""
+        home = tmp_path / "home"
+        (home / ".config" / "opencode").mkdir(parents=True)
+        (home / ".config" / "opencode" / "config.json").write_text("{}")
+        pvc = tmp_path / "pvc"
+        pvc.mkdir()
+        # Block `mkdir -p pvc/.config/opencode` by making pvc/.config a file.
+        (pvc / ".config").write_text("not a dir")
+
+        persist_fn = _persist_config_dir_bash_function(str(pvc))
+        script = textwrap.dedent(f"""\
+            #!/bin/bash
+            export HOME="{home}"
+            {persist_fn}
+            persist_config_dir ".config/opencode"
+        """)
+        result = _run_script(script)
+        assert result.returncode == 0, result.stderr
+
+        opencode = home / ".config" / "opencode"
+        assert opencode.is_dir(), "seeded HOME dir must survive an unwritable PVC"
+        assert not opencode.is_symlink(), "must not create a dangling symlink"
+        assert (opencode / "config.json").exists()
+        assert "cannot create" in result.stderr
 
     def test_image_baked_config_does_not_replace_pvc_state(
         self, tmp_path: Path

--- a/tests/test_podman_session.py
+++ b/tests/test_podman_session.py
@@ -167,6 +167,47 @@ def _make_create_session_backend(
     return backend
 
 
+class TestPodmanBackendStartNoAttach:
+    """Tests for PodmanBackend.start_session_no_attach output."""
+
+    @patch("paude.backends.podman.backend.ContainerRunner")
+    def test_announces_start(
+        self, mock_runner_class: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """It prints a 'Starting session' line so create/upgrade don't leave
+        'created (stopped)' as the last status line for a running container."""
+        mock_runner = MagicMock()
+        mock_runner.container_exists.return_value = True
+        mock_runner.container_running.return_value = False
+        mock_runner_class.return_value = mock_runner
+
+        backend = _make_backend(mock_runner)
+        backend._setup = MagicMock()
+
+        backend.start_session_no_attach("test-session")
+
+        assert "Starting session 'test-session'..." in capsys.readouterr().err
+        backend._setup.start_session_containers.assert_called_once()
+
+    @patch("paude.backends.podman.backend.ContainerRunner")
+    def test_silent_when_already_running(
+        self, mock_runner_class: MagicMock, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """No start message when the container is already running (no-op)."""
+        mock_runner = MagicMock()
+        mock_runner.container_exists.return_value = True
+        mock_runner.container_running.return_value = True
+        mock_runner_class.return_value = mock_runner
+
+        backend = _make_backend(mock_runner)
+        backend._setup = MagicMock()
+
+        backend.start_session_no_attach("test-session")
+
+        assert "Starting session" not in capsys.readouterr().err
+        backend._setup.start_session_containers.assert_not_called()
+
+
 class TestPodmanBackendCreateSession:
     """Tests for PodmanBackend.create_session."""
 


### PR DESCRIPTION
The "Remove OpenShift support" change switched the container's paude user from a fixed uid 1000 / gid 0 to `useradd --system`, which assigns an unpinned system UID (e.g. 997). A `paude upgrade` force-rebuilds the image, so the runtime user's UID drifted away from the uid 1000 that owns the persistent /pvc volume. The new user could no longer write the volume, producing EACCES on agent transcript writes and, because persist_config_dir's `mkdir -p` under /pvc failed, a dangling ~/.config/opencode -> /pvc/.config/opencode symlink.

Pin the runtime user to uid 1000 / gid 0 in both the base Dockerfile and the generated custom-image Dockerfile so the identity is stable across rebuilds and matches existing volumes. Centralize the values as CONTAINER_RUNTIME_UID/GID in constants.py (the static Dockerfile keeps a synced hardcode since it cannot import Python).

Also:
- persist_config_dir now bails with a warning instead of creating a dangling symlink when the /pvc target cannot be created.
- start_session_no_attach prints "Starting session..." so create and upgrade no longer leave "created (stopped)" as the last status line for a container that is actually running.

Add tests covering the UID/GID pin, the persist guard, and the start message.