### PR TITLE
Fix paude upgrade failures for remote, UID-drifted sessions

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -239,6 +239,95 @@ is installed at headless start). Add `--connect-timeout`/`--max-time` to the
 agent install curls (codex, and any other curl-based installer) so a blocked
 network fails fast with a clear error rather than hanging startup.
 
+### RUNTIME-004: `paude upgrade` aborted on an un-copyable migration source, and stranded pre-pin `/pvc` ownership
+
+**Status**: Resolved (2026-08-11)
+**Discovered**: 2026-08-11 while upgrading a remote codex/ChatGPT session
+(`0.20.0a8` → `0.20.0a10`)
+
+Two independent problems, both hit during one upgrade:
+
+1. **Crash (opaque):** the pre-upgrade state migration (`_MIGRATE_SCRIPT` in
+   `src/paude/cli/upgrade_persistence.py`) ran under `set -e` with an
+   **unguarded** `cp`, so the *first* un-copyable path aborted the whole
+   upgrade. In the reported case the runtime UID matched the `/pvc` owner
+   (both `997`), so it was **not** a `/pvc` write/EACCES problem — the copy
+   died trying to **read the source** `cp: cannot open '/home/paude/.gitconfig'
+   for reading: Permission denied`. For a `--host` (remote) session
+   `~/.gitconfig` is a **read-only host file bind-mounted** into the container,
+   owned by `root` (and, on an SELinux host, unreadable by the `997` runtime
+   user regardless of the `644` bits). The real error never reached the user
+   because the handler printed only `str(CalledProcessError)`, which drops
+   `.stderr`. Same class of swallowed-error as RUNTIME-001.
+
+2. **Stranded ownership (second-order):** pinning the runtime user to `1000:0`
+   (commit `8edd527`) left volumes created by the earlier `useradd --system`
+   UID (`~997`) owned by that stale UID. `paude upgrade` reuses the `/pvc`
+   named volume, and `fix_volume_permissions` never reconciled ownership on
+   podman (it early-returned, was non-recursive, and chowned to the *name*
+   `paude`, not `uid:gid`). So after upgrading to a `1000:0` image the recreated
+   container couldn't read `/pvc/.codex/auth.json` (mode `0600`, owner `~997`)
+   → Codex ChatGPT OAuth silently broke. Related to SEC-004 / AGENT-001
+   (auth on `/pvc`).
+
+**Fix**:
+- `_MIGRATE_SCRIPT` guards each `cp`/`mkdir` (warn-and-continue via a `warn`
+  helper), mirroring the runtime entrypoint's hardened `persist_config_dir`, so
+  one un-copyable path can no longer abort the upgrade. The copy runs as the old
+  container's default user (best-effort salvage) and leaves `cp`'s own error
+  visible.
+- Migration failures now re-raise with the captured `stderr`, and the generic
+  upgrade handler surfaces `CalledProcessError.stderr` instead of the opaque
+  exit-status string.
+- `ContainerRunner.reconcile_volume_ownership()` chowns `/pvc` to the image's
+  actual `paude` user — resolved at runtime with `id -u paude`/`id -g paude`,
+  **not** a hardcoded UID (a wrong hardcoded value would itself lock the
+  container out of its volume), guarded by a `stat` probe so the already-correct
+  case skips the recursive walk. It runs on the **recreated** container via the
+  now podman-capable `fix_volume_permissions`, before `configure_codex` and the
+  agent entrypoint — the sole, correctly-placed reconcile. (An earlier draft
+  reconciled *before* the migration copy too; that was removed because the old
+  container can own the volume at a pre-pin UID, so chowning it there would only
+  remove its own write access.)
+
+### RUNTIME-005: Remote sessions bind-mount `~/.gitconfig`, which SELinux can make unreadable
+
+**Status**: Open
+**Priority**: Medium (a fresh remote session on an SELinux host can silently end
+up with no global git config / identity)
+**Discovered**: 2026-08-11 while debugging a remote (`--host`) codex upgrade
+
+Config sync is engine-split: local engines copy host config into `/credentials/`
+via `podman cp` (`ConfigSyncer`, `src/paude/backends/podman/sync.py`), while SSH
+remotes skip that and rely on bind mounts instead (`sync.py:25`, early
+`return`). So on a remote session `build_mounts(include_config=True)`
+(`src/paude/mounts.py:73-79`) bind-mounts the host gitconfig read-only at
+`$HOME/.gitconfig` (the source is transferred to the remote's `/tmp` by
+`sync_configs_to_remote` and remapped). On an SELinux-enforcing host that
+bind-mounted file is owned by root (the host user maps to container-root under
+rootless podman) and carries a host SELinux label the container's confined
+`paude` process cannot read — despite `0644` mode bits. (The `podman cp` copy
+path used for local engines exists precisely to avoid this, per
+`mounts.py:48-50`.)
+
+The consequence surfaces on a **fresh** remote session: `setup_gitconfig`
+(`containers/paude/entrypoint-lib-credentials.sh:88-128`) seeds `/pvc/.gitconfig`
+by `cp`-ing from `$HOME/.gitconfig` when `/pvc/.gitconfig` doesn't yet exist. If
+SELinux blocks that read, the `cp` fails silently (`2>/dev/null || true`),
+`/pvc/.gitconfig` is never created, `GIT_CONFIG_GLOBAL` is never exported, and git
+falls back to the unreadable `~/.gitconfig` — leaving the session with no global
+git config or identity. Sessions that already have a populated `/pvc/.gitconfig`
+(e.g. an existing session being upgraded) are unaffected, because the seed step
+is skipped and `GIT_CONFIG_GLOBAL` still points at the readable PVC copy. Same
+class of silently-swallowed setup failure as RUNTIME-001.
+
+Fix directions: make the remote path copy gitconfig into `/credentials/` like the
+local path (so the entrypoint reads a readable, correctly-labeled source), or
+relabel the bind mount (`:z`/`:Z`), or have `setup_gitconfig` fall back to
+`touch`-ing `/pvc/.gitconfig` and filling identity from
+`PAUDE_GIT_USER_NAME`/`PAUDE_GIT_USER_EMAIL` when the source is unreadable, so
+`GIT_CONFIG_GLOBAL` is always set even when the seed copy fails.
+
 ## Test Suite
 
 ### TEST-002: Single-file branch of `_transfer_path` is untested

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -79,6 +79,13 @@ older container writable layers into the session volume. This preserves agent
 configuration, logins, conversation history, installed skills, and other
 mutable state in addition to `/pvc/workspace`.
 
