### PR TITLE
Fix flaky proxy-IP determination on Podman --disable-dns networks

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -128,6 +128,34 @@ SSH transfer paths untouched by the streaming-backup work.
 
 This predates the `--add-agent` work (the `--providers` validation branch was already in `upgrade.py`); the cleanup pass left it in place because a proper fix reaches outside the changed code and is entangled with the resolver's `SettingValue`/provenance tracking. Consider extracting a shared `reconcile_credential_providers(agent_providers, explicit_providers) -> list[str]` (plus a `providers_from_composition(composition)` helper) next to `_derive_agent_providers` in `resolver.py`, and calling it from both `create` and `upgrade` so the invariant and error wording can't drift.
 
+### REFACTOR-009: Proxy IP is inspected back from an auto-allocated subnet instead of being chosen deterministically
+
+**Status**: Open
+**Priority**: Low (bounded retry makes it reliable today; deterministic subnet is the deeper fix)
+**Discovered**: 2026-08-14 during a `/simplify` review of the proxy-IP race fix
+
+`PodmanProxyManager.create_proxy` (`src/paude/backends/podman/proxy.py`) lets
+Podman auto-allocate the session network's subnet (`create_internal_network`
+with no `--subnet`), then discovers the gateway/proxy IP by running `podman
+network inspect` (`_get_proxy_ip` → `NetworkManager.get_network_gateway`) and
+deriving `gateway + 1`. The inspect can race the create — on a `--disable-dns`
+network run under CI load, `network inspect` occasionally returns before the
+subnet/IPAM is populated, so the proxy IP comes back `None`. The current fix is
+a bounded retry poll in `_get_proxy_ip` (5 attempts, 0.25s apart) plus a
+Podman-gated hard error when the IP still can't be determined.
+
+The retry is a reasonable, low-risk interim measure, but it is a workaround for
+a design that could be deterministic: passing an explicit `--subnet` at network
+create time makes the gateway/proxy IP known *without inspecting at all*,
+eliminating the whole race class — and with it the retry poll, the `None`
+return, the hard-error gate, and the Docker hostname-fallback branch in
+`session_setup.py`. The catch (why it's deferred): an explicit subnet trades the
+inspect race for a subnet-allocation/collision problem — concurrent sessions
+would each need a distinct, non-colliding subnet within a private range, which
+Podman's auto-allocator currently handles for free. That's a meaningful new
+subsystem. If this race keeps recurring, the deterministic subnet is the actual
+fix and should be prioritized over widening the retry budget.
+
 ## Correctness Backlog
 
 Lower-severity correctness/robustness issues surfaced during code review.

--- a/src/paude/backends/podman/proxy.py
+++ b/src/paude/backends/podman/proxy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+import time
 from collections.abc import Mapping
 
 from paude.backends.labels import (
@@ -28,9 +29,15 @@ from paude.backends.proxy_config import (
 )
 from paude.container.engine import ContainerEngine
 from paude.container.network import NetworkManager
-from paude.container.proxy_runner import ProxyRunner
+from paude.container.proxy_runner import ProxyRunner, ProxyStartError
 from paude.container.runner import ContainerRunner
 from paude.platform import get_podman_machine_dns, is_macos
+
+# Bounded poll for deriving the proxy IP from a freshly-created network;
+# see _get_proxy_ip for the inspect-vs-create race this compensates for.
+# The happy path returns on the first attempt with no added latency.
+_PROXY_IP_POLL_ATTEMPTS = 5
+_PROXY_IP_POLL_INTERVAL = 0.25  # seconds (<=4 sleeps -> ~1s worst case)
 
 
 def _get_host_dns(engine: ContainerEngine) -> str | None:
@@ -175,11 +182,12 @@ class PodmanProxyManager:
         if not volume_mgr.volume_exists(auth_vol):
             volume_mgr.create_volume(auth_vol)
 
-        self._network_manager.create_internal_network(
-            nname, disable_dns=self._runner.engine.is_podman
-        )
+        disable_dns = self._runner.engine.is_podman
+        self._network_manager.create_internal_network(nname, disable_dns=disable_dns)
 
-        proxy_ip = self._get_proxy_ip(nname)
+        proxy_ip = self._resolve_proxy_ip(
+            nname, disable_dns, remove_network_on_failure=True
+        )
         agent_ip = derive_agent_ip(proxy_ip) if proxy_ip else None
         dns = _get_host_dns(self._runner.engine)
         secret_refs = self._create_credential_secrets(session_name, credentials)
@@ -235,11 +243,57 @@ class PodmanProxyManager:
         derive_proxy_ip() adds 1 → 10.89.2.2. The proxy is then
         explicitly assigned this IP via --network net:ip=10.89.2.2,
         so container creation order does not matter.
+
+        The gateway lookup is polled a few times because
+        ``network inspect`` run right after ``network create`` can briefly
+        report the network before its subnet/IPAM is populated (a race that
+        widens under CI load). Returns None only if no gateway/subnet shows
+        up within the bounded retry budget.
         """
-        gateway = self._network_manager.get_network_gateway(nname)
-        if not gateway:
-            return None
-        return NetworkManager.derive_proxy_ip(gateway)
+        for attempt in range(_PROXY_IP_POLL_ATTEMPTS):
+            gateway = self._network_manager.get_network_gateway(nname)
+            if gateway:
+                return NetworkManager.derive_proxy_ip(gateway)
+            if attempt < _PROXY_IP_POLL_ATTEMPTS - 1:
+                time.sleep(_PROXY_IP_POLL_INTERVAL)
+        return None
+
+    def _resolve_proxy_ip(
+        self,
+        nname: str,
+        disable_dns: bool,
+        *,
+        remove_network_on_failure: bool,
+    ) -> str | None:
+        """Derive the proxy IP, failing loudly when it would be unreachable.
+
+        On a --disable-dns network the agent container can't resolve the
+        proxy by name, so a None IP means the proxy is genuinely
+        unreachable. Raise ProxyStartError instead of silently degrading to
+        an unusable session. With DNS the hostname fallback is legitimate,
+        so None passes through unchanged.
+
+        This invariant is a property of the network, not of any one caller,
+        so every path that derives a proxy IP routes through here rather
+        than re-implementing (and drifting from) the guard.
+
+        Args:
+            remove_network_on_failure: Remove the network before raising.
+                Callers that just created the network pass True; callers
+                operating on a live network (update_domains) pass False so
+                a transient inspect failure doesn't tear down a working
+                session's network.
+        """
+        proxy_ip = self._get_proxy_ip(nname)
+        if proxy_ip is None and disable_dns:
+            if remove_network_on_failure:
+                self._network_manager.remove_network(nname)
+            raise ProxyStartError(
+                f"Could not determine proxy IP for network {nname}; the "
+                "proxy would be unreachable on a --disable-dns network. "
+                "Aborting."
+            )
+        return proxy_ip
 
     def create_proxy(
         self,
@@ -259,11 +313,17 @@ class PodmanProxyManager:
             raise ValueError("proxy_image is required to create a proxy")
 
         nname = network_name(session_name)
-        self._network_manager.create_internal_network(
-            nname, disable_dns=self._runner.engine.is_podman
-        )
+        # `disable_dns` is the single fact that decides whether a hostname
+        # fallback is viable: with DNS the agent can resolve the proxy by
+        # name, without it only the IP works. Derive it once and reuse it for
+        # both the network create and the reachability guard in
+        # _resolve_proxy_ip so the two can't drift.
+        disable_dns = self._runner.engine.is_podman
+        self._network_manager.create_internal_network(nname, disable_dns=disable_dns)
 
-        proxy_ip = self._get_proxy_ip(nname)
+        proxy_ip = self._resolve_proxy_ip(
+            nname, disable_dns, remove_network_on_failure=True
+        )
 
         # Create a named volume for the CA certificate
         from paude.container.volume import VolumeManager
@@ -370,7 +430,14 @@ class PodmanProxyManager:
         nname = network_name(session_name)
         ca_vol = ca_volume_name(session_name)
         auth_vol = auth_volume_name(session_name)
-        proxy_ip = self._get_proxy_ip(nname)
+        # The network is already live here, so don't remove it on a
+        # transient inspect failure — that would tear down a working
+        # session's network.
+        proxy_ip = self._resolve_proxy_ip(
+            nname,
+            self._runner.engine.is_podman,
+            remove_network_on_failure=False,
+        )
         agent_ip = derive_agent_ip(proxy_ip) if proxy_ip else None
         dns = _get_host_dns(self._runner.engine)
 

--- a/src/paude/backends/podman/session_setup.py
+++ b/src/paude/backends/podman/session_setup.py
@@ -330,10 +330,12 @@ class SessionSetup:
             credentials=proxy_creds,
         )
         if proxy_ip is None:
+            # Reached only on DNS-enabled networks (Docker); create_proxy()
+            # raises on --disable-dns networks (Podman) where the hostname
+            # wouldn't resolve. Source-IP filtering and proxy DNS are skipped.
             print(
-                "WARNING: Could not determine proxy IP; "
-                "container DNS will not use the proxy "
-                "for resolution.",
+                "WARNING: Could not determine proxy IP; falling back to the "
+                "proxy hostname (source-IP filtering disabled).",
                 file=sys.stderr,
             )
         proxy.start_proxy(session_name)

--- a/tests/integration/test_podman_backend.py
+++ b/tests/integration/test_podman_backend.py
@@ -769,6 +769,7 @@ class TestPodmanProxySetup:
                 check=True,
             )
             proxy_ip = result.stdout.strip()
+            assert proxy_ip, "Proxy IP should be resolvable on the internal network"
 
             # Verify main container has HTTP_PROXY env var set
             result = subprocess.run(

--- a/tests/test_podman_proxy.py
+++ b/tests/test_podman_proxy.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from paude.backends.podman.proxy import (
+    _PROXY_IP_POLL_ATTEMPTS,
     CA_CERT_CONTAINER_PATH,
     PodmanProxyManager,
     _get_host_dns,
@@ -14,6 +15,7 @@ from paude.backends.podman.proxy import (
     ca_volume_name,
 )
 from paude.backends.proxy_config import derive_agent_ip
+from paude.container.proxy_runner import ProxyStartError
 
 
 def _make_mock_runner(engine_binary: str = "podman") -> MagicMock:
@@ -155,13 +157,14 @@ class TestProxyManagerFixedIp:
         assert nname == "paude-net-test-session"
         assert proxy_ip == "10.89.0.2"
 
+    @patch("paude.backends.podman.proxy.time.sleep")
     @patch("paude.backends.podman.proxy.get_podman_machine_dns")
-    def test_create_proxy_returns_none_ip_when_no_gateway(
-        self, mock_dns: MagicMock
+    def test_create_proxy_docker_returns_none_ip_when_no_gateway(
+        self, mock_dns: MagicMock, mock_sleep: MagicMock
     ) -> None:
-        """create_proxy returns None for proxy_ip when gateway unavailable."""
+        """On Docker, create_proxy returns None IP (hostname fallback is ok)."""
         mock_dns.return_value = None
-        mock_runner = _make_mock_runner()
+        mock_runner = _make_mock_runner("docker")
         mock_runner.container_exists.return_value = False
         mock_network = MagicMock()
         mock_network.get_network_gateway.return_value = None
@@ -175,6 +178,29 @@ class TestProxyManagerFixedIp:
 
         assert nname == "paude-net-test-session"
         assert proxy_ip is None
+        mock_network.remove_network.assert_not_called()
+
+    @patch("paude.backends.podman.proxy.time.sleep")
+    @patch("paude.backends.podman.proxy.get_podman_machine_dns")
+    def test_create_proxy_raises_on_podman_when_ip_unavailable(
+        self, mock_dns: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        """On Podman, create_proxy aborts and removes the network if no IP."""
+        mock_dns.return_value = None
+        mock_runner = _make_mock_runner()
+        mock_runner.container_exists.return_value = False
+        mock_network = MagicMock()
+        mock_network.get_network_gateway.return_value = None
+
+        manager = PodmanProxyManager(mock_runner, mock_network)
+        with pytest.raises(ProxyStartError):
+            manager.create_proxy(
+                session_name="test-session",
+                proxy_image="proxy:latest",
+                allowed_domains=[".googleapis.com"],
+            )
+
+        mock_network.remove_network.assert_called_once_with("paude-net-test-session")
 
     @patch("paude.backends.podman.proxy.get_podman_machine_dns")
     def test_create_proxy_passes_ip_to_proxy_runner(self, mock_dns: MagicMock) -> None:
@@ -204,6 +230,178 @@ class TestProxyManagerFixedIp:
         net_indices = [i for i, a in enumerate(call_args) if a == "--network"]
         assert len(net_indices) == 2
         assert "ip=172.28.0.2" in call_args[net_indices[0] + 1]
+
+
+class TestResolveProxyIpGuard:
+    """Direct tests for the shared _resolve_proxy_ip reachability guard."""
+
+    @patch("paude.backends.podman.proxy.time.sleep")
+    def test_raises_and_removes_network_when_owned(self, mock_sleep: MagicMock) -> None:
+        """On disable-dns with no IP, raise and remove a just-created network."""
+        mock_runner = _make_mock_runner()
+        mock_network = MagicMock()
+        mock_network.get_network_gateway.return_value = None
+
+        manager = PodmanProxyManager(mock_runner, mock_network)
+        with pytest.raises(ProxyStartError):
+            manager._resolve_proxy_ip(
+                "paude-net-test", disable_dns=True, remove_network_on_failure=True
+            )
+
+        mock_network.remove_network.assert_called_once_with("paude-net-test")
+
+    @patch("paude.backends.podman.proxy.time.sleep")
+    def test_raises_without_removing_live_network(self, mock_sleep: MagicMock) -> None:
+        """A live network is not torn down on a transient inspect failure."""
+        mock_runner = _make_mock_runner()
+        mock_network = MagicMock()
+        mock_network.get_network_gateway.return_value = None
+
+        manager = PodmanProxyManager(mock_runner, mock_network)
+        with pytest.raises(ProxyStartError):
+            manager._resolve_proxy_ip(
+                "paude-net-test", disable_dns=True, remove_network_on_failure=False
+            )
+
+        mock_network.remove_network.assert_not_called()
+
+    @patch("paude.backends.podman.proxy.time.sleep")
+    def test_returns_none_without_raising_when_dns_enabled(
+        self, mock_sleep: MagicMock
+    ) -> None:
+        """With DNS the hostname fallback is legitimate, so None passes through."""
+        mock_runner = _make_mock_runner("docker")
+        mock_network = MagicMock()
+        mock_network.get_network_gateway.return_value = None
+
+        manager = PodmanProxyManager(mock_runner, mock_network)
+        result = manager._resolve_proxy_ip(
+            "paude-net-test", disable_dns=False, remove_network_on_failure=True
+        )
+
+        assert result is None
+        mock_network.remove_network.assert_not_called()
+
+    def test_returns_derived_ip_on_success(self) -> None:
+        """The happy path returns the derived proxy IP."""
+        mock_runner = _make_mock_runner()
+        mock_network = MagicMock()
+        mock_network.get_network_gateway.return_value = "10.89.0.1"
+
+        manager = PodmanProxyManager(mock_runner, mock_network)
+        result = manager._resolve_proxy_ip(
+            "paude-net-test", disable_dns=True, remove_network_on_failure=True
+        )
+
+        assert result == "10.89.0.2"
+        mock_network.remove_network.assert_not_called()
+
+    @patch("paude.backends.podman.proxy.time.sleep")
+    @patch("paude.backends.podman.proxy._get_host_dns")
+    def test_start_if_needed_raises_on_podman_when_ip_unavailable(
+        self, mock_dns: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        """Recreating a missing proxy aborts + removes the network if no IP."""
+        mock_dns.return_value = None
+        mock_runner = _make_mock_runner()
+        # Proxy container is gone -> recreate path
+        mock_runner.container_exists.return_value = False
+        mock_network = MagicMock()
+        mock_network.get_network_gateway.return_value = None
+
+        manager = PodmanProxyManager(mock_runner, mock_network)
+        with patch.object(
+            manager,
+            "get_config_from_labels",
+            return_value=("proxy:latest", [".googleapis.com"], []),
+        ):
+            with pytest.raises(ProxyStartError):
+                manager.start_if_needed(session_name="test-session")
+
+        mock_network.remove_network.assert_called_once_with("paude-net-test-session")
+        # A silently-broken proxy must never be created
+        create_calls = [
+            c
+            for c in mock_runner.engine.run.call_args_list
+            if c[0] and c[0][0] == "create"
+        ]
+        assert not create_calls
+
+    @patch("paude.backends.podman.proxy.time.sleep")
+    @patch("paude.backends.podman.proxy._get_host_dns")
+    def test_update_domains_raises_on_podman_when_ip_unavailable(
+        self, mock_dns: MagicMock, mock_sleep: MagicMock
+    ) -> None:
+        """update_domains aborts without tearing down the live network."""
+        mock_dns.return_value = None
+        mock_runner = _make_mock_runner()
+        mock_runner.container_exists.return_value = True
+        mock_runner.get_container_image.return_value = "proxy:latest"
+        mock_network = MagicMock()
+        mock_network.get_network_gateway.return_value = None
+
+        manager = PodmanProxyManager(mock_runner, mock_network)
+        with pytest.raises(ProxyStartError):
+            manager.update_domains(
+                session_name="test-session",
+                domains=[".googleapis.com"],
+            )
+
+        # The live network must survive a transient inspect failure
+        mock_network.remove_network.assert_not_called()
+
+
+class TestProxyIpRetry:
+    """Tests for the bounded retry in PodmanProxyManager._get_proxy_ip."""
+
+    @patch("paude.backends.podman.proxy.time.sleep")
+    def test_get_proxy_ip_retries_until_gateway_available(
+        self, mock_sleep: MagicMock
+    ) -> None:
+        """A transient empty inspect is retried until the gateway appears."""
+        mock_runner = _make_mock_runner()
+        mock_network = MagicMock()
+        mock_network.get_network_gateway.side_effect = [None, None, "10.89.0.1"]
+
+        manager = PodmanProxyManager(mock_runner, mock_network)
+        result = manager._get_proxy_ip("paude-net-test")
+
+        assert result == "10.89.0.2"
+        assert mock_network.get_network_gateway.call_count == 3
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(0.25)
+
+    @patch("paude.backends.podman.proxy.time.sleep")
+    def test_get_proxy_ip_returns_none_after_exhausting_attempts(
+        self, mock_sleep: MagicMock
+    ) -> None:
+        """After all attempts fail, _get_proxy_ip returns None."""
+        mock_runner = _make_mock_runner()
+        mock_network = MagicMock()
+        mock_network.get_network_gateway.return_value = None
+
+        manager = PodmanProxyManager(mock_runner, mock_network)
+        result = manager._get_proxy_ip("paude-net-test")
+
+        assert result is None
+        assert mock_network.get_network_gateway.call_count == _PROXY_IP_POLL_ATTEMPTS
+        assert mock_sleep.call_count == _PROXY_IP_POLL_ATTEMPTS - 1
+
+    @patch("paude.backends.podman.proxy.time.sleep")
+    def test_get_proxy_ip_no_sleep_on_first_success(
+        self, mock_sleep: MagicMock
+    ) -> None:
+        """The happy path returns on the first attempt without sleeping."""
+        mock_runner = _make_mock_runner()
+        mock_network = MagicMock()
+        mock_network.get_network_gateway.return_value = "10.89.0.1"
+
+        manager = PodmanProxyManager(mock_runner, mock_network)
+        result = manager._get_proxy_ip("paude-net-test")
+
+        assert result == "10.89.0.2"
+        assert mock_network.get_network_gateway.call_count == 1
+        mock_sleep.assert_not_called()
 
 
 class TestProxyManagerDisableDns:
@@ -909,13 +1107,18 @@ class TestSourceIpFiltering:
         env_vals = [call_args[i + 1] for i in env_indices]
         assert "PAUDE_PROXY_ALLOWED_CLIENTS=10.89.0.3" in env_vals
 
+    @patch("paude.backends.podman.proxy.time.sleep")
     @patch("paude.backends.podman.proxy.get_podman_machine_dns")
     def test_create_proxy_no_allowed_clients_when_no_gateway(
-        self, mock_dns: MagicMock
+        self, mock_dns: MagicMock, mock_sleep: MagicMock
     ) -> None:
-        """create_proxy omits allowed_clients when gateway is unavailable."""
+        """create_proxy omits allowed_clients when gateway is unavailable.
+
+        Uses Docker, where a missing IP is a legitimate hostname fallback;
+        on Podman create_proxy raises instead (see TestProxyManagerFixedIp).
+        """
         mock_dns.return_value = None
-        mock_runner = _make_mock_runner()
+        mock_runner = _make_mock_runner("docker")
         mock_runner.container_exists.return_value = False
         mock_network = MagicMock()
         mock_network.get_network_gateway.return_value = None

--- a/tests/test_podman_session.py
+++ b/tests/test_podman_session.py
@@ -52,6 +52,7 @@ def _make_backend(
     mock_runner: MagicMock | None = None,
     mock_network_manager: MagicMock | None = None,
     mock_volume_manager: MagicMock | None = None,
+    engine_binary: str = "podman",
 ) -> PodmanBackend:
     """Create a PodmanBackend with mocked runner, network, and volume manager."""
     backend = PodmanBackend()
@@ -60,10 +61,13 @@ def _make_backend(
         if not hasattr(mock_runner.engine, "binary") or isinstance(
             mock_runner.engine.binary, MagicMock
         ):
-            mock_runner.engine.binary = "podman"
-            mock_runner.engine.is_podman = True
-            mock_runner.engine.supports_multi_network_create = True
-            mock_runner.engine.default_bridge_network = "podman"
+            is_podman = engine_binary != "docker"
+            mock_runner.engine.binary = engine_binary
+            mock_runner.engine.is_podman = is_podman
+            mock_runner.engine.supports_multi_network_create = is_podman
+            mock_runner.engine.default_bridge_network = (
+                "podman" if is_podman else "bridge"
+            )
             mock_runner.engine.is_remote = False
             mock_runner.engine.run.return_value = MagicMock(
                 returncode=0, stdout="", stderr=""
@@ -1185,12 +1189,20 @@ class TestPodmanBackendCreateSessionWithProxy:
         assert call_kwargs["dns"] == ["10.89.0.2"]
         assert call_kwargs["network"] == "paude-net-dns-session"
 
+    @patch("paude.backends.podman.proxy.time.sleep")
     @patch("paude.backends.podman.proxy.get_podman_machine_dns")
     @patch("paude.backends.podman.backend.ContainerRunner")
     def test_create_session_no_dns_false_when_no_proxy_ip(
-        self, mock_runner_class: MagicMock, mock_dns: MagicMock
+        self,
+        mock_runner_class: MagicMock,
+        mock_dns: MagicMock,
+        mock_sleep: MagicMock,
     ) -> None:
-        """Network keeps plain name when proxy IP cannot be determined."""
+        """On Docker, the network keeps its plain name when the proxy IP
+        cannot be determined: the DNS-enabled network makes the hostname
+        fallback legitimate. Podman aborts instead — see
+        tests/test_podman_proxy.py.
+        """
         mock_runner = MagicMock()
         mock_runner.container_exists.return_value = False
         mock_runner_class.return_value = mock_runner
@@ -1198,7 +1210,7 @@ class TestPodmanBackendCreateSessionWithProxy:
         mock_network = MagicMock()
         mock_network.get_network_gateway.return_value = None
 
-        backend = _make_backend(mock_runner, mock_network)
+        backend = _make_backend(mock_runner, mock_network, engine_binary="docker")
 
         config = SessionConfig(
             name="no-ip-session",


### PR DESCRIPTION
`podman network inspect` run immediately after `podman network create --disable-dns` can return before the subnet/IPAM is populated (a race that widens under CI load). When that happened, create_proxy() derived a None proxy IP and silently fell back to the proxy hostname -- which is unresolvable on a --disable-dns network, so the session's proxy was genuinely unreachable. This surfaced as an integration-test flake where HTTP_PROXY intermittently held the hostname instead of the IP.

Fix it in two parts:

- Bounded retry in _get_proxy_ip: poll get_network_gateway up to 5 times (0.25s apart, ~1s worst case) before giving up. The happy path returns on the first attempt with no added latency, and the retry is inert on the network-already-exists call sites (start_if_needed, update_domains) where the subnet is already populated.

- Fail loudly on Podman: centralize the reachability guard in _resolve_proxy_ip so all three IP-deriving paths (create_proxy, start_if_needed, update_domains) refuse to build a silently-broken session when the IP can't be determined on a --disable-dns network. Paths that just created the network remove it before raising; update_domains leaves its live network intact so a transient inspect failure can't tear down a working session. Docker keeps DNS, so its hostname fallback stays legitimate. Deriving disable_dns once and passing it to both the network create and the guard keeps the two from drifting.

Also add an integration assertion that the proxy IP is resolvable, and document the deterministic-`--subnet` deeper fix as REFACTOR-009.