### PR TITLE
Bump paude-proxy pin to include downloads.claude.ai fix

### DIFF
--- a/containers/proxy/Dockerfile
+++ b/containers/proxy/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage — compile paude-proxy from source
 FROM golang:1.23 AS builder
 WORKDIR /app
-ARG PAUDE_PROXY_VERSION=37b1f74f591f444ce323a96a47c1e6ad4021c866
+ARG PAUDE_PROXY_VERSION=185a6b9bce3533aa916a4277c6bd282e8a9c7c4d
 RUN git init . && \
     git fetch --depth 1 https://github.com/bbrowning/paude-proxy.git ${PAUDE_PROXY_VERSION} && \
     git checkout FETCH_HEAD && \


### PR DESCRIPTION
The previous pin (37b1f74) shipped the anthropic-oauth provider's proxy route, whose bare .claude.ai suffix match also matched downloads.claude.ai -- a public GCS CDN fetched anonymously by Claude Code's auto-updater. The proxy fabricated an OAuth bearer onto those requests, turning 200s into 401s and breaking auto-update.

Bump to 185a6b9, which gates credential injection on the request already carrying the routed auth header, leaving anonymous fetches untouched.