### PR TITLE
Fix stale-network start failures; harden upgrade's legacy salvage

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -197,6 +197,14 @@ distinguish "displaced by this swap" from "provisioned on purpose." A fix would
 track which provider each remap displaces and prune only that, rather than
 pruning every unreferenced provider.
 
+### NET-001: `NetworkManager.remove_network` silently swallows failures
+
+**Status**: Open
+**Severity**: Low
+**Discovered**: 2026-08-24 while fixing the `start_if_needed` stale-network bug (see git history for the fix that stopped the risky call site from invoking this)
+
+`remove_network()` in `src/paude/container/network.py` runs `podman network rm <name>` with `check=False` and doesn't inspect the `CompletedProcess` result at all, so a failed removal (e.g. the network still has a container attached) is indistinguishable from success. The one call site that removed a network still in active use by a live agent container (`PodmanProxyManager.start_if_needed`'s recreate-missing-proxy branch) has been fixed to no longer call this in that situation, but the underlying swallow-everything behavior in `remove_network` itself is still present for any future caller. A fix would capture the result and at least log a warning on non-zero exit (mirroring the pattern already used for `echo_captured_stderr`).
+
 ## Agent Limitations
 
 Issues caused by upstream agent behavior, not paude bugs.

--- a/src/paude/backends/podman/proxy.py
+++ b/src/paude/backends/podman/proxy.py
@@ -185,8 +185,12 @@ class PodmanProxyManager:
         disable_dns = self._runner.engine.is_podman
         self._network_manager.create_internal_network(nname, disable_dns=disable_dns)
 
+        # This network may already have the session's long-lived agent
+        # container attached (created once at `paude create` time), so unlike
+        # create_proxy's brand-new network it must not be torn down on a
+        # transient IP-resolution failure — see _resolve_proxy_ip's docstring.
         proxy_ip = self._resolve_proxy_ip(
-            nname, disable_dns, remove_network_on_failure=True
+            nname, disable_dns, remove_network_on_failure=False
         )
         agent_ip = derive_agent_ip(proxy_ip) if proxy_ip else None
         dns = _get_host_dns(self._runner.engine)

--- a/src/paude/cli/commands/lifecycle.py
+++ b/src/paude/cli/commands/lifecycle.py
@@ -12,6 +12,7 @@ from paude.cli.helpers import (
     _auto_select_session,
     _get_backend_instance,
     _parse_forward_ports,
+    called_process_stderr,
     find_session_backend,
 )
 from paude.session_discovery import resolve_session_for_backend
