### PR TITLE
Bump paude-proxy to pick up gcloud token refresh retry fix

### DIFF
--- a/containers/proxy/Dockerfile
+++ b/containers/proxy/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage — compile paude-proxy from source
 FROM golang:1.23 AS builder
 WORKDIR /app
-ARG PAUDE_PROXY_VERSION=efc0fe8d2d54ed2d3ef3abe503e5110449413b37
+ARG PAUDE_PROXY_VERSION=43f9bbc089a122e675e3c781a7e552ae6a3c85db
 RUN git init . && \
     git fetch --depth 1 https://github.com/bbrowning/paude-proxy.git ${PAUDE_PROXY_VERSION} && \
     git checkout FETCH_HEAD && \


### PR DESCRIPTION
paude-proxy commit 43f9bbc adds a retry-once-with-forced-refresh path for upstream 401s from Vertex/gcloud, fixing a bug where a long-idle proxy container (e.g. after a laptop sleep/resume) could keep replaying a locally-"valid" but server-rejected OAuth token until the session was fully stopped and restarted.