+When the new container starts, `upgrade` reconciles ownership of the reused
+`/pvc` volume to the pinned runtime user, so a volume created before the runtime
+UID was pinned stays readable and writable and agent logins survive the upgrade.
+State migration is also best-effort: a source it cannot copy (for example a
+read-only, host-mounted `~/.gitconfig` on a remote session) is skipped with a
+warning instead of aborting the upgrade.
+
 The legacy `--rebuild` option is still accepted for compatibility, but is no
 longer necessary because upgrades always rebuild.
 

--- a/src/paude/backends/podman/session_setup.py
+++ b/src/paude/backends/podman/session_setup.py
@@ -206,19 +206,16 @@ class SessionSetup:
             )
 
     def fix_volume_permissions(self, container_name: str) -> None:
-        """Fix /pvc volume ownership for Docker."""
-        if self._engine.supports_secrets:
-            return
-        self._engine.run(
-            "exec",
-            "--user",
-            "root",
-            container_name,
-            "chown",
-            "paude",
-            "/pvc",
-            check=False,
-        )
+        """Reconcile /pvc ownership before configure_codex and the entrypoint run.
+
+        Thin lifecycle hook over
+        ``ContainerRunner.reconcile_volume_ownership`` (see there for the
+        drifted-UID rationale and why the target is resolved at runtime rather
+        than assumed). Kept in the start path so a volume whose owner no longer
+        matches the possibly-rebuilt image is fixed up before anything reads or
+        writes it — on both podman and docker.
+        """
+        self._runner.reconcile_volume_ownership(container_name)
 
     def start_session_containers(
         self,

--- a/src/paude/backends/podman/volume_archive.py
+++ b/src/paude/backends/podman/volume_archive.py
@@ -16,8 +16,9 @@ and using ``transport.copy_from_host`` for SSH).
 
 Restore (future, ``import_volume``) is the mirror image: create the volume,
 push the tar in with :func:`copy_to_container`, and ``tar -xzf`` it into
