### PR TITLE
Add anthropic-oauth provider for Claude Max plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,49 @@ paude create --agent openclaw --provider anthropic ...
 </details>
 
 <details>
+<summary><strong>Anthropic Max plan (OAuth)</strong> (Claude Code, Gas City)</summary>
+
+Use an Anthropic subscription (Max plan) instead of an API key or Vertex. On the
+**host**, mint a long-lived token with the official Claude Code client and export
+it, then pass `--provider anthropic-oauth`:
+
+```bash
+export CLAUDE_CODE_OAUTH_TOKEN="$(claude setup-token)"
+paude create --agent claude --provider anthropic-oauth --git my-project
+```
+
+`claude setup-token` produces a static (~1-year) OAuth token. paude reads it from
+your host environment and injects it into the session's proxy sidecar, which
+adds it as the `Authorization: Bearer` header on requests to `api.anthropic.com`;
+the real token never reaches the agent container (the agent only sees a
+`paude-proxy-managed` sentinel). Because the token does not rotate, one token can
+be shared across all your sessions — the same value must be present on later
+`start`/`connect`/`upgrade`. When it expires, re-run `claude setup-token`, export
+the new value, and upgrade (or recreate) the session.
+
+The token is used only by the official `claude` binary running in the session
+(including when Gas City's `gc` spawns it). Sharing one subscription seat across
+many parallel sessions is subject to that plan's fair-use limits.
+
+You can switch an **existing** session in place with `paude upgrade`:
+
+```bash
+export CLAUDE_CODE_OAUTH_TOKEN="$(claude setup-token)"
+# e.g. move a gascity,claude,codex session off Vertex, keeping Codex on ChatGPT
+paude upgrade my-project \
+    --agent-provider claude=anthropic-oauth \
+    --agent-provider gascity=anthropic-oauth
+```
+
+For a session where both a standalone `claude` agent **and** `gascity` are
+installed, remap **both** to `anthropic-oauth`. They share one container's
+environment, so leaving `claude` on its Vertex default would set
+`CLAUDE_CODE_USE_VERTEX=1` for the whole container and reach the Claude Code that
+`gc` launches.
+
+</details>
+
+<details>
 <summary><strong>OpenAI API key</strong> (Codex CLI, OpenClaw, OpenCode)</summary>
 
 ```bash

--- a/containers/proxy/Dockerfile
+++ b/containers/proxy/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage — compile paude-proxy from source
 FROM golang:1.23 AS builder
 WORKDIR /app
-ARG PAUDE_PROXY_VERSION=43f9bbc089a122e675e3c781a7e552ae6a3c85db
+ARG PAUDE_PROXY_VERSION=37b1f74f591f444ce323a96a47c1e6ad4021c866
 RUN git init . && \
     git fetch --depth 1 https://github.com/bbrowning/paude-proxy.git ${PAUDE_PROXY_VERSION} && \
     git checkout FETCH_HEAD && \

--- a/src/paude/cli/help.py
+++ b/src/paude/cli/help.py
@@ -236,7 +236,11 @@ _SECTIONS: tuple[HelpSection, ...] = (
                 "Map an installed agent to a provider; repeatable",
             ),
             ("--provider vertex", "Vertex AI (default for claude, openclaw)"),
-            ("--provider anthropic", "Anthropic API"),
+            ("--provider anthropic", "Anthropic API key"),
+            (
+                "--provider anthropic-oauth",
+                "Anthropic Max plan via `claude setup-token` (claude, gascity)",
+            ),
             ("--provider chatgpt", "Codex ChatGPT-plan OAuth, HTTP/SSE (default)"),
             ("--provider openai", "OpenAI API (Codex API-key mode)"),
             ("--provider cursor", "Cursor API (default for cursor)"),
@@ -244,6 +248,10 @@ _SECTIONS: tuple[HelpSection, ...] = (
             (
                 "codex login",
                 "Run inside a codex session to authenticate (ChatGPT plan)",
+            ),
+            (
+                "claude setup-token",
+                "Run on host; export CLAUDE_CODE_OAUTH_TOKEN for anthropic-oauth",
             ),
         ),
     ),

--- a/src/paude/providers/agent_providers.py
+++ b/src/paude/providers/agent_providers.py
@@ -31,6 +31,9 @@ AGENT_PROVIDERS: dict[str, dict[str, AgentProviderConfig]] = {
             extra_env_vars={"CLAUDE_CODE_USE_VERTEX": "1"},
         ),
         "anthropic": AgentProviderConfig(),
+        "anthropic-oauth": AgentProviderConfig(
+            extra_env_vars={"CLAUDE_CODE_OAUTH_TOKEN": "paude-proxy-managed"},
+        ),
     },
     "codex": {
         "openai": AgentProviderConfig(),
@@ -64,6 +67,11 @@ AGENT_PROVIDERS: dict[str, dict[str, AgentProviderConfig]] = {
                 "CLAUDE_CODE_USE_VERTEX": "1",
                 "CLAUDE_CODE_OAUTH_TOKEN": "paude-proxy-managed",
             },
+        ),
+        # No CLAUDE_CODE_USE_VERTEX here: the bundled Claude Code talks to
+        # api.anthropic.com via the proxy-injected OAuth token, not Vertex.
+        "anthropic-oauth": AgentProviderConfig(
+            extra_env_vars={"CLAUDE_CODE_OAUTH_TOKEN": "paude-proxy-managed"},
         ),
     },
     "gemini": {

--- a/src/paude/providers/base.py
+++ b/src/paude/providers/base.py
@@ -58,6 +58,16 @@ _PROVIDERS: dict[str, ProviderConfig] = {
         secret_env_vars=["ANTHROPIC_API_KEY"],
         domain_aliases=["claude"],
     ),
+    "anthropic-oauth": ProviderConfig(
+        name="anthropic-oauth",
+        display_name="Anthropic (Max OAuth)",
+        # The host provides a long-lived `claude setup-token`; paude delivers it
+        # to paude-proxy as a secret and the proxy injects it as an
+        # `Authorization: Bearer` header. The agent only ever sees the
+        # `paude-proxy-managed` sentinel (set per-agent via extra_env_vars).
+        secret_env_vars=["CLAUDE_CODE_OAUTH_TOKEN"],
+        domain_aliases=["claude"],
+    ),
     "cursor": ProviderConfig(
         name="cursor",
         display_name="Cursor",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -393,6 +393,59 @@ class TestCodexChatgptProvider:
         assert result.exit_code != 0
 
 
+class TestAnthropicOAuthProvider:
+    """Tests for the `anthropic-oauth` (Anthropic Max plan) provider."""
+
+    def test_claude_anthropic_oauth_dry_run(self):
+        result = runner.invoke(
+            app,
+            [
+                "create",
+                "--agent",
+                "claude",
+                "--provider",
+                "anthropic-oauth",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "provider: anthropic-oauth" in _strip_ansi(result.stdout)
+
+    def test_gascity_claude_codex_swap_to_anthropic_oauth(self):
+        """The user's flow: claude + gascity on anthropic-oauth, codex on chatgpt."""
+        result = runner.invoke(
+            app,
+            [
+                "create",
+                "--agents",
+                "gascity,claude,codex",
+                "--agent-provider",
+                "gascity=anthropic-oauth,claude=anthropic-oauth,codex=chatgpt",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0
+        out = _strip_ansi(result.stdout)
+        assert "gascity -> anthropic-oauth" in out
+        assert "claude -> anthropic-oauth" in out
+        assert "codex -> chatgpt" in out
+
+    def test_codex_anthropic_oauth_rejected(self):
+        """anthropic-oauth is not a valid provider for codex."""
+        result = runner.invoke(
+            app,
+            [
+                "create",
+                "--agent",
+                "codex",
+                "--provider",
+                "anthropic-oauth",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code != 0
+
+
 class TestAgentsProvidersLists:
     """Tests for the list-valued --agents/--providers options."""
 

--- a/tests/test_gascity.py
+++ b/tests/test_gascity.py
@@ -49,6 +49,17 @@ class TestGascityAgentConfig:
             "GC_DISABLE_USAGE_METRICS": "1",
         }
 
+    def test_env_vars_anthropic_oauth_omits_vertex(self) -> None:
+        # Under the anthropic-oauth provider, Claude Code talks to
+        # api.anthropic.com via the proxy-injected OAuth token, so the
+        # Vertex-only env var must not be set — but the sentinel still must.
+        cfg = GascityAgent("anthropic-oauth").config
+        assert cfg.env_vars["CLAUDE_CODE_OAUTH_TOKEN"] == "paude-proxy-managed"  # noqa: S105
+        assert "CLAUDE_CODE_USE_VERTEX" not in cfg.env_vars
+        # Gas City-specific env vars are still present regardless of provider.
+        assert cfg.env_vars["GC_DISABLE_USAGE_METRICS"] == "1"
+        assert cfg.env_vars["NODE_USE_ENV_PROXY"] == "1"
+
     def test_passthrough_vars(self) -> None:
         cfg = GascityAgent().config
         assert "ANTHROPIC_VERTEX_PROJECT_ID" in cfg.passthrough_env_vars

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -32,6 +32,12 @@ class TestProviderRegistry:
         p = get_provider("anthropic")
         assert "ANTHROPIC_API_KEY" in p.secret_env_vars
 
+    def test_get_provider_anthropic_oauth(self) -> None:
+        p = get_provider("anthropic-oauth")
+        assert p.name == "anthropic-oauth"
+        assert p.secret_env_vars == ["CLAUDE_CODE_OAUTH_TOKEN"]
+        assert "claude" in p.domain_aliases
+
     def test_get_provider_cursor(self) -> None:
         p = get_provider("cursor")
         assert "CURSOR_API_KEY" in p.secret_env_vars
@@ -85,6 +91,15 @@ class TestAgentProviderResolution:
     def test_resolve_claude_anthropic(self) -> None:
         provider, agent_cfg = resolve_agent_provider("claude", "anthropic")
         assert provider.name == "anthropic"
+        assert "CLAUDE_CODE_USE_VERTEX" not in agent_cfg.extra_env_vars
+
+    def test_resolve_claude_anthropic_oauth(self) -> None:
+        provider, agent_cfg = resolve_agent_provider("claude", "anthropic-oauth")
+        assert provider.name == "anthropic-oauth"
+        assert (
+            agent_cfg.extra_env_vars.get("CLAUDE_CODE_OAUTH_TOKEN")
+            == "paude-proxy-managed"
+        )
         assert "CLAUDE_CODE_USE_VERTEX" not in agent_cfg.extra_env_vars
 
     def test_resolve_claude_default(self) -> None:
@@ -150,6 +165,16 @@ class TestAgentProviderResolution:
         provider, agent_cfg = resolve_agent_provider("gascity", "vertex")
         assert provider.name == "vertex"
         assert agent_cfg.extra_env_vars.get("CLAUDE_CODE_USE_VERTEX") == "1"
+
+    def test_resolve_gascity_anthropic_oauth(self) -> None:
+        provider, agent_cfg = resolve_agent_provider("gascity", "anthropic-oauth")
+        assert provider.name == "anthropic-oauth"
+        assert (
+            agent_cfg.extra_env_vars.get("CLAUDE_CODE_OAUTH_TOKEN")
+            == "paude-proxy-managed"
+        )
+        # The Vertex-only env var must NOT be set under the OAuth provider.
+        assert "CLAUDE_CODE_USE_VERTEX" not in agent_cfg.extra_env_vars
 
     def test_resolve_gascity_default(self) -> None:
         provider, _ = resolve_agent_provider("gascity")
@@ -217,6 +242,7 @@ class TestSupportedProviders:
         providers = supported_providers("claude")
         assert "vertex" in providers
         assert "anthropic" in providers
+        assert "anthropic-oauth" in providers
 
     def test_opencode_providers(self) -> None:
         providers = supported_providers("opencode")
@@ -238,6 +264,7 @@ class TestSupportedProviders:
     def test_gascity_providers(self) -> None:
         providers = supported_providers("gascity")
         assert "vertex" in providers
+        assert "anthropic-oauth" in providers
 
     def test_unknown_agent_returns_empty(self) -> None:
         assert supported_providers("nonexistent") == []

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -173,6 +173,23 @@ class TestGatherProxyCredentials:
         assert "ANTHROPIC_API_KEY" in creds
         assert creds["ANTHROPIC_API_KEY"] == "test-key-value"  # noqa: S105
 
+    def test_includes_anthropic_oauth_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The setup-token is gathered from the host for anthropic-oauth."""
+        monkeypatch.delenv("PAUDE_GITHUB_TOKEN", raising=False)
+        agent = ClaudeAgent(provider="anthropic-oauth")
+        monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat01-real")  # noqa: S105
+
+        creds = gather_proxy_credentials(agent.config)
+
+        # The real token is delivered to the proxy...
+        assert creds["CLAUDE_CODE_OAUTH_TOKEN"] == "sk-ant-oat01-real"  # noqa: S105
+        # ...while the agent itself only ever sees the sentinel.
+        assert (
+            agent.config.env_vars["CLAUDE_CODE_OAUTH_TOKEN"] == "paude-proxy-managed"  # noqa: S105
+        )
+
     def test_includes_gh_token_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """GH_TOKEN is picked up from PAUDE_GITHUB_TOKEN env var."""
         monkeypatch.setenv("PAUDE_GITHUB_TOKEN", "test-token-value")  # noqa: S105


### PR DESCRIPTION
Add an `anthropic-oauth` provider that authenticates Claude Code with an Anthropic Max-plan OAuth credential (`claude setup-token`), brokered by paude-proxy alongside the existing Vertex and API-key options.

The host holds the real setup-token; paude delivers it to the proxy as a podman secret and the proxy injects it as an `Authorization: Bearer` header on api.anthropic.com. The agent only ever sees the `paude-proxy-managed` sentinel. Because setup-token is a long-lived, non-rotating credential, one token can be shared across all sessions and hosts, so it maps onto paude's existing env-var secret delivery with no per-session login flow.

Wire the provider into the `claude` and `gascity` agents. The gascity entry deliberately omits `CLAUDE_CODE_USE_VERTEX` so that Vertex-only env var is set under the vertex provider and absent under OAuth.

Bump the pinned paude-proxy commit to pick up the matching bearer route for CLAUDE_CODE_OAUTH_TOKEN.