@@ -53,8 +54,15 @@ def session_start(
             try:
                 exit_code = backend_obj.start_session(name, forward_ports)
                 raise typer.Exit(exit_code)
+            except typer.Exit:
+                # A clean start raises typer.Exit(exit_code); let it propagate
+                # instead of being caught by the broad handler below and
+                # reported as a failure.
+                raise
             except Exception as e:
                 typer.echo(f"Error starting session: {e}", err=True)
+                if detail := called_process_stderr(e):
+                    typer.echo(detail, err=True)
                 raise typer.Exit(1) from None
         else:
             typer.echo(f"Session '{name}' not found.", err=True)
@@ -85,11 +93,17 @@ def session_start(
     try:
         exit_code = backend_instance.start_session(name, forward_ports)
         raise typer.Exit(exit_code)
+    except typer.Exit:
+        # A clean start raises typer.Exit(exit_code); let it propagate instead
+        # of being caught by the broad handler below and reported as a failure.
+        raise
     except SessionNotFoundError as e:
         typer.echo(f"Error: {e}", err=True)
         raise typer.Exit(1) from None
     except Exception as e:
         typer.echo(f"Error starting session: {e}", err=True)
+        if detail := called_process_stderr(e):
+            typer.echo(detail, err=True)
         raise typer.Exit(1) from None
 
 

--- a/src/paude/cli/create_podman.py
+++ b/src/paude/cli/create_podman.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -14,6 +13,7 @@ from paude.cli.helpers import (
     _detect_dev_script_dir,
     _finalize_session_create,
     _run_setup_command,
+    called_process_stderr,
 )
 from paude.config.models import PaudeConfig
 
@@ -141,8 +141,8 @@ def create_podman_session(
         raise typer.Exit(1) from None
     except Exception as e:
         typer.echo(f"Error creating session: {e}", err=True)
-        if isinstance(e, subprocess.CalledProcessError) and e.stderr:
-            typer.echo(e.stderr.strip(), err=True)
+        if detail := called_process_stderr(e):
+            typer.echo(detail, err=True)
         try:
             backend_instance.delete_session(session.name, confirm=True)
         except Exception:  # noqa: S110 - best-effort cleanup

--- a/src/paude/cli/helpers.py
+++ b/src/paude/cli/helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -21,6 +22,18 @@ from paude.session_discovery import (
 if TYPE_CHECKING:
     from paude.agents.base import AgentComposition
     from paude.backends.port_forward_utils import ForwardPort
+
+
+def called_process_stderr(e: Exception) -> str | None:
+    """Return a CalledProcessError's captured stderr, stripped, if any.
+
+    str(CalledProcessError) omits the captured stderr, so callers reporting a
+    failure via an f-string need this to surface the underlying command's
+    actual explanation instead of just "returned non-zero exit status N".
+    """
+    if isinstance(e, subprocess.CalledProcessError) and e.stderr:
+        return str(e.stderr).strip()
+    return None
 
 
 def find_session_backend(

--- a/src/paude/cli/upgrade.py
+++ b/src/paude/cli/upgrade.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
@@ -11,7 +10,7 @@ import typer
 
 from paude.backends import SessionNotFoundError
 from paude.cli.app import BackendType, app
-from paude.cli.helpers import find_session_backend
+from paude.cli.helpers import called_process_stderr, find_session_backend
 
 if TYPE_CHECKING:
     from paude.agents.base import AgentComposition
@@ -350,11 +349,7 @@ def session_upgrade(
     except Exception as e:
         # str(CalledProcessError) omits captured stderr — surface it so a
         # failing container command isn't reported as an opaque exit status.
-        detail = (
-            e.stderr.strip()
-            if isinstance(e, subprocess.CalledProcessError) and e.stderr
-            else str(e)
-        )
+        detail = called_process_stderr(e) or str(e)
         typer.echo(f"Error upgrading session: {detail}", err=True)
         typer.echo(
             f"The upgrade did not finish. Your workspace data is safe. "

--- a/src/paude/cli/upgrade_persistence.py
+++ b/src/paude/cli/upgrade_persistence.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 
+from paude.cli.helpers import called_process_stderr
 from paude.constants import CONTAINER_HOME
 from paude.container.runner import echo_captured_stderr
 
@@ -104,7 +106,21 @@ def migrate_legacy_state(
     was_running = runner.container_running(container_name)
     if was_running:
         runner.stop_container_graceful(container_name)
-    runner.start_container(container_name)
+    try:
+        runner.start_container(container_name)
+    except subprocess.CalledProcessError as e:
+        # Salvage is best-effort: an old container that can't even start
+        # (e.g. a stale network reference from a previous bug) has nothing
+        # new to offer beyond what's already persisted to the session
+        # volume, so skip it with a warning instead of blocking the upgrade.
+        detail = called_process_stderr(e) or str(e)
+        print(
+            f"migrate: could not start {container_name} to migrate legacy "
+            f"state ({detail}); skipping salvage. State already persisted "
+            "to the session volume is unaffected.",
+            file=sys.stderr,
+        )
+        return
     try:
         # Run as the old container's default user (not root): the copy is a
         # best-effort salvage into the volume that user already owns. Anything it

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -142,6 +143,45 @@ def test_forward_port_invalid_spec_errors(command):
     # Error goes to stderr, which typer may redirect to stdout
     output = result.stdout + (result.stderr or "")
     assert "invalid port spec" in output
+
+
+@pytest.mark.parametrize("exit_code", [0, 2])
+def test_start_autodetect_propagates_exit_code(exit_code):
+    """A clean start propagates start_session's exit code as-is.
+
+    Regression: start_session's result was raised via typer.Exit *inside* a
+    try/except Exception. Since typer.Exit subclasses Exception, a successful
+    exit was caught and reported as "Error starting session: 0" with exit 1.
+    """
+    from paude.cli.app import BackendType
+
+    backend_obj = MagicMock()
+    backend_obj.start_session.return_value = exit_code
+    with patch(
+        "paude.cli.commands.lifecycle.find_session_backend",
+        return_value=(BackendType.podman, backend_obj),
+    ):
+        result = runner.invoke(app, ["start", "my-session"])
+    assert result.exit_code == exit_code
+    output = result.stdout + (result.stderr or "")
+    assert "Error starting session" not in output
+    backend_obj.start_session.assert_called_once()
+
+
+@pytest.mark.parametrize("exit_code", [0, 2])
+def test_start_explicit_backend_propagates_exit_code(exit_code):
+    """Same regression guard for the explicit --backend try/except site."""
+    backend_obj = MagicMock()
+    backend_obj.start_session.return_value = exit_code
+    with patch(
+        "paude.cli.commands.lifecycle._get_backend_instance",
+        return_value=backend_obj,
+    ):
+        result = runner.invoke(app, ["start", "my-session", "--backend", "podman"])
+    assert result.exit_code == exit_code
+    output = result.stdout + (result.stderr or "")
+    assert "Error starting session" not in output
+    backend_obj.start_session.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -1099,6 +1139,24 @@ class TestStartMultiBackend:
             side_effect=Exception("docker not available"),
         ):
             yield
+
+
+class TestStartErrorReporting:
+    """Tests for surfacing the real error when a session fails to start."""
+
+    @patch("paude.cli.commands.lifecycle.find_session_backend")
+    def test_start_surfaces_podman_stderr(self, mock_find_backend: MagicMock):
+        """A CalledProcessError's captured stderr is echoed, not swallowed."""
+        mock_backend = MagicMock()
+        mock_backend.start_session.side_effect = subprocess.CalledProcessError(
+            125, ["podman", "start", "paude-my-session"], "", "no such network"
+        )
+        mock_find_backend.return_value = ("podman", mock_backend)
+
+        result = runner.invoke(app, ["start", "my-session"])
+
+        assert result.exit_code == 1
+        assert "no such network" in result.output
 
 
 class TestStopMultiBackend:

--- a/tests/test_podman_proxy.py
+++ b/tests/test_podman_proxy.py
@@ -301,7 +301,9 @@ class TestResolveProxyIpGuard:
     def test_start_if_needed_raises_on_podman_when_ip_unavailable(
         self, mock_dns: MagicMock, mock_sleep: MagicMock
     ) -> None:
-        """Recreating a missing proxy aborts + removes the network if no IP."""
+        """Recreating a missing proxy aborts without IP, but leaves the
+        network alone since the session's agent container may still be
+        attached to it."""
         mock_dns.return_value = None
         mock_runner = _make_mock_runner()
         # Proxy container is gone -> recreate path
@@ -318,7 +320,7 @@ class TestResolveProxyIpGuard:
             with pytest.raises(ProxyStartError):
                 manager.start_if_needed(session_name="test-session")
 
-        mock_network.remove_network.assert_called_once_with("paude-net-test-session")
+        mock_network.remove_network.assert_not_called()
         # A silently-broken proxy must never be created
         create_calls = [
             c

--- a/tests/test_upgrade_persistence.py
+++ b/tests/test_upgrade_persistence.py
@@ -94,6 +94,24 @@ def test_migration_surfaces_stderr_on_failure() -> None:
     runner.stop_container_graceful.assert_called_once_with("paude-demo")
 
 
+def test_migration_skips_salvage_when_container_wont_start(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An old container that can't even start (e.g. a stale network
+    reference) must not block the upgrade — salvage is best-effort and
+    everything already persisted to the session volume is unaffected."""
+    runner = MagicMock()
+    runner.container_running.return_value = False
+    runner.start_container.side_effect = subprocess.CalledProcessError(
+        125, ["podman", "start", "paude-demo"], stderr="no such network"
+    )
+
+    migrate_legacy_state(runner, "paude-demo", get_agents(["codex"]))
+
+    runner.exec_in_container.assert_not_called()
+    assert "skipping salvage" in capsys.readouterr().err
+
+
 def test_migration_prints_nonfatal_warnings(
     capsys: pytest.CaptureFixture[str],
 ) -> None:


### PR DESCRIPTION
start_if_needed's recreate-missing-proxy path could delete a session's network out from under its already-attached agent container when the proxy IP couldn't be resolved (remove_network_on_failure=True was meant for brand-new networks, but this path can run against a live one). Podman later recreates a same-named network with a new ID, leaving the untouched agent container permanently unable to start with a bare exit 125 -- and CalledProcessError's stderr, which would have explained why, was never surfaced to the user.

- proxy.py: stop deleting the network in this recreate path.
- lifecycle.py: echo the underlying podman stderr on start failure.
- upgrade_persistence.py: migrate_legacy_state now tolerates an old container that can't start (best-effort salvage, not fatal), so `paude upgrade` can repair a session stuck in this state in place, reusing its /pvc volume instead of losing work.
- helpers.py: extract called_process_stderr(), used by all four CLI error paths that were duplicating this stderr-extraction logic (create_podman, upgrade, and the two new lifecycle sites).

Logs the pre-existing remove_network() silent-failure behavior as NET-001 in KNOWN_ISSUES.md.