-``/pvc`` from inside a helper container (on docker, ``chown paude /pvc`` first,
-matching ``SessionSetup.fix_volume_permissions``).
+``/pvc`` from inside a helper container, reconciling ownership to the pinned
+runtime user afterward (see ``SessionSetup.fix_volume_permissions`` /
+``ContainerRunner.reconcile_volume_ownership``).
 """
 
 from __future__ import annotations

--- a/src/paude/cli/upgrade.py
+++ b/src/paude/cli/upgrade.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
@@ -347,7 +348,14 @@ def session_upgrade(
         )
         raise typer.Exit(130) from None
     except Exception as e:
-        typer.echo(f"Error upgrading session: {e}", err=True)
+        # str(CalledProcessError) omits captured stderr — surface it so a
+        # failing container command isn't reported as an opaque exit status.
+        detail = (
+            e.stderr.strip()
+            if isinstance(e, subprocess.CalledProcessError) and e.stderr
+            else str(e)
+        )
+        typer.echo(f"Error upgrading session: {detail}", err=True)
         typer.echo(
             f"The upgrade did not finish. Your workspace data is safe. "
             f"Run 'paude upgrade {name}' again to retry.",
@@ -734,6 +742,20 @@ def _upgrade_podman(
     # Build mounts and env
     home = Path.home()
     mounts = build_mounts(home, composition, include_config=engine.is_remote)
+
+    # For SSH remotes, transfer the local config files referenced by the bind
+    # mounts to the remote host and rewrite the mount sources to the remote
+    # paths — the local (e.g. Mac) source paths don't exist on the remote host,
+    # so podman would fail to create the container ("statfs ...: no such file").
+    # Mirrors the create path (see create_podman.py).
+    if engine.is_remote:
+        from paude.transport.config_sync import remap_mounts, sync_configs_to_remote
+        from paude.transport.ssh import SshTransport
+
+        if isinstance(engine.transport, SshTransport):
+            typer.echo("Syncing configuration to remote host...", err=True)
+            remote_config_paths = sync_configs_to_remote(engine.transport, mounts)
+            mounts = remap_mounts(mounts, remote_config_paths.path_map)
 
     # Expand domains — all sessions get a proxy.
     # allowed_domains=None (old sessions without proxy) is passed as-is to

--- a/src/paude/cli/upgrade_persistence.py
+++ b/src/paude/cli/upgrade_persistence.py
@@ -2,34 +2,42 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 
 from paude.constants import CONTAINER_HOME
+from paude.container.runner import echo_captured_stderr
 
 if TYPE_CHECKING:
     from paude.agents.base import AgentComposition
     from paude.container.runner import ContainerRunner
 
 
+# Per-path writes are non-fatal: one un-writable path (e.g. a /pvc whose UID
+# drifted from the runtime user) must not abort the whole upgrade. Each mkdir/cp
+# is guarded and warns on stderr (which the caller surfaces); cp's own error is
+# left visible so the specific failing path is diagnosable. This mirrors the
+# runtime entrypoint's hardened persist_config_dir. set -e still guards the rest.
 _MIGRATE_SCRIPT = r"""
 set -e
+warn() { echo "migrate: could not fully migrate $1" >&2; }
 mode=dirs
 for relative in "$@"; do
     if [ "$relative" = "--files" ]; then mode=files; continue; fi
-    source_path="$HOME/$relative"
-    target_path="/pvc/$relative"
-    if [ -L "$source_path" ]; then continue; fi
-    if [ "$mode" = "dirs" ] && [ -d "$source_path" ]; then
-        mkdir -p "$target_path"
-        cp -dR --preserve=mode,timestamps "$source_path/." "$target_path/"
-        chmod -R g+rwX "$target_path" 2>/dev/null || true
-        chcon -R --reference=/pvc "$target_path" 2>/dev/null || true
-    elif [ "$mode" = "files" ] && [ -f "$source_path" ]; then
-        mkdir -p "$(dirname "$target_path")"
-        cp -f --preserve=mode,timestamps "$source_path" "$target_path"
-        chmod g+rw "$target_path" 2>/dev/null || true
-        chcon --reference=/pvc "$target_path" 2>/dev/null || true
+    src="$HOME/$relative"
+    dst="/pvc/$relative"
+    if [ -L "$src" ]; then continue; fi
+    if [ "$mode" = "dirs" ] && [ -d "$src" ]; then
+        mkdir -p "$dst" 2>/dev/null || { warn "$relative"; continue; }
+        cp -dR --preserve=mode,timestamps "$src/." "$dst/" || warn "$relative"
+        chmod -R g+rwX "$dst" 2>/dev/null || true
+        chcon -R --reference=/pvc "$dst" 2>/dev/null || true
+    elif [ "$mode" = "files" ] && [ -f "$src" ]; then
+        mkdir -p "$(dirname "$dst")" 2>/dev/null || { warn "$relative"; continue; }
+        cp -f --preserve=mode,timestamps "$src" "$dst" || warn "$relative"
+        chmod g+rw "$dst" 2>/dev/null || true
+        chcon --reference=/pvc "$dst" 2>/dev/null || true
     fi
 done
 """
@@ -98,7 +106,16 @@ def migrate_legacy_state(
         runner.stop_container_graceful(container_name)
     runner.start_container(container_name)
     try:
-        runner.exec_in_container(
+        # Run as the old container's default user (not root): the copy is a
+        # best-effort salvage into the volume that user already owns. Anything it
+        # can't read or write — e.g. a read-only host-mounted ~/.gitconfig owned
+        # by root on a remote session — is skipped with a warning by the hardened
+        # script instead of aborting the upgrade. Volume ownership is NOT
+        # reconciled here: the old container may run as a pre-pin UID that owns
+        # the volume, and chowning it to the pinned user would only take write
+        # access away. Final ownership is reconciled on the recreated container
+        # (SessionSetup.fix_volume_permissions), which runs as the pinned user.
+        result = runner.exec_in_container(
             container_name,
             [
                 "env",
@@ -112,6 +129,12 @@ def migrate_legacy_state(
                 *files,
             ],
         )
+        # Surface any non-fatal per-path warnings the hardened script emitted.
+        echo_captured_stderr(result)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(
+            f"migrating persistent agent state failed: {e.stderr or e.stdout or e}"
+        ) from e
     finally:
         if not was_running:
             runner.stop_container_graceful(container_name)

--- a/src/paude/container/runner.py
+++ b/src/paude/container/runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,19 @@ class ContainerNotFoundError(Exception):
     """Container not found."""
 
     pass
+
+
+def echo_captured_stderr(result: subprocess.CompletedProcess[str]) -> None:
+    """Print a captured command's stderr to our own stderr, if it has any.
+
+    ``exec_in_container`` captures output, so container-side warnings and
+    progress lines (e.g. the migration script's per-path warnings or the
+    volume-reconcile progress line) would otherwise be invisible. The
+    ``isinstance`` check keeps mocked results — whose ``.stderr`` is a ``Mock``
+    — quiet in tests.
+    """
+    if isinstance(result.stderr, str) and result.stderr.strip():
+        print(result.stderr, file=sys.stderr, end="")
 
 
 class ContainerRunner:
@@ -267,9 +281,51 @@ class ContainerRunner:
         name: str,
         command: list[str],
         check: bool = True,
+        user: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
-        """Execute a command in a running container and capture output."""
-        return self._engine.run("exec", name, *command, check=check)
+        """Execute a command in a running container and capture output.
+
+        When ``user`` is set, the command runs as that container user (e.g.
+        ``"root"``); otherwise it runs as the image's default ``USER``.
+        """
+        args = ["exec"]
+        if user is not None:
+            args += ["--user", user]
+        args.append(name)
+        return self._engine.run(*args, *command, check=check)
+
+    def reconcile_volume_ownership(self, name: str) -> None:
+        """Chown ``/pvc`` to the image's runtime user if the volume drifted.
+
+        Volumes created before the runtime UID/GID was pinned (see
+        ``paude.constants``) are owned by a non-deterministic ``useradd
+        --system`` UID. When the image is rebuilt during ``paude upgrade`` the
+        new container can run as a different UID and can no longer read/write the
+        reused volume (EACCES), which breaks config persistence and agent
+        logins. Reconcile so the volume always matches whoever the image's
+        ``paude`` user actually is — resolved at runtime with ``id``, not
+        assumed, so this stays correct whether the rebuilt image pinned the UID
+        to 1000:0 or inherited an older one (chowning to a wrong hardcoded UID
+        would itself lock the container out of its own volume).
+
+        Runs as root (rootless podman maps container-root to the invoking host
+        user, which can chown within the user namespace). Guarded so the common
+        already-correct case skips the recursive walk, and tolerant of failure
+        (best effort) so it never aborts an upgrade on its own.
+        """
+        script = (
+            "owner=$(id -u paude 2>/dev/null):$(id -g paude 2>/dev/null); "
+            "cur=$(stat -c %u:%g /pvc 2>/dev/null || echo); "
+            'if [ "$owner" != ":" ] && [ "$cur" != "$owner" ]; then '
+            'echo "Reconciling /pvc ownership to $owner..." >&2; '
+            'chown -R "$owner" /pvc; fi'
+        )
+        result = self.exec_in_container(
+            name, ["sh", "-c", script], check=False, user="root"
+        )
+        # Surface the one-time "Reconciling..." progress line (only emitted when
+        # a chown actually ran).
+        echo_captured_stderr(result)
 
     def inject_file(
         self,

--- a/tests/integration/test_upgrade_podman.py
+++ b/tests/integration/test_upgrade_podman.py
@@ -232,6 +232,91 @@ class TestPodmanUpgrade:
         finally:
             cleanup_session(backend, unique_session_name)
 
+    def test_upgrade_reconciles_drifted_volume_ownership(
+        self,
+        require_podman: None,
+        require_test_image: None,
+        require_proxy_image: None,
+        temp_workspace: Path,
+        unique_session_name: str,
+        podman_test_image: str,
+        podman_proxy_image: str,
+    ) -> None:
+        """A /pvc volume owned by a drifted (pre-pin) UID is reconciled to the
+        pinned runtime user when the container is recreated, so owner-only agent
+        credentials created before the UID pin stay readable after the upgrade.
+
+        Regression for the reported ``paude upgrade`` failure on a codex/chatgpt
+        session over a volume created before the UID/GID pin: without the
+        reconcile the recreated 1000:0 container cannot read /pvc/.codex/auth.json
+        (mode 600, owner ~997) and its OAuth login silently breaks.
+        """
+        backend = PodmanBackend()
+        container = f"paude-{unique_session_name}"
+
+        try:
+            with patch("paude.__version__", OLD_VERSION):
+                config = SessionConfig(
+                    name=unique_session_name,
+                    workspace=temp_workspace,
+                    image=podman_test_image,
+                    allowed_domains=["redhat.com"],
+                    proxy_image=podman_proxy_image,
+                    agent="gemini",
+                )
+                backend.create_session(config)
+
+            backend.start_session_no_attach(unique_session_name)
+            time.sleep(1)
+
+            # Seed an owner-only credential, then simulate a pre-pin volume by
+            # chowning /pvc to a UID the pinned runtime user (1000) doesn't own.
+            subprocess.run(
+                [
+                    "podman",
+                    "exec",
+                    "--user",
+                    "root",
+                    container,
+                    "sh",
+                    "-c",
+                    "mkdir -p /pvc/.codex && echo tok > /pvc/.codex/auth.json && "
+                    "chmod 600 /pvc/.codex/auth.json && chown -R 997:997 /pvc",
+                ],
+                check=True,
+                capture_output=True,
+            )
+
+            # The upgrade must complete (the hardened migration never aborts) and
+            # the recreated container must reconcile ownership.
+            _run_upgrade(
+                unique_session_name,
+                backend,
+                UpgradeOverrides(),
+                podman_test_image,
+                podman_proxy_image,
+            )
+
+            session = backend.get_session(unique_session_name)
+            assert session is not None
+            assert session.status == "running"
+
+            # /pvc and the owner-only auth.json are reconciled to the pinned user.
+            owner = _exec(container, "stat", "-c", "%u:%g", "/pvc")
+            assert owner.stdout.strip() == "1000:0", owner.stdout
+            auth_owner = _exec(
+                container, "stat", "-c", "%u:%g", "/pvc/.codex/auth.json"
+            )
+            assert auth_owner.stdout.strip() == "1000:0", auth_owner.stdout
+
+            # The runtime user (default exec user) can now read its own token.
+            auth = _exec(container, "cat", "/pvc/.codex/auth.json")
+            assert auth.returncode == 0
+            assert "tok" in auth.stdout
+
+        finally:
+            cleanup_session(backend, unique_session_name)
+
 
 class TestPodmanUpgradeReconfigure:
     """Integration coverage for `paude upgrade` add-agent / provider-swap.

--- a/tests/test_docker_compat.py
+++ b/tests/test_docker_compat.py
@@ -299,38 +299,51 @@ class TestDockerListContainers:
 
 
 class TestDockerVolumePermissions:
-    """Tests for Docker volume permission fixing."""
+    """Tests for /pvc volume ownership reconciliation on start."""
+
+    def _reconcile_exec(self, mock_run: MagicMock) -> list[str]:
+        """Return the single guarded root-exec argv issued by the reconcile."""
+        exec_calls = [
+            c[0][0]
+            for c in mock_run.call_args_list
+            if "exec" in c[0][0] and "--user" in c[0][0]
+        ]
+        assert len(exec_calls) == 1, exec_calls
+        return exec_calls[0]
 
     @patch("subprocess.run")
-    def test_docker_fixes_volume_permissions_on_start(
+    def test_docker_reconciles_volume_ownership_on_start(
         self, mock_run: MagicMock
     ) -> None:
-        """Docker should chown /pvc after starting a container."""
+        """Docker should chown /pvc to the pinned runtime user via a root exec."""
         mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         engine = ContainerEngine("docker")
         backend = PodmanBackend(engine=engine)
         backend._setup.fix_volume_permissions("paude-test")
-        # Find the chown call
-        chown_calls = [c for c in mock_run.call_args_list if "chown" in c[0][0]]
-        assert len(chown_calls) == 1
-        cmd = chown_calls[0][0][0]
-        assert cmd == [
-            "docker",
-            "exec",
-            "--user",
-            "root",
-            "paude-test",
-            "chown",
-            "paude",
-            "/pvc",
-        ]
+        argv = self._reconcile_exec(mock_run)
+        assert argv[:5] == ["docker", "exec", "--user", "root", "paude-test"]
+        assert argv[5:7] == ["sh", "-c"]
+        script = argv[7]
+        # Ownership target is resolved at runtime (not hardcoded), and the
+        # recursive chown is guarded by a stat probe so the already-correct case
+        # skips the walk.
+        assert "id -u paude" in script
+        assert 'chown -R "$owner" /pvc' in script
+        assert "stat -c %u:%g /pvc" in script
 
-    def test_podman_skips_volume_permission_fix(self) -> None:
-        """Podman should skip volume permission fix (uses user namespaces)."""
+    @patch("subprocess.run")
+    def test_podman_reconciles_volume_ownership_on_start(
+        self, mock_run: MagicMock
+    ) -> None:
+        """Podman no longer skips: a reused, UID-drifted volume must be fixed."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
         engine = ContainerEngine("podman")
         backend = PodmanBackend(engine=engine)
-        # Should be a no-op, no subprocess call needed
         backend._setup.fix_volume_permissions("paude-test")
+        argv = self._reconcile_exec(mock_run)
+        assert argv[:5] == ["podman", "exec", "--user", "root", "paude-test"]
+        assert 'chown -R "$owner" /pvc' in argv[-1]
+        assert "id -u paude" in argv[-1]
 
 
 class TestDockerCredentialInjection:

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -413,6 +414,67 @@ class TestUpgradePodman:
         assert config.reuse_volume is True
         # start_session_no_attach called
         backend.start_session_no_attach.assert_called_once_with("test-session")
+
+    @patch("paude.transport.config_sync.remap_mounts")
+    @patch("paude.transport.config_sync.sync_configs_to_remote")
+    @patch("paude.mounts.build_mounts")
+    @patch("paude.cli.helpers._prepare_session_create")
+    @patch("paude.container.ImageManager")
+    @patch("paude.config.detector.detect_config", return_value=None)
+    @patch("paude.backends.podman.helpers.find_container_by_session_name")
+    def test_upgrade_remaps_remote_config_mounts(
+        self,
+        mock_find_container: MagicMock,
+        mock_detect_config: MagicMock,
+        mock_image_manager_class: MagicMock,
+        mock_prepare: MagicMock,
+        mock_build_mounts: MagicMock,
+        mock_sync: MagicMock,
+        mock_remap: MagicMock,
+    ) -> None:
+        """A --host upgrade transfers config to the remote host and remaps the
+        bind-mount sources, so podman on the remote isn't handed a local (e.g.
+        Mac) path that doesn't exist there ("statfs ...: no such file")."""
+        from paude.transport.ssh import SshTransport
+
+        mock_find_container.return_value = {"Labels": self._make_container_labels()}
+
+        mock_image_manager = MagicMock()
+        mock_image_manager.ensure_default_image.return_value = "paude:latest"
+        mock_image_manager_class.return_value = mock_image_manager
+        mock_prepare.return_value = ([], [], {}, True)
+
+        local_mounts = ["-v", "/Users/bob/.gitconfig:/home/paude/.gitconfig:ro"]
+        remote_mounts = [
+            "-v",
+            "/tmp/paude-config-x/0/.gitconfig:/home/paude/.gitconfig:ro",
+        ]
+        mock_build_mounts.return_value = local_mounts
+        mock_sync.return_value = MagicMock(
+            path_map={"/Users/bob/.gitconfig": "/tmp/paude-config-x/0/.gitconfig"}
+        )
+        mock_remap.return_value = remote_mounts
+
+        from paude.backends.podman.backend import PodmanBackend
+
+        backend = MagicMock(spec=PodmanBackend)
+        backend._runner = MagicMock()
+        backend._runner.container_exists.return_value = False
+        backend._network_manager = MagicMock()
+        backend._volume_manager = MagicMock()
+        backend._engine = MagicMock()
+        backend._engine.is_remote = True
+        backend._engine.transport = MagicMock(spec=SshTransport)
+
+        from paude.cli.upgrade import _upgrade_podman
+
+        _upgrade_podman("test-session", backend, rebuild=False, overrides=_NO_OVERRIDES)
+
+        mock_sync.assert_called_once()
+        mock_remap.assert_called_once()
+        # The recreated session uses the remapped (remote) mount sources.
+        session_config = backend.create_session.call_args[0][0]
+        assert session_config.mounts == remote_mounts
 
     @patch("paude.mounts.build_mounts", return_value=[])
     @patch("paude.cli.helpers._prepare_session_create")
@@ -1093,6 +1155,34 @@ class TestUpgradeResume:
         assert "safe" in output.lower()
         assert "retry" in output.lower()
         assert "paude upgrade test-session" in output
+
+    @patch("paude.cli.upgrade._upgrade_podman")
+    @patch("paude.cli.upgrade.find_session_backend")
+    def test_failure_surfaces_called_process_stderr(
+        self, mock_find: MagicMock, mock_upgrade_podman: MagicMock
+    ) -> None:
+        """A CalledProcessError escaping the upgrade must report its captured
+        stderr, not the opaque 'returned non-zero exit status' string that hid
+        the /pvc ownership migration failure."""
+        from paude.backends.podman.backend import PodmanBackend
+
+        mock_upgrade_podman.side_effect = subprocess.CalledProcessError(
+            1, ["podman", "exec"], stderr="cp: '/pvc/.codex': Permission denied"
+        )
+
+        mock_backend = MagicMock()
+        mock_backend.__class__ = PodmanBackend
+        mock_backend.get_session.return_value = _make_session(
+            "test-session", version="0.1.0"
+        )
+        mock_find.return_value = ("podman", mock_backend)
+
+        result = runner.invoke(app, ["upgrade", "test-session"])
+
+        assert result.exit_code == 1
+        output = result.stdout + (result.stderr or "")
+        assert "Permission denied" in output
+        assert "returned non-zero exit status" not in output
 
     def test_unregister_clears_manifest(self) -> None:
         """Deleting a session (via registry.unregister) removes its manifest,

--- a/tests/test_upgrade_persistence.py
+++ b/tests/test_upgrade_persistence.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import subprocess
 from unittest.mock import MagicMock, call
 
 import pytest
 
 from paude.agents import get_agents
 from paude.cli.upgrade_persistence import (
+    _MIGRATE_SCRIPT,
     migrate_legacy_state,
     persistent_state_paths,
 )
@@ -64,12 +66,61 @@ def test_migration_quiesces_an_already_running_container() -> None:
     ]
 
 
-def test_migration_restops_container_when_copy_fails() -> None:
+def test_migration_does_not_reconcile_ownership() -> None:
+    """Migration must NOT chown the volume: the old container may own it at a
+    pre-pin UID, and reconciling to the pinned user here would remove its write
+    access. Ownership is reconciled on the recreated container instead."""
     runner = MagicMock()
     runner.container_running.return_value = False
-    runner.exec_in_container.side_effect = RuntimeError("copy failed")
 
-    with pytest.raises(RuntimeError, match="copy failed"):
-        migrate_legacy_state(runner, "paude-demo", get_agents(["opencode"]))
+    migrate_legacy_state(runner, "paude-demo", get_agents(["codex"]))
 
+    runner.reconcile_volume_ownership.assert_not_called()
+    # The copy runs as the container's default user, not root.
+    assert runner.exec_in_container.call_args.kwargs.get("user") is None
+
+
+def test_migration_surfaces_stderr_on_failure() -> None:
+    runner = MagicMock()
+    runner.container_running.return_value = False
+    runner.exec_in_container.side_effect = subprocess.CalledProcessError(
+        1, ["bash"], stderr="cp: cannot create '/pvc/.codex': Permission denied"
+    )
+
+    with pytest.raises(RuntimeError, match="Permission denied"):
+        migrate_legacy_state(runner, "paude-demo", get_agents(["codex"]))
+
+    # The container is still re-stopped even when the copy fails.
     runner.stop_container_graceful.assert_called_once_with("paude-demo")
+
+
+def test_migration_prints_nonfatal_warnings(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runner = MagicMock()
+    runner.container_running.return_value = False
+    runner.exec_in_container.return_value = subprocess.CompletedProcess(
+        args=["bash"],
+        returncode=0,
+        stdout="",
+        stderr="migrate: could not fully migrate .codex\n",
+    )
+
+    migrate_legacy_state(runner, "paude-demo", get_agents(["codex"]))
+
+    assert "could not fully migrate .codex" in capsys.readouterr().err
+
+
+def test_migrate_script_guards_every_write() -> None:
+    """Each cp/mkdir in the migration script must be non-fatal and warn.
+
+    Guards the fix against regressing back to an unguarded ``set -e`` copy that
+    aborts the whole upgrade on one un-writable path (the reported failure).
+    """
+    # A warn helper emits per-path failures to stderr (surfaced by the caller).
+    assert "warn()" in _MIGRATE_SCRIPT
+    assert ">&2" in _MIGRATE_SCRIPT
+    for line in _MIGRATE_SCRIPT.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(("cp ", "mkdir ")):
+            assert "||" in stripped, f"unguarded write: {stripped}"


### PR DESCRIPTION
`paude upgrade` failed on a remote (--host) codex/ChatGPT session in several ways, each masked by the previous one. This fixes them and records a related latent issue.

State migration (upgrade_persistence.py):
- _MIGRATE_SCRIPT ran `set -e` with unguarded cp/mkdir, so the first un-copyable path aborted the whole upgrade. On a remote session this surfaced as an opaque "returned non-zero exit status 1": cp could not read the root-owned, host-mounted ~/.gitconfig. Each cp/mkdir now warns and continues (mirroring the entrypoint's persist_config_dir); the copy runs as the old container's default user (best-effort salvage).
- Migration failures, and the generic upgrade handler, now surface the captured stderr instead of an opaque exit status.

Volume ownership (runner.py, session_setup.py):
- Pinning the runtime user to 1000:0 left volumes created by the earlier `useradd --system` UID owned by that stale UID; upgrade reuses /pvc and never reconciled ownership on podman, so a recreated container could not read /pvc/.codex/auth.json and Codex OAuth silently broke.
- Add ContainerRunner.reconcile_volume_ownership: chown /pvc to the image's actual paude user, resolved at runtime with `id -u paude` (not a hardcoded UID, which could lock the container out of its own volume), guarded by a stat probe so the already-correct case skips the walk. Generalize SessionSetup.fix_volume_permissions to delegate to it so it runs on the recreated container (podman and docker) before configure_codex and the entrypoint read the volume. Add exec_in_container(user=...) and an echo_captured_stderr helper.

Remote mount remap (upgrade.py):
- _upgrade_podman built bind mounts from the local home but, unlike the create path, never transferred the referenced config to the remote host or remapped the mount sources, so podman on the remote got a local (e.g. Mac) path like /Users/<user>/.gitconfig and failed with "statfs ...: no such file". Mirror create_podman: sync_configs_to_remote
  + remap_mounts for SSH remotes.

Tests/docs:
- Add unit + integration coverage (migration hardening, stderr surfacing, reconcile exec, remote mount remap); update KNOWN_ISSUES (RUNTIME-004) and docs/SESSIONS.md.
- Record RUNTIME-005: remote sessions bind-mount ~/.gitconfig, which SELinux can make unreadable, so a fresh remote session's gitconfig seed can silently fail.