### PR TITLE
Consolidate the session-rebuild path and rebuild the test infrastructure under it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy
-        entry: uv run --frozen mypy src
+        entry: uv run --frozen mypy src tests
         language: system
         types: [python]
         pass_filenames: false

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -478,6 +478,45 @@ No path forward here is trivial — SELinux MAC enforcement and `podman exec`'s 
 
 ## Test Suite
 
+### TEST-004: Remaining test-suite duplication and untestable-by-design seams
+
+**Status**: Open
+**Priority**: Medium (this is what makes refactoring `src/` expensive)
+**Discovered**: 2026-08-25 during the test-infrastructure pass that added
+`tests/fakes.py`'s `make_backend`/`make_runner`/`FakeTransport`
+
+The shared doubles now exist and the poll-sleep tax is gone, but three larger
+items were deliberately left:
+
+1. **`git_remote/utils.py` calls `subprocess.run` 17 times directly**
+   (`workflow.py` adds 5 more), which is why
+   `@patch("paude.git_remote.subprocess.run")` is the single most-patched
+   target in the suite at 79 sites. This violates the project's own rule in
+   `docs/CODING_STANDARDS.md` ("Wrap external commands ... in testable classes
+   rather than calling subprocess directly"). Routing git through an injectable
+   runner would delete those 79 patches and let a `FakeTransport`-style double
+   record git invocations. Deferred because it is a `src/` change, and the
+   test-infrastructure work was kept behaviour-preserving.
+
+2. **`tests/test_upgrade.py` still assigns `backend._runner` in 15 places**, and
+   `MagicMock(spec=PodmanBackend)` with `__class__` reassignment in 15 more.
+   These are not a test smell that can be fixed in the tests: they faithfully
+   model `cli/upgrade.py` and `cli/backup.py` reaching into `PodmanBackend`
+   privates (18 sites). The tests can only be cleaned up once that layering is,
+   which is the session-rebuild consolidation described in REFACTOR-007.
+
+3. **`tests/test_cli.py` (2041 lines) is a grab-bag** whose classes duplicate
+   topics that already have dedicated files (`TestBlockedDomainsCLI` vs
+   `test_blocked_domains.py`, `TestParseCopyPath` vs `test_remote_copy.py`,
+   `TestAgentSpecificDomainExpansion` vs `test_domains.py`). Splitting it along
+   its existing class boundaries is mechanical. Separately,
+   `tests/test_agents.py` (2000 lines, 45 classes, zero mocks) is a
+   6-agents x 6-concerns copy-paste grid that wants parametrizing -- best done
+   after the Gemini removal in AGENT-003, which deletes one row of it.
+
+For reference, the pass that opened this entry took `make test` from 26.9s to
+6.8s, mock/patch constructions from 2028 to 1937, and put `tests/` under mypy.
+
 ### TEST-003: Test signatures are unannotated, so mypy runs relaxed over `tests/`
 
 **Status**: Open

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -17,17 +17,29 @@ Technical debt identified during codebase analysis. Address these before adding 
 - `backends/podman/proxy.py` — reduced from 641 lines to 400 lines. Deleted dead code, extracted collaborator classes.
 - `backends/podman/backend.py` — `create_session()` reduced from 143 lines to ~37 lines.
 
-**Still open — files exceeding 400-line limit:**
-- `cli/commands.py` — 580 lines
-- `workflow.py` — 467 lines
-- `container/runner.py` — 442 lines
+**Still open — files exceeding 400-line limit** (counts refreshed 2026-08-25
+after the session-rebuild consolidation):
+- `cli/upgrade.py` — 715 lines (was 802)
+- `cli/backup.py` — 682 lines (was 703; still needs splitting into a package)
+- `workflow.py` — 534 lines
 - `container/image.py` — 531 lines
-- `cli/backup.py` — 703 lines (grew past the limit adding `--remote-only`
-  streaming backup support; needs splitting into a package)
+- `cli/helpers.py` — 515 lines
+- `container/runner.py` — 460 lines
+- `backends/podman/backend.py` — 455 lines (was 479; two teardowns moved to
+  `backends/podman/resources.py`)
+
+`cli/commands.py` is no longer listed: it is now a package (`cli/commands/`)
+whose largest module is 168 lines.
 
 **Still open — methods exceeding 50-line limit:**
 - `workflow.py` — `harvest_session()` (~102 lines), `status_sessions()` (~84), `reset_session()` (~72)
-- `cli/commands.py` — `session_cp()` (~75 lines)
+- `cli/commands/cp.py` — `session_cp()` (~75 lines)
+- `cli/create_podman.py` — `create_podman_session()` (65 lines, down from 157).
+  Nearly all of what remains is keyword arguments being forwarded from a
+  23-parameter signature to three collaborators; an attempt to extract a
+  fourth helper needed 10 forwarded parameters to remove 4 lines and was
+  reverted as parameter-plumbing rather than decomposition. The real fix is
+  fewer parameters, not another helper.
 
 ### REFACTOR-004: Duplicated Dockerfile between static file and generated code
 
@@ -65,27 +77,30 @@ The third occurrence was added while fixing SEC-003 rather than reusing `_build_
 
 ### REFACTOR-007: BackupManifest and UpgradeManifest duplicate the label-derived config block
 
-**Status**: Open
-**Priority**: Low (drift-prone; two dataclasses + two loaders must stay in sync)
+**Status**: Resolved (2026-08-25)
 **Discovered**: 2026-08-10 during a cleanup review of the `paude backup` work
 
-`BackupManifest` (`src/paude/backup_state.py`) and `UpgradeManifest`
-(`src/paude/upgrade_state.py`) embed an identical ~9-field "label-derived session
-config" block (`agent`, `provider`, `agent_providers`, `credential_providers`,
-`gpu`, `yolo`, `otel_endpoint`, `allowed_domains`, `proxy_image`), and both
-`backup_state.loads()` and `upgrade_state.load()` re-implement the same
-JSON-list→tuple normalization for `agent_providers`. A new label (e.g. a future
-`env_profile`) must be added to both dataclasses and both loaders.
+`BackupManifest` and `UpgradeManifest` embedded an identical ~9-field
+"label-derived session config" block, and both loaders re-implemented the same
+JSON-list-to-tuple normalization for `agent_providers`, so a new label meant
+editing four places.
 
-Keeping the two *types* separate is correct — they have genuinely different
-lifecycles (`UpgradeManifest` is a durable `name`-keyed host file with
-save/load/delete; `BackupManifest` is a standalone, version-gated bundle member
-with integrity + registry/transport fields). Only the shared *core* should be
-extracted: a small serializable `LabelDerivedConfig` dataclass both manifests
-embed (or inherit), with the tuple-normalization living once beside it. This was
-left out of the backup work because it reaches into the stable upgrade path
-(`_manifest_from_state`/`_resolve_base_from_manifest` in `cli/upgrade.py`), which
-is out of scope for that feature.
+Resolved by the session-rebuild consolidation. Both manifests now inherit
+`SessionSpec` (`backends/labels.py`), which declares those nine fields once
+beside the label constants they come from, along with the codec that produces
+them. Inheritance rather than an embedded `spec` field is what keeps
+`asdict()` flat, so existing `upgrades.json` files and backup bundles are
+unchanged -- guarded by tests that parse a literal written the way 0.20.2 wrote
+it and assert the serialized key set.
+
+Inheritance dedupes the *schema*, not the *copying*: `_manifest_from_state` and
+`_build_manifest` still assign the fields explicitly so mypy can check them, so
+a tenth label could still be silently dropped. Both now have a drift guard that
+loops over `dataclasses.fields(SessionSpec)` and fails by name if either
+manifest does not carry one.
+
+The layering violation behind it went with it: `src/paude/cli` no longer
+imports a `PAUDE_LABEL_*` constant or touches a `PodmanBackend` private.
 
 ### REFACTOR-008: streaming-subprocess lifecycle is duplicated between engine and SSH transport
 
@@ -161,9 +176,132 @@ Podman's auto-allocator currently handles for free. That's a meaningful new
 subsystem. If this race keeps recurring, the deterministic subnet is the actual
 fix and should be prioritized over widening the retry budget.
 
+### RESTORE-001: `paude restore` is still a stub, and needs a volume-import primitive
+
+**Status**: Open
+**Priority**: Medium (the command exists, is documented as planned, and exits 2)
+**Discovered**: 2026-08-25 while sequencing the session-rebuild consolidation
+
+`session_restore` (`cli/backup.py`) validates a bundle and prints the restore it
+would perform. The consolidation was sequenced to make the implementation small:
+it can now reuse `build_session_images` / `prepare_session_mounts` /
+`session_config_from_spec` (`cli/session_rebuild.py`) plus
+`SessionResources.teardown_for_rebuild`, and read its configuration straight off
+`BackupManifest`'s inherited `SessionSpec`.
+
+The blocker is that `VolumeArchiver` (`backends/podman/volume_archive.py`) has
+`export_volume` / `export_volume_to_remote_file` / `volume_size_bytes` and **no
+inverse**. Building one means a helper container running `tar xzf -` from stdin
+under the same `--user root --security-opt label=disable` escape hatch
+RUNTIME-006 already flags -- except *writing* attacker-influenced tar content
+rather than reading. Path traversal, symlink escape, device nodes, and
+verifying `archive_sha256` **before** extracting are all open questions that
+want their own review. Note also that `--confirm` (restore over an existing
+session) has to call the destructive `delete_session`, which is exactly the
+operation `teardown_for_rebuild` was kept separate from.
+
+`--host` retargeting and `--name` renaming raise product questions the
+consolidation does not answer: whether a rename rewrites `PAUDE_LABEL_WORKSPACE`,
+whether `--host` re-syncs configs and registers `remote_config_dir` (see
+UPGRADE-002), and whether the bundle's recorded `image` is reused or rebuilt.
+
 ## Correctness Backlog
 
 Lower-severity correctness/robustness issues surfaced during code review.
+
+### UPGRADE-002: upgrading an SSH session leaks its remote config directory
+
+**Status**: Open
+**Severity**: Medium (leaks a directory per upgrade; registry actively lies)
+**Discovered**: 2026-08-25 during the session-rebuild consolidation
+
+A `--host` session's config files are synced to a temp directory on the remote
+host, and the registry records where (`remote_config_dir`). Upgrade re-syncs
+them -- it needs the new paths to remap its bind mounts -- but discards the new
+`remote_base` and never updates the registry.
+`SessionRegistry.refresh_from_session` (`registry.py`) *deliberately* preserves
+`remote_config_dir`, so after an upgrade the entry still names the pre-upgrade
+directory.
+
+Two consequences: every upgrade of a remote session leaves one
+`/tmp/paude-config-*` tree behind on the remote host, and
+`_cleanup_remote_config_dir` (`cli/commands/delete.py`) then deletes the
+*stale* directory on `paude delete` while leaking the live one.
+
+The plumbing is now in place -- `prepare_session_mounts` returns the
+`RemoteConfigPaths` that upgrade drops on the floor -- so the fix is small, but
+it needs a new `SessionRegistry` method (`refresh_from_session` cannot carry the
+field, by design) and it is a real behaviour change with a visible effect on
+`paude delete`, so it wants its own commit and test rather than riding along
+with a refactor.
+
+### UPGRADE-003: an upgraded session silently loses its `--agent-args`
+
+**Status**: Open
+**Severity**: Low
+**Discovered**: 2026-08-25 during the session-rebuild consolidation
+
+`SessionConfig.args` is live: `backends/session_env.py` turns it into the
+primary agent's `args_env_var`. `create` passes the parsed `--agent-args`;
+upgrade passes nothing, so a rebuilt container comes back without them. Upgrade
+even computes `parsed_args` (it calls `_prepare_session_create` with
+`claude_args=None`) and discards the result.
+
+Preserved deliberately through the consolidation, because passing the computed
+value would change nothing -- it is always empty -- and *fixing* it properly
+means persisting the agent args somewhere durable (a label, or the upgrade
+manifest), which is a feature rather than a refactor.
+
+### UPGRADE-004: `Path.cwd()` is a poor workspace fallback for a session with no workspace label
+
+**Status**: Open
+**Severity**: Low (only reachable for sessions predating the workspace label)
+**Discovered**: 2026-08-25 during the session-rebuild consolidation
+
+`_resolve_base_from_view` (`cli/upgrade.py`) falls back to `Path.cwd()` when the
+container has no `paude.io/workspace` label, so the rebuilt session records
+whatever directory the user happened to run `paude upgrade` from.
+`build_session_from_container` uses `Path("/")` for the same missing label, and
+a test pins that, so the two disagree.
+
+Preserved on both sides by the consolidation --
+`labels.workspace_from_labels` returns `Path | None` and each caller applies its
+own fallback, so the disagreement is at least visible now instead of buried in a
+shared default. `SessionConfig.workspace` only reaches labels and the `Session`
+object (never a bind mount), so this is metadata, not a mount bug.
+
+### CREATE-001: a failed `create_session` performs no rollback
+
+**Status**: Open
+**Severity**: Low (leaves a half-built session that `paude delete` can clear)
+**Discovered**: 2026-08-25 while characterizing the create pipeline
+
+`_create_session_or_exit` (`cli/create_podman.py`) cleans up on failure by
+calling `delete_session(session.name, ...)`, but `session` is only bound by the
+`create_session` call itself. When *that* is what failed, the cleanup raises
+`UnboundLocalError` into its own best-effort `except Exception: pass`, so
+nothing is rolled back. A failure in `start_session_no_attach` (where `session`
+*is* bound) rolls back correctly.
+
+The container itself is cleaned up by `PodmanBackend`'s own
+`rollback_create`, so the leak is bounded, but the outer cleanup is dead code on
+the path it most needs to run. Both behaviours are characterized in
+`tests/test_create_podman.py` so the fix cannot be made accidentally. The fix is
+to use `session_config.name` (or the generated name) instead.
+
+### CONFIG-001: three `SessionConfig` fields are never read
+
+**Status**: Open
+**Severity**: Low (dead weight, and one of them is misleading)
+**Discovered**: 2026-08-25 during the session-rebuild consolidation
+
+`SessionConfig.workdir`, `.network` and `.wait_for_ready` (`backends/base.py`)
+are set by callers and read by nobody. `workdir` is the misleading one: `create`
+sets it to the *host* workspace path, while `SessionSetup` hardcodes
+`workdir="/pvc"` when it creates the container, so the field reads like a knob
+that does something. `SessionConfig`'s docstring is also stale -- it documents
+through `ports` and omits `proxy_image`, the `agent*` fields, `gpu`,
+`reuse_volume` and the `otel_*` fields.
 
 ### HARVEST-001: `harvest` diff summary hardcodes `main` as the base ref
 
@@ -498,12 +636,21 @@ items were deliberately left:
    record git invocations. Deferred because it is a `src/` change, and the
    test-infrastructure work was kept behaviour-preserving.
 
-2. **`tests/test_upgrade.py` still assigns `backend._runner` in 15 places**, and
-   `MagicMock(spec=PodmanBackend)` with `__class__` reassignment in 15 more.
-   These are not a test smell that can be fixed in the tests: they faithfully
-   model `cli/upgrade.py` and `cli/backup.py` reaching into `PodmanBackend`
-   privates (18 sites). The tests can only be cleaned up once that layering is,
-   which is the session-rebuild consolidation described in REFACTOR-007.
+2. **Half-resolved (2026-08-25).** The 15 `backend._runner` assignments in
+   `tests/test_upgrade.py` are gone: the session-rebuild consolidation
+   (REFACTOR-007) gave `PodmanBackend` a `resources` collaborator, `cli/` moved
+   onto it, and the tests moved onto `tests/fakes.py`'s `make_backend` via one
+   `_upgrade_backend` helper. Assertions now land on the doubles the test
+   injected rather than on attributes read back out of the system under test.
+
+   The other 15 -- `MagicMock()` with `__class__ = PodmanBackend` -- remain, and
+   the original entry was wrong to lump them together. They are in the
+   `session_upgrade` tests, where `_upgrade_podman` is patched out entirely;
+   they exist only to satisfy `isinstance(backend_obj, PodmanBackend)` while
+   controlling `get_session`/`stop_session`. No layering change reaches them.
+   Fixing them means either making `make_backend` cheap enough to use where a
+   bare mock is wanted, or having `session_upgrade` dispatch on something other
+   than `isinstance`.
 
 3. **`tests/test_cli.py` (2041 lines) is a grab-bag** whose classes duplicate
    topics that already have dedicated files (`TestBlockedDomainsCLI` vs

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -478,6 +478,29 @@ No path forward here is trivial — SELinux MAC enforcement and `podman exec`'s 
 
 ## Test Suite
 
+### TEST-003: Test signatures are unannotated, so mypy runs relaxed over `tests/`
+
+**Status**: Open
+**Priority**: Low (the checks that catch real bugs are already on)
+**Discovered**: 2026-08-25 while extending `make typecheck` to cover `tests/`
+
+`tests/` is now type-checked (it is the larger half of the repo's Python), but
+`[[tool.mypy.overrides]]` for `tests.*` disables `disallow_untyped_defs`,
+`disallow_incomplete_defs` and `disallow_untyped_calls`. Without those three,
+enabling mypy on tests surfaced 81 real errors, all since fixed; with them it
+is 782, of which 701 are purely "this signature has no annotations".
+
+The relaxation is deliberate: the value of checking tests is catching wrong
+argument types, stale attribute names and str/bytes confusion, and strict mode
+still enforces all of that. Annotating ~1900 test signatures buys little and
+would churn every test file.
+
+To tighten later, drop the override keys one at a time — `disallow_untyped_calls`
+first (47 errors, mostly calls into unannotated test helpers), then
+`disallow_incomplete_defs` (a further ~81), then `disallow_untyped_defs`
+(~654). Note `tests/*` also waives `E501` in the ruff per-file ignores, so test
+code has one fewer guardrail than `src` either way.
+
 ### TEST-002: Single-file branch of `_transfer_path` is untested
 
 **Status**: Open

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -32,8 +32,9 @@ Technical debt identified during codebase analysis. Address these before adding 
 ### REFACTOR-004: Duplicated Dockerfile between static file and generated code
 
 **Status**: Open
-**Priority**: Medium (every new container script requires updates in multiple places)
+**Priority**: High (has now caused two real build failures; every new container script requires updates in four places)
 **Discovered**: 2026-03-28 while adding entrypoint-lib-openclaw.sh
+**Recurred**: 2026-08-25 with patch-gemini-otel-proxy.sh (see AGENT-003)
 
 The static `containers/paude/Dockerfile` and the programmatic Dockerfile generator in `src/paude/config/dockerfile.py` must be kept in sync manually. Adding a new script to the container requires changes in four places:
 
@@ -42,7 +43,11 @@ The static `containers/paude/Dockerfile` and the programmatic Dockerfile generat
 3. `src/paude/container/build_context.py` — `copy_entrypoints()` file list
 4. `pyproject.toml` — `force-include` for production wheel packaging
 
-This caused a bug where the new OpenClaw helper script was added to the static Dockerfile but not to generated images. Consider having a single source of truth for the list of container scripts (e.g., a constant in `build_context.py`) that all four locations reference, or generating the static Dockerfile from the same code path.
+This caused a bug where the new OpenClaw helper script was added to the static Dockerfile but not to generated images. **It has since recurred**: `patch-gemini-otel-proxy.sh` is present in locations 1, 3 and 4 but missing from location 2, so `generate_workspace_dockerfile` emits a `RUN` referencing a script it never COPYs and the build fails (see AGENT-003 for the reproduction and trigger conditions).
+
+Two recurrences of the same defect mean the manual-sync approach has been falsified. Fix by giving the list of container scripts a single source of truth (e.g. a constant in `build_context.py`) that all four locations derive from, or by generating the static Dockerfile from the same code path.
+
+Whatever the fix, add a guard test — none exists today. The cheapest one that would have caught both bugs: assert that every `/usr/local/bin/*.sh` referenced by a `RUN` line in each generator's output also has a matching `COPY` in that same output. `tests/test_build_context.py:141,156,177` only checks that scripts reach the *build context*, which both bugs passed.
 
 ### REFACTOR-005: SSH transport construction (`ssh_host` string → `SshTransport`) duplicated in three places
 
@@ -208,6 +213,59 @@ pruning every unreferenced provider.
 ## Agent Limitations
 
 Issues caused by upstream agent behavior, not paude bugs.
+
+### AGENT-003: Remove the Gemini agent entirely (deprecated upstream)
+
+**Status**: Open
+**Priority**: Medium (supersedes AGENT-001 and AGENT-002, and resolves a live build bug)
+**Discovered**: 2026-08-25 during a codebase maintenance review
+
+Google has deprecated the Gemini CLI, so paude should drop the agent rather than
+keep carrying workarounds for it. This supersedes **AGENT-001** (idle-session
+OAuth token expiry) and **AGENT-002** (proxy support broken in 0.36.0+, which is
+why `src/paude/agents/gemini.py` has been pinned to `@google/gemini-cli@0.35.3`
+since 2026-05-12); both entries can be deleted along with the agent.
+
+**Decide this first — it is the actual blocker.** `src/paude/agents/gascity.py`
+declares `bundled_agents=["claude", "gemini"]`, so removing gemini forces a
+decision about what gascity bundles. Everything else is mechanical.
+
+**Removal surface (~34 files).** Source: `agents/gemini.py`, `agents/__init__.py`
+(import + `_AGENTS`), `agents/gascity.py` (`bundled_agents`),
+`providers/agent_providers.py` (`AGENT_PROVIDERS` **and** `DEFAULT_PROVIDER` —
+the default provider is stored in both), `domains.py` (`DOMAIN_ALIASES`),
+`otel.py` (`builders`), `hash.py`, `registry.py`, `cli/create.py`,
+`cli/help.py`, `container/build_context.py`. Containers:
+`containers/paude/Dockerfile` (COPY line) and
+`containers/paude/patch-gemini-otel-proxy.sh` (delete). Packaging:
+`pyproject.toml` `force-include`. Docs: `README.md`, `docs/SESSIONS.md`. Plus
+~19 test files, of which `tests/test_gascity.py` and `tests/test_agents.py` need
+real edits rather than deletions.
+
+Note that existing sessions created with gemini will still carry a
+`paude.io/agent=gemini` label, so `paude list` / `paude upgrade` need to degrade
+sensibly (or fail with a clear message) rather than raising a bare `ValueError`
+from `get_agent()`.
+
+**A live bug that removal also fixes.** `generate_workspace_dockerfile`
+(`src/paude/config/dockerfile.py:219-231`) COPYs `patch-proxy-fetch.sh` and the
+two OpenClaw patch scripts, but **not** `patch-gemini-otel-proxy.sh` — while
+`agents/gemini.py:59-61` emits
+
+```
+RUN npm install -g @google/gemini-cli@latest && /usr/local/bin/patch-gemini-otel-proxy.sh --force 2>&1
+```
+
+so the generated Dockerfile references a file it never copied and the build
+fails. Reproduced against `generate_workspace_dockerfile(cfg, agent=get_agent("gemini"))`:
+`REFERENCED BUT NEVER COPIED: ['patch-gemini-otel-proxy.sh']`.
+
+Trigger: a `paude.json` setting `base_image` or `dockerfile` (so
+`_resolve_custom_base` returns `using_default=False`, `container/image.py:357-366`)
+plus gemini in the agent set — directly or via gascity. The default-image path
+(`generate_pip_install_dockerfile`) is unaffected only because its base was built
+from the *static* `containers/paude/Dockerfile:101`, which does have the COPY.
+This is REFACTOR-004 recurring on a third script; see that entry.
 
 ### AGENT-001: Gemini CLI token expiry in long-running sessions
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -25,7 +25,7 @@ after the session-rebuild consolidation):
 - `container/image.py` — 531 lines
 - `cli/helpers.py` — 515 lines
 - `container/runner.py` — 460 lines
-- `backends/podman/backend.py` — 455 lines (was 479; two teardowns moved to
+- `backends/podman/backend.py` — 448 lines (was 479; two teardowns moved to
   `backends/podman/resources.py`)
 
 `cli/commands.py` is no longer listed: it is now a package (`cli/commands/`)
@@ -36,7 +36,7 @@ whose largest module is 168 lines.
 - `cli/commands/cp.py` — `session_cp()` (~75 lines)
 - `cli/create_podman.py` — `create_podman_session()` (65 lines, down from 157).
   Nearly all of what remains is keyword arguments being forwarded from a
-  23-parameter signature to three collaborators; an attempt to extract a
+  22-parameter signature to three collaborators; an attempt to extract a
   fourth helper needed 10 forwarded parameters to remove 4 lines and was
   reverted as parameter-plumbing rather than decomposition. The real fix is
   fewer parameters, not another helper.
@@ -176,6 +176,50 @@ Podman's auto-allocator currently handles for free. That's a meaningful new
 subsystem. If this race keeps recurring, the deterministic subnet is the actual
 fix and should be prioritized over widening the retry budget.
 
+### PERF-001: the same container labels are fetched up to four times per command
+
+**Status**: Open
+**Priority**: Medium (every fetch is an SSH round trip on a `--host` session)
+**Discovered**: 2026-08-25 during a `/simplify` review of the session-rebuild
+consolidation
+
+Measured by instrumenting `Transport.run` and driving the real paths.
+`ControlPersist` is off (`transport/ssh.py`), so sequential calls do not share
+an SSH master -- each is a full handshake.
+
+- `backend.start_session_no_attach` issues 21 engine round trips, **four** of
+  them the byte-identical `podman ps --format json -a --filter label=app=paude`.
+  Two pairs cause it: `SessionSetup.sync_sandbox_config` calls
+  `get_session_labels` then `get_session_composition` (which re-fetches), and
+  `start_session_containers` calls `get_session_composition` then
+  `get_session_credential_providers`. `connect_session` and
+  `update_allowed_domains` repeat the pattern.
+- `paude backup` pays three `inspect`-style calls (`resources.exists`,
+  `.running`, `.image`) before the `ps` that `resources.labels` makes, for
+  facts that one `ps` record already carries (`State`, `Image`).
+
+The consolidation built exactly the pieces that fix the first one --
+`spec_from_labels` + `composition_for_spec` + `credential_providers_for_spec`
+are pure and I/O-free -- and applied them to `upgrade` and `backup` only.
+One `spec = spec_from_labels(get_session_labels(runner, name))` per command,
+then the two pure derivations, takes `start`/`connect`/`domains --set` from
+four fetches to one. Left out of the consolidation because those call sites are
+outside its diff.
+
+The backup half needs care rather than a mechanical swap: `resources.exists`
+keys off the *container name* while `resources.labels` keys off the *session
+label*, so they are not the same predicate, and `get_container_image` uses
+`ContainerEngine.image_name_format` (`{{.ImageName}}` vs `{{.Config.Image}}`),
+which is not verified to equal `ps`'s `Image` field on both engines. Collapsing
+them wants a `describe()` returning existence, state, image and labels from one
+fetch, checked against both engines.
+
+Separately, `build_session_images` runs the agent and proxy builds
+sequentially though they share no inputs; `paude upgrade` always rebuilds both.
+Parallelising is the largest raw saving here, but both stream progress with
+`capture=False`, so it is only worth doing alongside capturing and replaying
+the proxy pull's output.
+
 ### RESTORE-001: `paude restore` is still a stub, and needs a volume-import primitive
 
 **Status**: Open
@@ -208,6 +252,40 @@ UPGRADE-002), and whether the bundle's recorded `image` is reused or rebuilt.
 ## Correctness Backlog
 
 Lower-severity correctness/robustness issues surfaced during code review.
+
+### TEST-005: the rebuild suites patch definition sites, which pins production import style
+
+**Status**: Open
+**Priority**: Low
+**Discovered**: 2026-08-25 during a `/simplify` review of the session-rebuild
+consolidation
+
+`tests/test_create_podman.py`, `tests/test_upgrade.py` and
+`tests/test_session_rebuild.py` patch `paude.container.ImageManager`,
+`paude.mounts.build_mounts` and `paude.transport.config_sync.*` at the modules
+that *define* them rather than where they are looked up. That works only
+because `cli/session_rebuild.py` imports them inside the functions that use
+them, so the module docstring has to warn future editors not to hoist those
+imports -- a test artifact constraining production code.
+
+Two fixes, ascending: patch the lookup site
+(`paude.cli.session_rebuild.ImageManager`), which frees the imports; or, better
+and in line with the project's own "wrap external commands in testable classes"
+rule, inject the `ImageManager` into `build_session_images` the way `engine`
+already is, so there is nothing to patch. The second touches all three suites,
+which the consolidation had just rewritten, so it was deferred.
+
+Related, and larger: `SessionSpec`'s natural sibling is `SessionConfig` in
+`backends/base.py` -- they are the same domain family and
+`session_config_from_spec` is the conversion between them, currently owned by a
+third package (`cli/`). Moving the spec there and making the conversion
+`SessionConfig.from_spec` would put two durable JSON schemas in a module named
+for domain types rather than one named for container-label constants. Deferred:
+a rename touching many imports, with no behaviour change to show for it.
+`cli/helpers._detect_dev_script_dir` is similarly misplaced -- after the
+consolidation its only caller is `cli/session_rebuild.py`, and it is an
+`ImageManager` concern, not a CLI one, yet its path arithmetic is hardcoded to
+living in `cli/`.
 
 ### UPGRADE-002: upgrading an SSH session leaks its remote config directory
 

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ format:
 	uv run ruff format src tests
 
 typecheck:
-	uv run mypy src
+	uv run mypy src tests
 
 # Login to container registry
 login:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,16 @@ strict = true
 warn_return_any = true
 warn_unused_configs = true
 
+# Tests are type-checked too (they are the larger half of the codebase), but
+# annotating ~1900 test signatures is not worth the churn -- the value is in
+# catching wrong argument types and stale attribute names, which the rest of
+# strict mode still enforces. See KNOWN_ISSUES.md TEST-003 to tighten this.
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+disallow_untyped_calls = false
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-v --ignore=tests/integration"

--- a/src/paude/backends/labels.py
+++ b/src/paude/backends/labels.py
@@ -1,6 +1,30 @@
-"""Container label constants for identifying paude sessions."""
+"""Container labels: the constants, their codec, and the typed spec they carry.
+
+A session's container labels are the only durable record of how it was
+configured. Three things need to read that record back -- ``paude upgrade``
+(to rebuild the container), ``paude backup`` (to write a bundle manifest), and
+``paude list`` (to describe a session) -- so the parse lives here, once,
+instead of once per caller.
+
+:class:`SessionSpec` is the typed form of that label set. The line it draws:
+*declared configuration* belongs in the spec; *build outputs* (the resolved
+image tag) and *identity* (name, workspace, created_at) do not. That is why
+``image`` is a ``BackupManifest`` field rather than a spec field -- upgrade
+always rebuilds and has nothing to pin -- and why ``workspace`` stays out, its
+"missing" default differing per caller.
+"""
 
 from __future__ import annotations
+
+import base64
+import binascii
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
 
 PAUDE_LABEL_APP = "app=paude"
 PAUDE_LABEL_SESSION = "paude.io/session-name"
@@ -17,3 +41,189 @@ PAUDE_LABEL_AGENT_PROVIDERS = "paude.io/agent-providers"
 PAUDE_LABEL_PROVIDERS = "paude.io/providers"
 PAUDE_LABEL_OTEL_PORTS = "paude.io/otel-ports"
 PAUDE_LABEL_OTEL_ENDPOINT = "paude.io/otel-endpoint"
+
+
+@dataclass(kw_only=True)
+class SessionSpec:
+    """A session's declared configuration, as carried by its container labels.
+
+    ``UpgradeManifest`` and ``BackupManifest`` both inherit this, so the field
+    set is declared once and ``asdict()`` stays flat -- an embedded ``spec``
+    field would nest the manifest JSON and strand in-flight upgrades written by
+    an earlier version.
+
+    ``kw_only`` is what makes that inheritance legal: every field here has a
+    default, and both subclasses add required fields after them.
+    """
+
+    agent: str = "claude"
+    provider: str | None = None
+    agent_providers: list[tuple[str, str]] = field(default_factory=list)
+    credential_providers: list[str] = field(default_factory=list)
+    gpu: str | None = None
+    yolo: bool = False
+    otel_endpoint: str | None = None
+    allowed_domains: list[str] | None = None
+    proxy_image: str | None = None
+
+
+@dataclass(frozen=True)
+class LabeledSession:
+    """Everything one container's labels say about it.
+
+    The unit of a single container fetch, which matters on SSH sessions where
+    each fetch is a round trip.
+    """
+
+    spec: SessionSpec
+    workspace: Path | None
+    created_at: str
+    version: str | None
+
+
+def encode_json_label(value: Any) -> str:
+    """Encode JSON as URL-safe base64 for use as a Podman label value."""
+    payload = json.dumps(value, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(payload).decode()
+
+
+def decode_json_label(raw: str) -> Any | None:
+    """Decode a structured label, accepting the original raw-JSON format."""
+    try:
+        decoded = base64.urlsafe_b64decode(raw.encode("ascii"))
+        return json.loads(decoded)
+    except (binascii.Error, UnicodeError, json.JSONDecodeError, ValueError):
+        try:
+            return json.loads(raw)
+        except (TypeError, ValueError):
+            return None
+
+
+def encode_agent_providers(specs: list[tuple[str, str]]) -> str:
+    """Encode ordered agent/provider pairs for a container label."""
+    return encode_json_label(specs)
+
+
+def encode_providers(providers: list[str]) -> str:
+    """Encode a credential-provider set for a container label."""
+    return encode_json_label(providers)
+
+
+def parse_agent_providers_label(raw: str | None) -> list[tuple[str, str]]:
+    """Parse a composition label, returning an empty list when invalid."""
+    if not raw:
+        return []
+    value = decode_json_label(raw)
+    if not isinstance(value, list):
+        return []
+    specs: list[tuple[str, str]] = []
+    for item in value:
+        if (
+            isinstance(item, list)
+            and len(item) == 2
+            and isinstance(item[0], str)
+            and isinstance(item[1], str)
+        ):
+            specs.append((item[0], item[1]))
+    return specs
+
+
+def parse_providers_label(raw: str | None) -> list[str]:
+    """Parse a credential-provider label, returning empty when invalid."""
+    if not raw:
+        return []
+    value = decode_json_label(raw)
+    if not isinstance(value, list):
+        return []
+    return list(dict.fromkeys(item for item in value if isinstance(item, str)))
+
+
+def parse_domains_label(raw: str | None) -> list[str] | None:
+    """Parse the allowed-domains label, distinguishing absent from empty.
+
+    ``None`` means the label was never written -- a legacy session created
+    before every session got a proxy -- and callers expand it to the default
+    domain set. ``[]`` means a proxy session that allows nothing, which the
+    label records as an empty string.
+    """
+    if raw is None:
+        return None
+    return raw.split(",") if raw else []
+
+
+def normalize_agent_providers(value: object) -> list[tuple[str, str]]:
+    """Coerce a JSON-decoded agent/provider list back into tuples.
+
+    JSON has no tuple type, so a round-tripped manifest reads its
+    ``agent_providers`` back as lists. Unlike
+    :func:`parse_agent_providers_label`, this is strict: a manifest is a
+    contract, and a malformed one should surface as an error its loader can
+    translate rather than as a silently truncated agent set.
+
+    Raises:
+        ValueError: If the value is not a list of two-string pairs.
+    """
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"agent_providers must be a list, got {type(value).__name__}")
+    specs: list[tuple[str, str]] = []
+    for item in value:
+        if not isinstance(item, list | tuple) or len(item) != 2:
+            raise ValueError(f"agent_providers entry is not a pair: {item!r}")
+        agent, provider = item
+        if not isinstance(agent, str) or not isinstance(provider, str):
+            raise ValueError(f"agent_providers entry is not two strings: {item!r}")
+        specs.append((agent, provider))
+    return specs
+
+
+def workspace_from_labels(labels: Mapping[str, str]) -> Path | None:
+    """Decode the workspace label, or ``None`` when it was never written.
+
+    Deliberately applies no default: the two callers disagree about what a
+    missing workspace means (``paude list`` shows ``/``; upgrade falls back to
+    the current directory), and that disagreement is clearer at the call sites
+    than hidden in here.
+    """
+    from paude.backends.session_env import decode_path
+
+    encoded = labels.get(PAUDE_LABEL_WORKSPACE, "")
+    return decode_path(encoded, url_safe=True) if encoded else None
+
+
+def spec_from_labels(labels: Mapping[str, str]) -> SessionSpec:
+    """Read a session's declared configuration out of its container labels.
+
+    Empty label values are normalized to ``None``. paude only writes the
+    optional labels when their value is truthy (see
+    ``SessionSetup.build_session_labels``), so this is a type nicety rather
+    than a behaviour change -- but it keeps ``""`` out of manifest JSON.
+
+    ``credential_providers`` is the raw label, with no derive-from-composition
+    fallback; that fallback belongs to callers describing a legacy session, not
+    to the record of what was declared.
+    """
+    return SessionSpec(
+        agent=labels.get(PAUDE_LABEL_AGENT, "claude"),
+        provider=labels.get(PAUDE_LABEL_PROVIDER) or None,
+        agent_providers=parse_agent_providers_label(
+            labels.get(PAUDE_LABEL_AGENT_PROVIDERS)
+        ),
+        credential_providers=parse_providers_label(labels.get(PAUDE_LABEL_PROVIDERS)),
+        gpu=labels.get(PAUDE_LABEL_GPU) or None,
+        yolo=labels.get(PAUDE_LABEL_YOLO) == "1",
+        otel_endpoint=labels.get(PAUDE_LABEL_OTEL_ENDPOINT) or None,
+        allowed_domains=parse_domains_label(labels.get(PAUDE_LABEL_DOMAINS)),
+        proxy_image=labels.get(PAUDE_LABEL_PROXY_IMAGE) or None,
+    )
+
+
+def read_labels(labels: Mapping[str, str]) -> LabeledSession:
+    """Read everything a container's labels record about its session."""
+    return LabeledSession(
+        spec=spec_from_labels(labels),
+        workspace=workspace_from_labels(labels),
+        created_at=labels.get(PAUDE_LABEL_CREATED, ""),
+        version=labels.get(PAUDE_LABEL_VERSION),
+    )

--- a/src/paude/backends/labels.py
+++ b/src/paude/backends/labels.py
@@ -6,12 +6,7 @@ configured. Three things need to read that record back -- ``paude upgrade``
 ``paude list`` (to describe a session) -- so the parse lives here, once,
 instead of once per caller.
 
-:class:`SessionSpec` is the typed form of that label set. The line it draws:
-*declared configuration* belongs in the spec; *build outputs* (the resolved
-image tag) and *identity* (name, workspace, created_at) do not. That is why
-``image`` is a ``BackupManifest`` field rather than a spec field -- upgrade
-always rebuilds and has nothing to pin -- and why ``workspace`` stays out, its
-"missing" default differing per caller.
+:class:`SessionSpec` is the typed form of that label set.
 """
 
 from __future__ import annotations
@@ -45,15 +40,23 @@ PAUDE_LABEL_OTEL_ENDPOINT = "paude.io/otel-endpoint"
 
 @dataclass(kw_only=True)
 class SessionSpec:
-    """A session's declared configuration, as carried by its container labels.
+    """The session configuration both durable manifests serialize.
 
-    ``UpgradeManifest`` and ``BackupManifest`` both inherit this, so the field
-    set is declared once and ``asdict()`` stays flat -- an embedded ``spec``
-    field would nest the manifest JSON and strand in-flight upgrades written by
-    an earlier version.
+    The field set is not a design principle, it is a schema constraint: these
+    are exactly the nine fields ``UpgradeManifest`` and ``BackupManifest``
+    already wrote to disk, kept verbatim so existing ``upgrades.json`` files
+    and backup bundles stay readable. Adding a field here changes both
+    schemas; that, not a rule about "declared configuration", is the test to
+    apply. (``proxy_image`` is in it despite being a build output, and
+    ``workspace`` is out despite being declared configuration -- both because
+    of what was already on disk. ``workspace`` also has no single type here:
+    the manifests store ``str`` where the rest of the code uses ``Path``.)
 
-    ``kw_only`` is what makes that inheritance legal: every field here has a
-    default, and both subclasses add required fields after them.
+    Both manifests inherit this, so ``asdict()`` stays flat -- an embedded
+    ``spec`` field would nest the JSON and strand in-flight upgrades written by
+    an earlier version. ``kw_only`` is what makes that inheritance legal: every
+    field here has a default, and both subclasses add required fields after
+    them.
     """
 
     agent: str = "claude"

--- a/src/paude/backends/podman/backend.py
+++ b/src/paude/backends/podman/backend.py
@@ -28,7 +28,6 @@ from paude.backends.podman.helpers import (
     find_container_by_session_name,
     get_session_agent,
     get_session_composition,
-    network_name,
     proxy_container_name,
     require_running_session,
     require_session,
@@ -36,11 +35,11 @@ from paude.backends.podman.helpers import (
 )
 from paude.backends.podman.port_forward import PodmanPortForwardManager
 from paude.backends.podman.proxy import PodmanProxyManager
+from paude.backends.podman.resources import SessionResources
 from paude.backends.podman.session_setup import SessionSetup
 from paude.backends.port_forward_utils import ForwardPort, merge_forward_ports
 from paude.constants import (
     CONTAINER_ENTRYPOINT,
-    GCP_ADC_SECRET_NAME,
 )
 from paude.container.engine import ContainerEngine
 from paude.container.network import NetworkManager
@@ -75,11 +74,23 @@ class PodmanBackend:
         self._proxy = PodmanProxyManager(self._runner, self._network_manager)
         self._port_forward = PodmanPortForwardManager(self._engine)
         self._setup = SessionSetup(self._runner, self._engine)
+        self._resources = SessionResources(
+            self._runner, self._network_manager, self._volume_manager, self._proxy
+        )
 
     @property
     def engine(self) -> ContainerEngine:
         """Access the underlying container engine."""
         return self._engine
+
+    @property
+    def resources(self) -> SessionResources:
+        """Read and remove this session's podman objects.
+
+        The public seam for callers that drive a rebuild (upgrade, backup)
+        without needing -- or being handed -- the backend's collaborators.
+        """
+        return self._resources
 
     @property
     def backend_type(self) -> str:
@@ -136,7 +147,7 @@ class PodmanBackend:
                 proxy_ip,
             )
         except Exception:
-            self._rollback_session_resources(config, name, vname, volume_reused)
+            self._resources.rollback_create(config, name, vname, volume_reused)
             raise
 
         print(f"Session '{name}' created (stopped).", file=sys.stderr)
@@ -174,21 +185,6 @@ class PodmanBackend:
             raise
         return network, proxy_ip
 
-    def _rollback_session_resources(
-        self,
-        config: SessionConfig,
-        session_name: str,
-        vname: str,
-        volume_reused: bool,
-    ) -> None:
-        """Clean up proxy/volume on container creation failure."""
-        if config.proxy_image:
-            pname = proxy_container_name(session_name)
-            self._runner.remove_container(pname, force=True)
-            self._network_manager.remove_network(network_name(session_name))
-        if not volume_reused:
-            self._volume_manager.remove_volume(vname, force=True)
-
     def start_session_no_attach(self, name: str) -> None:
         """Start containers without attaching (used by create and upgrade)."""
         cname = require_session(self._runner, name)
@@ -218,7 +214,7 @@ class PodmanBackend:
             if not self._volume_manager.volume_exists(vname):
                 raise SessionNotFoundError(f"Session '{name}' not found")
             print(f"Removing orphaned volume {vname}...", file=sys.stderr)
-            self._cleanup_session_resources(name, vname)
+            self._resources.cleanup_all(name, vname)
             return
 
         print(f"Deleting session '{name}'...", file=sys.stderr)
@@ -233,27 +229,7 @@ class PodmanBackend:
             self._runner.remove_container_verified(pname)
         print(f"Removing container {cname}...", file=sys.stderr)
         self._runner.remove_container_verified(cname)
-        self._cleanup_session_resources(name, vname)
-
-    def _cleanup_session_resources(
-        self,
-        name: str,
-        vname: str,
-    ) -> None:
-        """Remove network, proxy volumes, secrets, and main volume."""
-        self._network_manager.remove_network(network_name(name))
-        from paude.backends.podman.proxy import (
-            auth_volume_name,
-            ca_volume_name,
-        )
-
-        for pv in (ca_volume_name(name), auth_volume_name(name)):
-            if self._volume_manager.volume_exists(pv):
-                self._volume_manager.remove_volume(pv, force=True)
-        self._proxy.remove_credential_secrets(name)
-        print(f"Removing volume {vname}...", file=sys.stderr)
-        self._volume_manager.remove_volume_verified(vname)
-        self._runner.remove_secret(GCP_ADC_SECRET_NAME)
+        self._resources.cleanup_all(name, vname)
 
     def start_session(
         self,

--- a/src/paude/backends/podman/backend.py
+++ b/src/paude/backends/podman/backend.py
@@ -12,6 +12,7 @@ from paude.backends.base import Session, SessionConfig
 from paude.backends.labels import (
     PAUDE_LABEL_APP,
     PAUDE_LABEL_SESSION,
+    SessionSpec,
 )
 from paude.backends.podman.exceptions import (
     SessionExistsError,
@@ -24,6 +25,7 @@ from paude.backends.podman.file_copy import (
 from paude.backends.podman.helpers import (
     _generate_session_name,
     build_session_from_container,
+    composition_for_spec,
     container_name,
     find_container_by_session_name,
     get_session_agent,
@@ -117,22 +119,13 @@ class PodmanBackend:
             print(f"Creating volume {vname}...", file=sys.stderr)
             self._volume_manager.create_volume(vname, labels=labels)
 
-        from paude.agents import get_agent, get_agent_composition, get_agents
-
-        if config.agent_providers:
-            composition = get_agents(
-                [agent for agent, _provider in config.agent_providers],
-                providers={
-                    agent: provider
-                    for agent, provider in config.agent_providers
-                    if provider
-                },
-                include_bundled=False,
+        composition = composition_for_spec(
+            SessionSpec(
+                agent=config.agent,
+                provider=config.provider,
+                agent_providers=config.agent_providers,
             )
-        else:
-            composition = get_agent_composition(
-                get_agent(config.agent, provider=config.provider)
-            )
+        )
         network, proxy_ip = self._create_session_proxy(
             config, name, composition, vname, volume_reused
         )

--- a/src/paude/backends/podman/helpers.py
+++ b/src/paude/backends/podman/helpers.py
@@ -11,18 +11,12 @@ from typing import TYPE_CHECKING, Any
 
 from paude.backends.base import Session
 from paude.backends.labels import (
-    PAUDE_LABEL_AGENT,
-    PAUDE_LABEL_AGENT_PROVIDERS,
     PAUDE_LABEL_APP,
-    PAUDE_LABEL_CREATED,
     PAUDE_LABEL_DOMAINS,
-    PAUDE_LABEL_PROVIDER,
-    PAUDE_LABEL_PROVIDERS,
     PAUDE_LABEL_SESSION,
-    PAUDE_LABEL_VERSION,
-    PAUDE_LABEL_WORKSPACE,
-    parse_agent_providers_label,
-    parse_providers_label,
+    SessionSpec,
+    read_labels,
+    spec_from_labels,
 )
 from paude.backends.naming import (
     network_name,
@@ -31,7 +25,6 @@ from paude.backends.naming import (
     volume_name,
 )
 from paude.backends.podman.exceptions import SessionNotFoundError
-from paude.backends.session_env import decode_path
 from paude.container.runner import ContainerRunner
 
 if TYPE_CHECKING:
@@ -174,38 +167,27 @@ def build_session_from_container(
         Fully-constructed Session object.
     """
     labels = container.get("Labels", {}) or {}
-
-    workspace_encoded = labels.get(PAUDE_LABEL_WORKSPACE, "")
-    workspace = (
-        decode_path(workspace_encoded, url_safe=True)
-        if workspace_encoded
-        else Path("/")
-    )
-    created_at = labels.get(PAUDE_LABEL_CREATED, "")
-
-    status = _get_container_status(container)
-    status = _check_proxy_health(runner, name, labels, status)
-
-    agent_name = labels.get(PAUDE_LABEL_AGENT, "claude")
-    provider_name = labels.get(PAUDE_LABEL_PROVIDER)
-    raw_specs = labels.get(PAUDE_LABEL_AGENT_PROVIDERS)
-    agent_providers = parse_agent_providers_label(raw_specs)
-    credential_providers = parse_providers_label(labels.get(PAUDE_LABEL_PROVIDERS))
-    version = labels.get(PAUDE_LABEL_VERSION)
+    view = read_labels(labels)
+    status = _check_proxy_health(runner, name, labels, _get_container_status(container))
 
     return Session(
         name=name,
         status=status,
-        workspace=workspace,
-        created_at=created_at,
+        # A session whose workspace label was never written must still list;
+        # "/" is the placeholder paude has always shown for one.
+        workspace=view.workspace or Path("/"),
+        created_at=view.created_at,
         backend_type=backend_type,
         container_id=container.get("Id", ""),
         volume_name=volume_name(name),
-        agent=agent_name,
-        provider=provider_name,
-        agent_providers=agent_providers,
-        credential_providers=credential_providers,
-        version=version,
+        agent=view.spec.agent,
+        provider=view.spec.provider,
+        agent_providers=view.spec.agent_providers,
+        # The raw label, deliberately: a listing reports what the session
+        # declared. Callers that want the legacy derivation for a session
+        # predating the label ask for credential_providers_for_spec.
+        credential_providers=view.spec.credential_providers,
+        version=view.version,
     )
 
 
@@ -265,37 +247,60 @@ def get_session_agent(runner: ContainerRunner, session_name: str) -> Agent:
     return get_session_composition(runner, session_name).primary
 
 
+def composition_for_spec(spec: SessionSpec) -> AgentComposition:
+    """Build the agent composition a session's declared spec describes.
+
+    The two branches are not interchangeable, which is why deriving a
+    composition from ``spec.agent_providers`` alone would be wrong. A session
+    created before multi-agent support has no agent-providers label, only a
+    primary agent name -- and resolving that through ``get_agent_composition``
+    expands the agent's ``bundled_agents``. A legacy ``gascity`` session
+    installs claude and gemini alongside itself; take the other branch and it
+    silently comes back with one agent instead of three.
+    """
+    from paude.agents import get_agent, get_agent_composition, get_agents
+
+    if spec.agent_providers:
+        return get_agents(
+            [name for name, _provider in spec.agent_providers],
+            providers={
+                name: provider for name, provider in spec.agent_providers if provider
+            },
+            include_bundled=False,
+        )
+    return get_agent_composition(get_agent(spec.agent, provider=spec.provider))
+
+
+def credential_providers_for_spec(spec: SessionSpec) -> list[str]:
+    """Credential providers for a session, derived for legacy sessions.
+
+    The spec carries the raw label; a session created before that label existed
+    has none, so fall back to the providers its agents map to.
+    """
+    if spec.credential_providers:
+        return spec.credential_providers
+    return list(
+        dict.fromkeys(
+            agent.config.provider or ""
+            for agent in composition_for_spec(spec).agents
+            if agent.config.provider
+        )
+    )
+
+
 def get_session_composition(
     runner: ContainerRunner, session_name: str
 ) -> AgentComposition:
     """Get the full agent composition for a session from its labels."""
-    from paude.agents import get_agent, get_agent_composition, get_agents
-
-    labels = get_session_labels(runner, session_name)
-    agent_name = str(labels.get(PAUDE_LABEL_AGENT, "claude"))
-    provider = labels.get(PAUDE_LABEL_PROVIDER) or None
-    specs = parse_agent_providers_label(labels.get(PAUDE_LABEL_AGENT_PROVIDERS))
-    if specs:
-        return get_agents(
-            [name for name, _provider in specs],
-            providers={name: provider for name, provider in specs if provider},
-            include_bundled=False,
-        )
-    return get_agent_composition(get_agent(agent_name, provider=provider))
+    return composition_for_spec(
+        spec_from_labels(get_session_labels(runner, session_name))
+    )
 
 
 def get_session_credential_providers(
     runner: ContainerRunner, session_name: str
 ) -> list[str]:
     """Get credential providers, deriving them for legacy sessions."""
-    labels = get_session_labels(runner, session_name)
-    providers = parse_providers_label(labels.get(PAUDE_LABEL_PROVIDERS))
-    if providers:
-        return providers
-    return list(
-        dict.fromkeys(
-            agent.config.provider or ""
-            for agent in get_session_composition(runner, session_name).agents
-            if agent.config.provider
-        )
+    return credential_providers_for_spec(
+        spec_from_labels(get_session_labels(runner, session_name))
     )

--- a/src/paude/backends/podman/helpers.py
+++ b/src/paude/backends/podman/helpers.py
@@ -271,6 +271,18 @@ def composition_for_spec(spec: SessionSpec) -> AgentComposition:
     return get_agent_composition(get_agent(spec.agent, provider=spec.provider))
 
 
+def agent_specs_for(composition: AgentComposition) -> list[tuple[str, str]]:
+    """Project a composition back into ordered (agent, provider) pairs.
+
+    The inverse of :func:`composition_for_spec`'s first branch, and the one
+    place that projection is written -- it feeds container labels, the upgrade
+    manifest and the rebuilt SessionConfig, which must not disagree.
+    """
+    return [
+        (item.config.name, item.config.provider or "") for item in composition.agents
+    ]
+
+
 def credential_providers_for_spec(spec: SessionSpec) -> list[str]:
     """Credential providers for a session, derived for legacy sessions.
 

--- a/src/paude/backends/podman/helpers.py
+++ b/src/paude/backends/podman/helpers.py
@@ -5,9 +5,6 @@ Free functions and naming helpers extracted from PodmanBackend.
 
 from __future__ import annotations
 
-import base64
-import binascii
-import json
 import secrets
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -24,6 +21,8 @@ from paude.backends.labels import (
     PAUDE_LABEL_SESSION,
     PAUDE_LABEL_VERSION,
     PAUDE_LABEL_WORKSPACE,
+    parse_agent_providers_label,
+    parse_providers_label,
 )
 from paude.backends.naming import (
     network_name,
@@ -190,8 +189,8 @@ def build_session_from_container(
     agent_name = labels.get(PAUDE_LABEL_AGENT, "claude")
     provider_name = labels.get(PAUDE_LABEL_PROVIDER)
     raw_specs = labels.get(PAUDE_LABEL_AGENT_PROVIDERS)
-    agent_providers = _parse_agent_providers(raw_specs)
-    credential_providers = _parse_providers(labels.get(PAUDE_LABEL_PROVIDERS))
+    agent_providers = parse_agent_providers_label(raw_specs)
+    credential_providers = parse_providers_label(labels.get(PAUDE_LABEL_PROVIDERS))
     version = labels.get(PAUDE_LABEL_VERSION)
 
     return Session(
@@ -275,7 +274,7 @@ def get_session_composition(
     labels = get_session_labels(runner, session_name)
     agent_name = str(labels.get(PAUDE_LABEL_AGENT, "claude"))
     provider = labels.get(PAUDE_LABEL_PROVIDER) or None
-    specs = _parse_agent_providers(labels.get(PAUDE_LABEL_AGENT_PROVIDERS))
+    specs = parse_agent_providers_label(labels.get(PAUDE_LABEL_AGENT_PROVIDERS))
     if specs:
         return get_agents(
             [name for name, _provider in specs],
@@ -285,22 +284,12 @@ def get_session_composition(
     return get_agent_composition(get_agent(agent_name, provider=provider))
 
 
-def encode_agent_providers(specs: list[tuple[str, str]]) -> str:
-    """Encode ordered agent/provider pairs for a container label."""
-    return _encode_json_label(specs)
-
-
-def encode_providers(providers: list[str]) -> str:
-    """Encode a credential-provider set for a container label."""
-    return _encode_json_label(providers)
-
-
 def get_session_credential_providers(
     runner: ContainerRunner, session_name: str
 ) -> list[str]:
     """Get credential providers, deriving them for legacy sessions."""
     labels = get_session_labels(runner, session_name)
-    providers = _parse_providers(labels.get(PAUDE_LABEL_PROVIDERS))
+    providers = parse_providers_label(labels.get(PAUDE_LABEL_PROVIDERS))
     if providers:
         return providers
     return list(
@@ -310,50 +299,3 @@ def get_session_credential_providers(
             if agent.config.provider
         )
     )
-
-
-def _parse_providers(raw: str | None) -> list[str]:
-    """Parse a credential-provider label, returning empty when invalid."""
-    if not raw:
-        return []
-    value = _decode_json_label(raw)
-    if not isinstance(value, list):
-        return []
-    return list(dict.fromkeys(item for item in value if isinstance(item, str)))
-
-
-def _parse_agent_providers(raw: str | None) -> list[tuple[str, str]]:
-    """Parse a composition label, returning an empty list when invalid."""
-    if not raw:
-        return []
-    value = _decode_json_label(raw)
-    if not isinstance(value, list):
-        return []
-    specs: list[tuple[str, str]] = []
-    for item in value:
-        if (
-            isinstance(item, list)
-            and len(item) == 2
-            and isinstance(item[0], str)
-            and isinstance(item[1], str)
-        ):
-            specs.append((item[0], item[1]))
-    return specs
-
-
-def _encode_json_label(value: Any) -> str:
-    """Encode JSON as URL-safe base64 for use as a Podman label value."""
-    payload = json.dumps(value, separators=(",", ":")).encode()
-    return base64.urlsafe_b64encode(payload).decode()
-
-
-def _decode_json_label(raw: str) -> Any | None:
-    """Decode a structured label, accepting the original raw-JSON format."""
-    try:
-        decoded = base64.urlsafe_b64decode(raw.encode("ascii"))
-        return json.loads(decoded)
-    except (binascii.Error, UnicodeError, json.JSONDecodeError, ValueError):
-        try:
-            return json.loads(raw)
-        except (TypeError, ValueError):
-            return None

--- a/src/paude/backends/podman/legacy_state.py
+++ b/src/paude/backends/podman/legacy_state.py
@@ -7,9 +7,9 @@ import sys
 from pathlib import PurePosixPath
 from typing import TYPE_CHECKING
 
-from paude.cli.helpers import called_process_stderr
 from paude.constants import CONTAINER_HOME
 from paude.container.runner import echo_captured_stderr
+from paude.subprocess_utils import called_process_stderr
 
 if TYPE_CHECKING:
     from paude.agents.base import AgentComposition

--- a/src/paude/backends/podman/resources.py
+++ b/src/paude/backends/podman/resources.py
@@ -9,18 +9,18 @@ backend, rather than assembled ad hoc from the CLI layer.
 Three teardowns live side by side, and they are not the same operation. The
 differences are the whole reason this module exists:
 
-===========================  ==========  ==============  ===================
-step                         cleanup_all  rollback_create  teardown_for_rebuild
-===========================  ==========  ==============  ===================
-remove proxy container       verified     force            force
-remove agent container       (caller)     --               force
-remove network               yes          if proxy_image   yes
-remove CA volume             if exists    --               force
-remove **auth** volume       yes          --               **no**
-remove **credential secrets** yes         --               **no**
-remove **workspace volume**  verified     if not reused    **no**
-remove GCP ADC secret        yes          --               --
-===========================  ==========  ==============  ===================
+==========================  ============  ================  ====================
+step                        cleanup_all   rollback_create   teardown_for_rebuild
+==========================  ============  ================  ====================
+proxy container             verified      if proxy_image    force
+agent container             (caller)      --                force
+network                     yes           if proxy_image    yes
+CA volume                   if exists     --                force
+**auth volume**             yes           --                **no**
+**credential secrets**      yes           --                **no**
+**workspace volume**        verified      if not reused     **no**
+GCP ADC secret              yes           --                --
+==========================  ============  ================  ====================
 
 Collapsing them behind flags would put "delete the user's workspace" one wrong
 default away from the upgrade path, so they stay three named verbs sharing only

--- a/src/paude/backends/podman/resources.py
+++ b/src/paude/backends/podman/resources.py
@@ -1,0 +1,162 @@
+"""The resource-level view of a session's container, network and volumes.
+
+Exists so ``paude upgrade`` and ``paude backup`` can drive a rebuild without
+reaching into ``PodmanBackend``'s collaborators. It deliberately does *not*
+expose the runner, network manager or volume manager: the point is that the set
+of destructive operations a rebuild may perform is enumerable here, in the
+backend, rather than assembled ad hoc from the CLI layer.
+
+Three teardowns live side by side, and they are not the same operation. The
+differences are the whole reason this module exists:
+
+===========================  ==========  ==============  ===================
+step                         cleanup_all  rollback_create  teardown_for_rebuild
+===========================  ==========  ==============  ===================
+remove proxy container       verified     force            force
+remove agent container       (caller)     --               force
+remove network               yes          if proxy_image   yes
+remove CA volume             if exists    --               force
+remove **auth** volume       yes          --               **no**
+remove **credential secrets** yes         --               **no**
+remove **workspace volume**  verified     if not reused    **no**
+remove GCP ADC secret        yes          --               --
+===========================  ==========  ==============  ===================
+
+Collapsing them behind flags would put "delete the user's workspace" one wrong
+default away from the upgrade path, so they stay three named verbs sharing only
+the two lines they genuinely have in common.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+from paude.backends.labels import LabeledSession, read_labels
+from paude.backends.podman.helpers import (
+    auth_volume_name,
+    ca_volume_name,
+    container_name,
+    find_container_by_session_name,
+    network_name,
+    proxy_container_name,
+)
+from paude.constants import GCP_ADC_SECRET_NAME
+
+if TYPE_CHECKING:
+    from paude.agents.base import AgentComposition
+    from paude.backends.base import SessionConfig
+    from paude.backends.podman.proxy import PodmanProxyManager
+    from paude.container.network import NetworkManager
+    from paude.container.runner import ContainerRunner
+    from paude.container.volume import VolumeManager
+
+
+class SessionResources:
+    """Read and remove the podman objects that make up one session."""
+
+    def __init__(
+        self,
+        runner: ContainerRunner,
+        network_manager: NetworkManager,
+        volume_manager: VolumeManager,
+        proxy: PodmanProxyManager,
+    ) -> None:
+        self._runner = runner
+        self._network_manager = network_manager
+        self._volume_manager = volume_manager
+        self._proxy = proxy
+
+    # -- reads ------------------------------------------------------------
+
+    def exists(self, name: str) -> bool:
+        """Whether the session's agent container exists."""
+        return self._runner.container_exists(container_name(name))
+
+    def running(self, name: str) -> bool:
+        """Whether the session's agent container is running."""
+        return self._runner.container_running(container_name(name))
+
+    def image(self, name: str) -> str | None:
+        """The image the session's agent container was created from."""
+        return self._runner.get_container_image(container_name(name))
+
+    def labels(self, name: str) -> LabeledSession | None:
+        """Read everything the session's labels record, in one container fetch.
+
+        ``None`` when no container matches. One fetch matters: on a ``--host``
+        session each one is an SSH round trip.
+        """
+        container = find_container_by_session_name(self._runner, name)
+        if container is None:
+            return None
+        return read_labels(container.get("Labels", {}) or {})
+
+    # -- rebuild ----------------------------------------------------------
+
+    def migrate_legacy_state(self, name: str, composition: AgentComposition) -> None:
+        """Salvage state written by an older image into the session volume.
+
+        A no-op when the old container is already gone -- which is the case
+        when resuming an interrupted upgrade, where its state was copied into
+        the volume before it was removed.
+        """
+        from paude.backends.podman.legacy_state import migrate_legacy_state
+
+        cname = container_name(name)
+        if not self._runner.container_exists(cname):
+            return
+        print("Migrating persistent agent state...", file=sys.stderr)
+        migrate_legacy_state(self._runner, cname, composition)
+
+    def teardown_for_rebuild(self, name: str) -> None:
+        """Remove the session's container, proxy, network and CA volume.
+
+        Keeps everything that holds state: the **workspace volume** (the user's
+        data), the **proxy auth volume** (live OAuth state -- see
+        ``PodmanProxyManager``), and the **credential secrets**. A rebuild
+        re-derives the rest from the host environment, exactly as a fresh
+        create does, but it must not make the user log in again or lose work.
+
+        Every removal is force/tolerant, so re-running after a partial teardown
+        converges rather than failing. That is what makes an interrupted
+        upgrade resumable.
+        """
+        cname = container_name(name)
+        print(f"Removing old container {cname}...", file=sys.stderr)
+        self._runner.remove_container(cname, force=True)
+        self._remove_proxy_and_network(name)
+        self._volume_manager.remove_volume(ca_volume_name(name), force=True)
+
+    def rollback_create(
+        self,
+        config: SessionConfig,
+        name: str,
+        vname: str,
+        volume_reused: bool,
+    ) -> None:
+        """Clean up proxy/volume on container creation failure."""
+        if config.proxy_image:
+            self._remove_proxy_and_network(name)
+        if not volume_reused:
+            self._volume_manager.remove_volume(vname, force=True)
+
+    def cleanup_all(self, name: str, vname: str) -> None:
+        """Remove network, proxy volumes, secrets, and the workspace volume.
+
+        The delete path: unlike :meth:`teardown_for_rebuild` this destroys the
+        session's data, including the workspace volume.
+        """
+        self._network_manager.remove_network(network_name(name))
+        for pv in (ca_volume_name(name), auth_volume_name(name)):
+            if self._volume_manager.volume_exists(pv):
+                self._volume_manager.remove_volume(pv, force=True)
+        self._proxy.remove_credential_secrets(name)
+        print(f"Removing volume {vname}...", file=sys.stderr)
+        self._volume_manager.remove_volume_verified(vname)
+        self._runner.remove_secret(GCP_ADC_SECRET_NAME)
+
+    def _remove_proxy_and_network(self, name: str) -> None:
+        """Drop the proxy sidecar and its network, tolerantly."""
+        self._runner.remove_container(proxy_container_name(name), force=True)
+        self._network_manager.remove_network(network_name(name))

--- a/src/paude/backends/podman/session_setup.py
+++ b/src/paude/backends/podman/session_setup.py
@@ -28,11 +28,11 @@ from paude.backends.labels import (
     PAUDE_LABEL_VERSION,
     PAUDE_LABEL_WORKSPACE,
     PAUDE_LABEL_YOLO,
+    encode_agent_providers,
+    encode_providers,
 )
 from paude.backends.podman.helpers import (
     container_name,
-    encode_agent_providers,
-    encode_providers,
     get_session_composition,
     get_session_credential_providers,
     get_session_labels,

--- a/src/paude/backup_state.py
+++ b/src/paude/backup_state.py
@@ -22,7 +22,9 @@ version gating, not atomic file persistence.
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
+
+from paude.backends.labels import SessionSpec, normalize_agent_providers
 
 # Bump when the bundle layout or manifest schema changes incompatibly.
 BACKUP_FORMAT_VERSION = 1
@@ -35,9 +37,15 @@ class BackupFormatError(ValueError):
     """Raised when a bundle's manifest is missing, corrupt, or unsupported."""
 
 
-@dataclass
-class BackupManifest:
+@dataclass(kw_only=True)
+class BackupManifest(SessionSpec):
     """Everything needed to identify and rebuild a backed-up session.
+
+    The label-derived configuration is inherited from
+    :class:`~paude.backends.labels.SessionSpec`; this adds the bundle's own
+    identity and integrity fields plus the registry-only fields a remote or
+    renamed restore needs. Inheriting rather than embedding keeps ``to_json()``
+    flat, so the manifest schema is unchanged.
 
     Attributes:
         name: Session name at backup time.
@@ -47,9 +55,7 @@ class BackupManifest:
         source_paude_version: paude version that produced the bundle.
         session_created_at: ISO timestamp of the original session creation.
         archive_sha256: SHA-256 of ``pvc.tar.gz`` for integrity checks.
-        agent/provider/agent_providers/credential_providers: agent composition.
-        gpu/yolo/otel_endpoint/allowed_domains/proxy_image/image: session config
-            derived from container labels.
+        image: The container image the bundle captured.
         backend_type/engine/ssh_host/ssh_key/remote_config_dir: registry-only
             fields needed to reconstruct how to reach the (possibly remote)
             session on restore.
@@ -63,16 +69,9 @@ class BackupManifest:
     session_created_at: str | None = None
     archive_sha256: str | None = None
 
-    # Label-derived config (mirrors UpgradeManifest).
-    agent: str = "claude"
-    provider: str | None = None
-    agent_providers: list[tuple[str, str]] = field(default_factory=list)
-    credential_providers: list[str] = field(default_factory=list)
-    gpu: str | None = None
-    yolo: bool = False
-    otel_endpoint: str | None = None
-    allowed_domains: list[str] | None = None
-    proxy_image: str | None = None
+    # The image the bundle captured. Not a SessionSpec field: the spec records
+    # declared configuration, and this is a build output. Upgrade has no use for
+    # it (it always force-rebuilds), but a restore must know what it restored.
     image: str | None = None
 
     # Registry-only fields (not present in container labels).
@@ -109,11 +108,18 @@ def loads(text: str) -> BackupManifest:
         )
 
     entry = dict(raw)
-    # JSON stores tuples as lists; normalize agent_providers back to tuples so it
-    # round-trips identically to the in-memory dataclass.
-    entry["agent_providers"] = [
-        tuple(item) for item in (entry.get("agent_providers") or [])
-    ]
+    try:
+        # JSON stores tuples as lists; normalize agent_providers back to tuples
+        # so it round-trips identically to the in-memory dataclass. Strict, so a
+        # malformed pair surfaces here rather than as a 1-tuple that blows up
+        # later where a caller unpacks `for agent, provider in specs`.
+        entry["agent_providers"] = normalize_agent_providers(
+            entry.get("agent_providers")
+        )
+    except ValueError as exc:
+        raise BackupFormatError(
+            f"Backup manifest has a malformed field: {exc}"
+        ) from exc
     try:
         return BackupManifest(**entry)
     except TypeError as exc:

--- a/src/paude/cli/backup.py
+++ b/src/paude/cli/backup.py
@@ -38,6 +38,7 @@ from paude.cli.app import BackendType, app
 from paude.transport.ssh import SshTransport
 
 if TYPE_CHECKING:
+    from paude.backends.labels import LabeledSession
     from paude.backends.podman.backend import PodmanBackend
     from paude.backends.podman.volume_archive import VolumeArchiver
 
@@ -104,61 +105,36 @@ def _resolve_remote_output_path(
 
 
 def _build_manifest(
-    backend: PodmanBackend,
+    view: LabeledSession,
     name: str,
     image: str,
     now: datetime,
+    backend_type: str,
 ) -> BackupManifest:
     """Assemble the backup manifest from the session's labels and registry entry."""
     from paude import __version__
-    from paude.backends.labels import (
-        PAUDE_LABEL_DOMAINS,
-        PAUDE_LABEL_GPU,
-        PAUDE_LABEL_OTEL_ENDPOINT,
-        PAUDE_LABEL_PROXY_IMAGE,
-        PAUDE_LABEL_YOLO,
-    )
-    from paude.backends.podman.helpers import (
-        build_session_from_container,
-        find_container_by_session_name,
-    )
     from paude.registry import SessionRegistry
-
-    # Fetch the container once and derive both the Session and its labels from
-    # it, rather than round-tripping to the backend twice (matters on SSH).
-    container = find_container_by_session_name(backend._runner, name)
-    if container is None:
-        raise RuntimeError(f"Session '{name}' not found.")
-    labels = container.get("Labels", {}) or {}
-    session = build_session_from_container(
-        name, container, backend._runner, backend.backend_type
-    )
-
-    domains_label = labels.get(PAUDE_LABEL_DOMAINS)
-    allowed_domains: list[str] | None = None
-    if domains_label is not None:
-        allowed_domains = domains_label.split(",") if domains_label else []
 
     entry = SessionRegistry().get(name)
 
     return BackupManifest(
         name=name,
-        workspace=str(session.workspace),
+        workspace=str(view.workspace or Path("/")),
         created_at=now.isoformat(),
         source_paude_version=__version__,
-        session_created_at=session.created_at or None,
-        agent=session.agent,
-        provider=session.provider,
-        agent_providers=list(session.agent_providers),
-        credential_providers=list(session.credential_providers),
-        gpu=labels.get(PAUDE_LABEL_GPU) or None,
-        yolo=labels.get(PAUDE_LABEL_YOLO) == "1",
-        otel_endpoint=labels.get(PAUDE_LABEL_OTEL_ENDPOINT) or None,
-        allowed_domains=allowed_domains,
-        proxy_image=labels.get(PAUDE_LABEL_PROXY_IMAGE) or None,
+        session_created_at=view.created_at or None,
+        agent=view.spec.agent,
+        provider=view.spec.provider,
+        agent_providers=list(view.spec.agent_providers),
+        credential_providers=list(view.spec.credential_providers),
+        gpu=view.spec.gpu,
+        yolo=view.spec.yolo,
+        otel_endpoint=view.spec.otel_endpoint,
+        allowed_domains=view.spec.allowed_domains,
+        proxy_image=view.spec.proxy_image,
         image=image,
-        backend_type=session.backend_type,
-        engine=entry.engine if entry else session.backend_type,
+        backend_type=backend_type,
+        engine=entry.engine if entry else backend_type,
         ssh_host=entry.ssh_host if entry else None,
         ssh_key=entry.ssh_key if entry else None,
         remote_config_dir=entry.remote_config_dir if entry else None,
@@ -217,7 +193,7 @@ def session_backup(
     SSH link back to this machine.
     """
     from paude.backends import PodmanBackend
-    from paude.backends.podman.helpers import container_name, volume_name
+    from paude.backends.podman.helpers import volume_name
     from paude.backends.podman.volume_archive import VolumeArchiver
     from paude.cli.helpers import (
         _auto_select_session,
@@ -248,23 +224,22 @@ def session_backup(
         typer.echo("Unsupported backend for backup.", err=True)
         raise typer.Exit(1)
 
-    cname = container_name(name)
     vname = volume_name(name)
 
-    if not backend_obj._runner.container_exists(cname):
+    if not backend_obj.resources.exists(name):
         typer.echo(f"Session '{name}' not found.", err=True)
         raise typer.Exit(1)
 
     # Refuse to back up a running session: a live container may be writing to
     # git/sqlite/dolt, which would tear the snapshot. No auto-stop.
-    if backend_obj._runner.container_running(cname):
+    if backend_obj.resources.running(name):
         typer.echo(
             f"Session '{name}' is running. Stop it first: paude stop {name}",
             err=True,
         )
         raise typer.Exit(1)
 
-    image = backend_obj._runner.get_container_image(cname)
+    image = backend_obj.resources.image(name)
     if not image:
         typer.echo(
             f"Could not determine the container image for session '{name}'.",
@@ -273,7 +248,7 @@ def session_backup(
         raise typer.Exit(1)
 
     now = datetime.now(UTC)
-    archiver = VolumeArchiver(backend_obj._engine)
+    archiver = VolumeArchiver(backend_obj.engine)
     backup_fn = _run_remote_backup if remote_only else _run_local_backup
     backup_fn(name, backend_obj, archiver, vname, image, output, force, now)
 
@@ -292,13 +267,17 @@ def _finalize_backup(
     building, error translation, and the success message aren't duplicated.
     """
     from paude.backends import SessionNotFoundError
-    from paude.backends.podman.helpers import get_session_composition
+    from paude.backends.podman.helpers import composition_for_spec
     from paude.backends.podman.legacy_state import credential_exclude_globs
 
     try:
-        composition = get_session_composition(backend_obj._runner, name)
-        exclude = credential_exclude_globs(composition)
-        manifest = _build_manifest(backend_obj, name, image, now)
+        # One container fetch feeds both the exclude list and the manifest;
+        # on a --host session each one is an SSH round trip.
+        view = backend_obj.resources.labels(name)
+        if view is None:
+            raise RuntimeError(f"Session '{name}' not found.")
+        exclude = credential_exclude_globs(composition_for_spec(view.spec))
+        manifest = _build_manifest(view, name, image, now, backend_obj.backend_type)
         write(manifest, exclude)
     except SessionNotFoundError as e:
         typer.echo(f"Error: {e}", err=True)
@@ -356,8 +335,8 @@ def _run_remote_backup(
     now: datetime,
 ) -> None:
     """Resolve, preflight, and write a bundle on the session's remote host."""
-    transport = backend_obj._engine.transport
-    if not backend_obj._engine.is_remote or not isinstance(transport, SshTransport):
+    transport = backend_obj.engine.transport
+    if not backend_obj.engine.is_remote or not isinstance(transport, SshTransport):
         typer.echo(
             f"Session '{name}' does not run on a remote host; --remote-only "
             "requires a session created with --host.",

--- a/src/paude/cli/backup.py
+++ b/src/paude/cli/backup.py
@@ -293,7 +293,7 @@ def _finalize_backup(
     """
     from paude.backends import SessionNotFoundError
     from paude.backends.podman.helpers import get_session_composition
-    from paude.cli.upgrade_persistence import credential_exclude_globs
+    from paude.backends.podman.legacy_state import credential_exclude_globs
 
     try:
         composition = get_session_composition(backend_obj._runner, name)

--- a/src/paude/cli/commands/lifecycle.py
+++ b/src/paude/cli/commands/lifecycle.py
@@ -12,10 +12,10 @@ from paude.cli.helpers import (
     _auto_select_session,
     _get_backend_instance,
     _parse_forward_ports,
-    called_process_stderr,
     find_session_backend,
 )
 from paude.session_discovery import resolve_session_for_backend
+from paude.subprocess_utils import called_process_stderr
 
 
 @app.command("start")

--- a/src/paude/cli/create.py
+++ b/src/paude/cli/create.py
@@ -334,7 +334,7 @@ def session_create(
             raise typer.Exit(1) from None
 
     # Shared pre-create: parse args, build env, expand domains, show warnings
-    expanded_domains, parsed_args, env, unrestricted = _prepare_session_create(
+    expanded_domains, parsed_args, env, _unrestricted = _prepare_session_create(
         allowed_domains=r_allowed_domains,
         yolo=r_yolo,
         claude_args=claude_args,
@@ -361,7 +361,6 @@ def session_create(
         config=config,
         env=env,
         expanded_domains=expanded_domains,
-        unrestricted=unrestricted,
         parsed_args=parsed_args,
         yolo=r_yolo,
         git=r_git,

--- a/src/paude/cli/create_podman.py
+++ b/src/paude/cli/create_podman.py
@@ -13,9 +13,9 @@ from paude.cli.helpers import (
     _detect_dev_script_dir,
     _finalize_session_create,
     _run_setup_command,
-    called_process_stderr,
 )
 from paude.config.models import PaudeConfig
+from paude.subprocess_utils import called_process_stderr
 
 if TYPE_CHECKING:
     from paude.transport.base import Transport

--- a/src/paude/cli/create_podman.py
+++ b/src/paude/cli/create_podman.py
@@ -10,6 +10,7 @@ import typer
 from paude.agents import get_agents
 from paude.backends import PodmanBackend, SessionConfig, SessionExistsError
 from paude.backends.labels import SessionSpec
+from paude.backends.podman.helpers import agent_specs_for
 from paude.cli.helpers import (
     _finalize_session_create,
     _run_setup_command,
@@ -38,7 +39,6 @@ def create_podman_session(
     config: PaudeConfig | None,
     env: dict[str, str],
     expanded_domains: list[str],
-    unrestricted: bool,
     parsed_args: list[str],
     yolo: bool,
     git: bool,
@@ -95,7 +95,7 @@ def create_podman_session(
         images=images,
         env=env,
         mounts=prepared.mounts,
-        allowed_domains=expanded_domains,
+        expanded_domains=expanded_domains,
         otel_ports=otel_ports or [],
         args=parsed_args,
         workdir=str(workspace),
@@ -137,9 +137,9 @@ def _resolve_composition_and_spec(
 ) -> tuple[AgentComposition, SessionSpec]:
     """Resolve the requested agents and gather the session's declared config.
 
-    ``credential_providers`` may legitimately be empty here; the spec records
-    what was asked for, and session_config_from_spec fills in the agents' own
-    providers when nothing was.
+    The spec is normalised here rather than downstream: unspecified credential
+    providers mean "whatever the agents map to", and that default belongs with
+    the caller that knows it, not inside the shared session builder.
     """
     specs = agent_providers or [(agent_name, provider_name or "")]
     composition = get_agents(
@@ -147,10 +147,13 @@ def _resolve_composition_and_spec(
         providers={name: provider for name, provider in specs if provider},
         include_bundled=False,
     )
+    resolved_specs = agent_specs_for(composition)
     spec = SessionSpec(
         agent=agent_name,
         provider=provider_name,
-        credential_providers=credential_providers or [],
+        agent_providers=resolved_specs,
+        credential_providers=credential_providers
+        or [provider for _agent, provider in resolved_specs],
         gpu=gpu,
         yolo=yolo,
         otel_endpoint=otel_endpoint,

--- a/src/paude/cli/create_podman.py
+++ b/src/paude/cli/create_podman.py
@@ -9,16 +9,26 @@ import typer
 
 from paude.agents import get_agents
 from paude.backends import PodmanBackend, SessionConfig, SessionExistsError
+from paude.backends.labels import SessionSpec
 from paude.cli.helpers import (
-    _detect_dev_script_dir,
     _finalize_session_create,
     _run_setup_command,
+)
+from paude.cli.session_rebuild import (
+    ImageBuildError,
+    build_session_images,
+    prepare_session_mounts,
+    session_config_from_spec,
 )
 from paude.config.models import PaudeConfig
 from paude.subprocess_utils import called_process_stderr
 
 if TYPE_CHECKING:
+    from paude.agents.base import AgentComposition
+    from paude.backends.base import Session
+    from paude.container.engine import ContainerEngine
     from paude.transport.base import Transport
+    from paude.transport.config_sync import RemoteConfigPaths
 
 
 def create_podman_session(
@@ -48,92 +58,120 @@ def create_podman_session(
     otel_endpoint: str | None = None,
 ) -> None:
     """Local container session creation logic (Podman or Docker)."""
-    from paude.container import ImageManager
     from paude.container.engine import ContainerEngine
-    from paude.mounts import build_mounts
 
     engine = ContainerEngine(engine_binary, transport=transport)
-    home = Path.home()
+    composition, spec = _resolve_composition_and_spec(
+        agent_name=agent_name,
+        provider_name=provider_name,
+        agent_providers=agent_providers,
+        credential_providers=credential_providers,
+        gpu=gpu,
+        yolo=yolo,
+        otel_endpoint=otel_endpoint,
+    )
+
+    try:
+        images = build_session_images(
+            engine=engine,
+            composition=composition,
+            config=config,
+            workspace=workspace,
+            force_rebuild=rebuild,
+            platform=platform,
+        )
+    except ImageBuildError as e:
+        label = "image" if e.stage == "agent" else "proxy image"
+        typer.echo(f"Error ensuring {label}: {e.cause}", err=True)
+        raise typer.Exit(1) from None
+
+    prepared = prepare_session_mounts(engine=engine, composition=composition)
+
+    session_config = session_config_from_spec(
+        spec,
+        name=name,
+        workspace=workspace,
+        composition=composition,
+        images=images,
+        env=env,
+        mounts=prepared.mounts,
+        allowed_domains=expanded_domains,
+        otel_ports=otel_ports or [],
+        args=parsed_args,
+        workdir=str(workspace),
+    )
+
+    backend_instance, session = _create_session_or_exit(
+        engine, session_config, prepared.remote_config
+    )
+
+    from paude import __version__
+
+    _finalize_session_create(
+        session=session,
+        expanded_domains=expanded_domains,
+        yolo=yolo,
+        git=git,
+        no_clone_origin=no_clone_origin,
+        ssh_host=ssh_host,
+        ssh_key=ssh_key,
+        remote_config_dir=(
+            prepared.remote_config.remote_base if prepared.remote_config else None
+        ),
+        paude_version=__version__,
+    )
+
+    if config and config.setup_command:
+        _run_setup_command(backend_instance, session.name, config.setup_command)
+
+
+def _resolve_composition_and_spec(
+    *,
+    agent_name: str,
+    provider_name: str | None,
+    agent_providers: list[tuple[str, str]] | None,
+    credential_providers: list[str] | None,
+    gpu: str | None,
+    yolo: bool,
+    otel_endpoint: str | None,
+) -> tuple[AgentComposition, SessionSpec]:
+    """Resolve the requested agents and gather the session's declared config.
+
+    ``credential_providers`` may legitimately be empty here; the spec records
+    what was asked for, and session_config_from_spec fills in the agents' own
+    providers when nothing was.
+    """
     specs = agent_providers or [(agent_name, provider_name or "")]
     composition = get_agents(
         [name for name, _provider in specs],
         providers={name: provider for name, provider in specs if provider},
         include_bundled=False,
     )
-    resolved_specs = [
-        (item.config.name, item.config.provider or "") for item in composition.agents
-    ]
-    agent_instance = composition.primary
-    image_manager = ImageManager(
-        script_dir=_detect_dev_script_dir(),
-        platform=platform,
-        agent=agent_instance,
-        composition=composition,
-        engine=engine,
-    )
-
-    # Ensure image
-    try:
-        if config is not None and config.has_customizations:
-            image = image_manager.ensure_custom_image(
-                config, force_rebuild=rebuild, workspace=workspace
-            )
-        else:
-            image = image_manager.ensure_default_image(force_rebuild=rebuild)
-    except Exception as e:
-        typer.echo(f"Error ensuring image: {e}", err=True)
-        raise typer.Exit(1) from None
-
-    # Build mounts — skip config bind mounts for local engines (use podman cp
-    # instead, which avoids SELinux label issues). SSH remotes keep bind mounts.
-    mounts = build_mounts(home, composition, include_config=engine.is_remote)
-
-    # Sync configs to remote host if using SSH
-    remote_config_paths = None
-    if engine.is_remote:
-        from paude.transport.config_sync import remap_mounts, sync_configs_to_remote
-        from paude.transport.ssh import SshTransport
-
-        if isinstance(engine.transport, SshTransport):
-            typer.echo("Syncing configuration to remote host...", err=True)
-            remote_config_paths = sync_configs_to_remote(engine.transport, mounts)
-            mounts = remap_mounts(mounts, remote_config_paths.path_map)
-
-    # Ensure proxy image (always required — all sessions use proxy)
-    podman_proxy_image: str | None = None
-    try:
-        podman_proxy_image = image_manager.ensure_proxy_image(force_rebuild=rebuild)
-    except Exception as e:
-        typer.echo(f"Error ensuring proxy image: {e}", err=True)
-        raise typer.Exit(1) from None
-
-    # Create session config
-    session_config = SessionConfig(
-        name=name,
-        workspace=workspace,
-        image=image,
-        env=env,
-        mounts=mounts,
-        args=parsed_args,
-        workdir=str(workspace),
-        allowed_domains=expanded_domains,
-        yolo=yolo,
-        proxy_image=podman_proxy_image,
+    spec = SessionSpec(
         agent=agent_name,
         provider=provider_name,
-        agent_providers=resolved_specs,
-        credential_providers=credential_providers
-        or [provider for _agent, provider in resolved_specs],
+        credential_providers=credential_providers or [],
         gpu=gpu,
-        ports=composition.exposed_ports,
-        otel_ports=otel_ports or [],
+        yolo=yolo,
         otel_endpoint=otel_endpoint,
     )
+    return composition, spec
 
+
+def _create_session_or_exit(
+    engine: ContainerEngine,
+    session_config: SessionConfig,
+    remote_config: RemoteConfigPaths | None,
+) -> tuple[PodmanBackend, Session]:
+    """Create and start the session, or report the failure and exit.
+
+    An existing session is reported as-is and deliberately left alone; every
+    other failure is rolled back on a best-effort basis, including any config
+    files synced to a remote host.
+    """
+    backend_instance = PodmanBackend(engine=engine)
     try:
-        backend_instance = PodmanBackend(engine=engine)
         session = backend_instance.create_session(session_config)
-
         # Auto-start the container (entrypoint is tini -- sleep infinity)
         backend_instance.start_session_no_attach(session.name)
     except SessionExistsError as e:
@@ -147,34 +185,14 @@ def create_podman_session(
             backend_instance.delete_session(session.name, confirm=True)
         except Exception:  # noqa: S110 - best-effort cleanup
             pass
-        if remote_config_paths:
+        if remote_config:
             try:
                 from paude.transport.config_sync import cleanup_remote_configs
                 from paude.transport.ssh import SshTransport
 
                 if isinstance(engine.transport, SshTransport):
-                    cleanup_remote_configs(
-                        engine.transport, remote_config_paths.remote_base
-                    )
+                    cleanup_remote_configs(engine.transport, remote_config.remote_base)
             except Exception:  # noqa: S110 - best-effort cleanup
                 pass
         raise typer.Exit(1) from None
-
-    from paude import __version__
-
-    _finalize_session_create(
-        session=session,
-        expanded_domains=expanded_domains,
-        yolo=yolo,
-        git=git,
-        no_clone_origin=no_clone_origin,
-        ssh_host=ssh_host,
-        ssh_key=ssh_key,
-        remote_config_dir=(
-            remote_config_paths.remote_base if remote_config_paths else None
-        ),
-        paude_version=__version__,
-    )
-
-    if config and config.setup_command:
-        _run_setup_command(backend_instance, session.name, config.setup_command)
+    return backend_instance, session

--- a/src/paude/cli/helpers.py
+++ b/src/paude/cli/helpers.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -22,18 +21,6 @@ from paude.session_discovery import (
 if TYPE_CHECKING:
     from paude.agents.base import AgentComposition
     from paude.backends.port_forward_utils import ForwardPort
-
-
-def called_process_stderr(e: Exception) -> str | None:
-    """Return a CalledProcessError's captured stderr, stripped, if any.
-
-    str(CalledProcessError) omits the captured stderr, so callers reporting a
-    failure via an f-string need this to surface the underlying command's
-    actual explanation instead of just "returned non-zero exit status N".
-    """
-    if isinstance(e, subprocess.CalledProcessError) and e.stderr:
-        return str(e.stderr).strip()
-    return None
 
 
 def find_session_backend(

--- a/src/paude/cli/session_rebuild.py
+++ b/src/paude/cli/session_rebuild.py
@@ -7,24 +7,28 @@ down first) and in how they report failure. This module owns the steps; the two
 callers own the order and the error UX, which is why these are three named
 functions rather than one ``rebuild_session()`` with hooks.
 
-Every collaborator is imported *inside* the function that uses it, from the
-module that defines it. That is not style: the create and upgrade test suites
-patch ``paude.container.ImageManager``, ``paude.mounts.build_mounts`` and
-``paude.transport.config_sync.*`` at those paths, and a module-level import here
-would bind the name once at import time and silently stop those patches from
-applying.
+``ImageManager``, ``build_mounts`` and the ``config_sync`` helpers are imported
+inside the functions that use them, from the modules that define them, and must
+stay that way for now: the create and upgrade suites patch them at those
+*definition* paths, so a module-level import here would bind the name at import
+time and silently defeat the patch. That is a property of the tests, not a
+design goal -- patching the lookup site (``paude.cli.session_rebuild.X``), or
+injecting the image manager the way ``engine`` already is, would free these.
+Everything else is imported normally.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
-if TYPE_CHECKING:
-    from pathlib import Path
+import typer
 
+from paude.backends.base import SessionConfig
+
+if TYPE_CHECKING:
     from paude.agents.base import AgentComposition
-    from paude.backends.base import SessionConfig
     from paude.backends.labels import SessionSpec
     from paude.config.models import PaudeConfig
     from paude.container.engine import ContainerEngine
@@ -50,7 +54,7 @@ class SessionImages:
     """The images a session runs: its agent container and its proxy sidecar."""
 
     agent: str
-    proxy: str | None
+    proxy: str
 
 
 @dataclass(frozen=True)
@@ -124,15 +128,11 @@ def prepare_session_mounts(
     the files are transferred and the mount sources rewritten -- otherwise
     podman there fails with "statfs ...: no such file".
     """
-    from pathlib import Path
-
     from paude.mounts import build_mounts
 
     mounts = build_mounts(Path.home(), composition, include_config=engine.is_remote)
     if not engine.is_remote:
         return SessionMounts(mounts=mounts, remote_config=None)
-
-    import typer
 
     from paude.transport.config_sync import remap_mounts, sync_configs_to_remote
     from paude.transport.ssh import SshTransport
@@ -157,18 +157,17 @@ def session_config_from_spec(
     images: SessionImages,
     env: dict[str, str],
     mounts: list[str],
-    allowed_domains: list[str],
+    expanded_domains: list[str],
     otel_ports: list[int],
     args: list[str] | None = None,
     workdir: str | None = None,
     reuse_volume: bool = False,
 ) -> SessionConfig:
-    """Turn a resolved spec plus this build's outputs into a SessionConfig."""
-    from paude.backends import SessionConfig
+    """Turn a resolved spec plus this build's outputs into a SessionConfig.
 
-    agent_specs = [
-        (item.config.name, item.config.provider or "") for item in composition.agents
-    ]
+    Reads the spec verbatim: both callers normalise theirs first, so no
+    caller-specific default lives here.
+    """
     return SessionConfig(
         name=name,
         workspace=workspace,
@@ -177,18 +176,16 @@ def session_config_from_spec(
         mounts=mounts,
         args=args or [],
         workdir=workdir,
-        allowed_domains=allowed_domains,
+        # The expanded set, deliberately not spec.allowed_domains: the spec
+        # records what was declared (or None for a session predating the
+        # always-on proxy), the container needs what that expands to.
+        allowed_domains=expanded_domains,
         yolo=spec.yolo,
-        # A rebuild falls back to the recorded label when its own proxy build
-        # produced nothing; a fresh create has no recorded label to fall back to.
-        proxy_image=images.proxy or spec.proxy_image,
+        proxy_image=images.proxy,
         agent=spec.agent,
         provider=spec.provider,
-        agent_providers=agent_specs,
-        # Create may be handed none, in which case the agents' own providers are
-        # what needs credentials. Upgrade always resolves them beforehand.
-        credential_providers=spec.credential_providers
-        or [provider for _agent, provider in agent_specs],
+        agent_providers=list(spec.agent_providers),
+        credential_providers=list(spec.credential_providers),
         gpu=spec.gpu,
         reuse_volume=reuse_volume,
         ports=composition.exposed_ports,

--- a/src/paude/cli/session_rebuild.py
+++ b/src/paude/cli/session_rebuild.py
@@ -1,0 +1,197 @@
+"""The steps shared by every path that builds a session's container.
+
+``paude create`` and ``paude upgrade`` are the same pipeline -- resolve a
+composition, build the images, assemble the mounts, hand a ``SessionConfig`` to
+the backend -- differing in one inserted step (upgrade tears the old container
+down first) and in how they report failure. This module owns the steps; the two
+callers own the order and the error UX, which is why these are three named
+functions rather than one ``rebuild_session()`` with hooks.
+
+Every collaborator is imported *inside* the function that uses it, from the
+module that defines it. That is not style: the create and upgrade test suites
+patch ``paude.container.ImageManager``, ``paude.mounts.build_mounts`` and
+``paude.transport.config_sync.*`` at those paths, and a module-level import here
+would bind the name once at import time and silently stop those patches from
+applying.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from paude.agents.base import AgentComposition
+    from paude.backends.base import SessionConfig
+    from paude.backends.labels import SessionSpec
+    from paude.config.models import PaudeConfig
+    from paude.container.engine import ContainerEngine
+    from paude.transport.config_sync import RemoteConfigPaths
+
+
+class ImageBuildError(RuntimeError):
+    """An image build failed, carrying which one and why.
+
+    The two callers report this very differently -- create exits, upgrade
+    raises a retryable error -- so the stage is data rather than a message
+    baked in here.
+    """
+
+    def __init__(self, stage: Literal["agent", "proxy"], cause: Exception) -> None:
+        super().__init__(f"building the {stage} image failed: {cause}")
+        self.stage = stage
+        self.cause = cause
+
+
+@dataclass(frozen=True)
+class SessionImages:
+    """The images a session runs: its agent container and its proxy sidecar."""
+
+    agent: str
+    proxy: str | None
+
+
+@dataclass(frozen=True)
+class SessionMounts:
+    """Mount arguments, plus where their sources were synced for a remote."""
+
+    mounts: list[str]
+    remote_config: RemoteConfigPaths | None
+
+
+def build_session_images(
+    *,
+    engine: ContainerEngine,
+    composition: AgentComposition,
+    config: PaudeConfig | None,
+    workspace: Path,
+    force_rebuild: bool,
+    platform: str | None = None,
+) -> SessionImages:
+    """Build (or reuse) the agent and proxy images for a session.
+
+    Both are built before any caller tears anything down, so a build failure --
+    the most likely and most transient failure in a rebuild -- is always
+    non-destructive.
+
+    Raises:
+        ImageBuildError: If either build fails, naming which one.
+    """
+    from paude.cli.helpers import _detect_dev_script_dir
+    from paude.container import ImageManager
+
+    image_manager = ImageManager(
+        script_dir=_detect_dev_script_dir(),
+        platform=platform,
+        agent=composition.primary,
+        composition=composition,
+        engine=engine,
+    )
+
+    try:
+        if config is not None and config.has_customizations:
+            agent_image = image_manager.ensure_custom_image(
+                config, force_rebuild=force_rebuild, workspace=workspace
+            )
+        else:
+            agent_image = image_manager.ensure_default_image(
+                force_rebuild=force_rebuild
+            )
+    except Exception as e:
+        raise ImageBuildError("agent", e) from e
+
+    # Always required: every session gets a proxy.
+    try:
+        proxy_image = image_manager.ensure_proxy_image(force_rebuild=force_rebuild)
+    except Exception as e:
+        raise ImageBuildError("proxy", e) from e
+
+    return SessionImages(agent=agent_image, proxy=proxy_image)
+
+
+def prepare_session_mounts(
+    *,
+    engine: ContainerEngine,
+    composition: AgentComposition,
+) -> SessionMounts:
+    """Assemble the session's mounts, syncing config to a remote host if needed.
+
+    Local engines skip the config bind mounts and copy the files in afterwards
+    instead, which avoids SELinux relabelling. SSH remotes keep the bind mounts,
+    but their sources are local paths that do not exist on the remote host, so
+    the files are transferred and the mount sources rewritten -- otherwise
+    podman there fails with "statfs ...: no such file".
+    """
+    from pathlib import Path
+
+    from paude.mounts import build_mounts
+
+    mounts = build_mounts(Path.home(), composition, include_config=engine.is_remote)
+    if not engine.is_remote:
+        return SessionMounts(mounts=mounts, remote_config=None)
+
+    import typer
+
+    from paude.transport.config_sync import remap_mounts, sync_configs_to_remote
+    from paude.transport.ssh import SshTransport
+
+    if not isinstance(engine.transport, SshTransport):
+        return SessionMounts(mounts=mounts, remote_config=None)
+
+    typer.echo("Syncing configuration to remote host...", err=True)
+    remote_config = sync_configs_to_remote(engine.transport, mounts)
+    return SessionMounts(
+        mounts=remap_mounts(mounts, remote_config.path_map),
+        remote_config=remote_config,
+    )
+
+
+def session_config_from_spec(
+    spec: SessionSpec,
+    *,
+    name: str | None,
+    workspace: Path,
+    composition: AgentComposition,
+    images: SessionImages,
+    env: dict[str, str],
+    mounts: list[str],
+    allowed_domains: list[str],
+    otel_ports: list[int],
+    args: list[str] | None = None,
+    workdir: str | None = None,
+    reuse_volume: bool = False,
+) -> SessionConfig:
+    """Turn a resolved spec plus this build's outputs into a SessionConfig."""
+    from paude.backends import SessionConfig
+
+    agent_specs = [
+        (item.config.name, item.config.provider or "") for item in composition.agents
+    ]
+    return SessionConfig(
+        name=name,
+        workspace=workspace,
+        image=images.agent,
+        env=env,
+        mounts=mounts,
+        args=args or [],
+        workdir=workdir,
+        allowed_domains=allowed_domains,
+        yolo=spec.yolo,
+        # A rebuild falls back to the recorded label when its own proxy build
+        # produced nothing; a fresh create has no recorded label to fall back to.
+        proxy_image=images.proxy or spec.proxy_image,
+        agent=spec.agent,
+        provider=spec.provider,
+        agent_providers=agent_specs,
+        # Create may be handed none, in which case the agents' own providers are
+        # what needs credentials. Upgrade always resolves them beforehand.
+        credential_providers=spec.credential_providers
+        or [provider for _agent, provider in agent_specs],
+        gpu=spec.gpu,
+        reuse_volume=reuse_volume,
+        ports=composition.exposed_ports,
+        otel_ports=otel_ports,
+        otel_endpoint=spec.otel_endpoint,
+    )

--- a/src/paude/cli/upgrade.py
+++ b/src/paude/cli/upgrade.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Annotated
 import typer
 
 from paude.backends import SessionNotFoundError
+from paude.backends.labels import SessionSpec
+from paude.backends.podman.helpers import composition_for_spec
 from paude.cli.app import BackendType, app
 from paude.cli.helpers import find_session_backend
 from paude.subprocess_utils import called_process_stderr
@@ -16,8 +18,8 @@ from paude.subprocess_utils import called_process_stderr
 if TYPE_CHECKING:
     from paude.agents.base import AgentComposition
     from paude.backends.base import Session
+    from paude.backends.labels import LabeledSession
     from paude.backends.podman.backend import PodmanBackend
-    from paude.container.runner import ContainerRunner
     from paude.upgrade_state import UpgradeManifest
 
 
@@ -366,104 +368,61 @@ def session_upgrade(
 
 
 @dataclass
-class _ResolvedUpgrade:
-    """Fully-resolved session configuration for a (re)build during upgrade.
+class ResolvedSession:
+    """A session's configuration, fully resolved and ready to rebuild from.
 
     Sourced either from the old container's labels (fresh upgrade) or from a
-    persisted :class:`~paude.cli.upgrade_state.UpgradeManifest` (resumed
-    upgrade), then normalised through :func:`_apply_overrides`.
+    persisted :class:`~paude.upgrade_state.UpgradeManifest` (resumed upgrade),
+    then normalised through :func:`_apply_overrides`.
+
+    The declared configuration lives in ``spec``, shared with both manifests,
+    so it is copied rather than restated. The other two fields are what a spec
+    deliberately excludes: ``composition`` is not serializable, and
+    ``workspace`` has no single sensible default across callers.
     """
 
-    agent_name: str
-    provider_name: str | None
+    spec: SessionSpec
     composition: AgentComposition
-    credential_providers: list[str]
     workspace: Path
-    gpu: str | None
-    yolo: bool
-    otel_endpoint: str | None
-    allowed_domains: list[str] | None
-    proxy_image_label: str | None
 
 
-def _resolve_base_from_labels(
-    runner: ContainerRunner, name: str, labels: dict[str, str]
-) -> _ResolvedUpgrade:
+def _resolve_base_from_view(view: LabeledSession) -> ResolvedSession:
     """Read the session's configuration from its container labels."""
-    from paude.backends.labels import (
-        PAUDE_LABEL_AGENT,
-        PAUDE_LABEL_DOMAINS,
-        PAUDE_LABEL_GPU,
-        PAUDE_LABEL_OTEL_ENDPOINT,
-        PAUDE_LABEL_PROVIDER,
-        PAUDE_LABEL_PROXY_IMAGE,
-        PAUDE_LABEL_WORKSPACE,
-        PAUDE_LABEL_YOLO,
-    )
-    from paude.backends.podman.helpers import (
-        get_session_composition,
-        get_session_credential_providers,
-    )
-    from paude.backends.session_env import decode_path
-
-    workspace_encoded = labels.get(PAUDE_LABEL_WORKSPACE, "")
-    workspace = (
-        decode_path(workspace_encoded, url_safe=True)
-        if workspace_encoded
-        else Path.cwd()
-    )
-
-    # Domain config — old sessions may not have the label (no proxy).
-    # On upgrade, all sessions get a proxy; default to None to trigger
-    # expansion via _prepare_session_create (which defaults to ["default"]).
-    domains_str = labels.get(PAUDE_LABEL_DOMAINS)
-    allowed_domains: list[str] | None = None
-    if domains_str is not None:
-        allowed_domains = domains_str.split(",") if domains_str else []
-
-    return _ResolvedUpgrade(
-        agent_name=labels.get(PAUDE_LABEL_AGENT, "claude"),
-        provider_name=labels.get(PAUDE_LABEL_PROVIDER),
-        composition=get_session_composition(runner, name),
-        credential_providers=get_session_credential_providers(runner, name),
-        workspace=workspace,
-        gpu=labels.get(PAUDE_LABEL_GPU),
-        yolo=labels.get(PAUDE_LABEL_YOLO) == "1",
-        otel_endpoint=labels.get(PAUDE_LABEL_OTEL_ENDPOINT),
-        allowed_domains=allowed_domains,
-        proxy_image_label=labels.get(PAUDE_LABEL_PROXY_IMAGE),
+    return ResolvedSession(
+        spec=view.spec,
+        composition=composition_for_spec(view.spec),
+        # A session created before the workspace label existed: the current
+        # directory is the only guess available, and it is what upgrade has
+        # always used.
+        workspace=view.workspace or Path.cwd(),
     )
 
 
-def _resolve_base_from_manifest(manifest: UpgradeManifest) -> _ResolvedUpgrade:
+def _resolve_base_from_manifest(manifest: UpgradeManifest) -> ResolvedSession:
     """Rebuild the session's configuration from a persisted upgrade manifest.
 
     Used when resuming an interrupted upgrade whose original container (the
     only other source of this config) has already been removed.
     """
-    from paude.agents import get_agents
-
-    specs = manifest.agent_providers or [(manifest.agent, manifest.provider or "")]
-    composition = get_agents(
-        [agent for agent, _provider in specs],
-        providers={agent: provider for agent, provider in specs if provider},
-        include_bundled=False,
-    )
-    return _ResolvedUpgrade(
-        agent_name=manifest.agent,
-        provider_name=manifest.provider,
-        composition=composition,
-        credential_providers=list(manifest.credential_providers or []),
-        workspace=Path(manifest.workspace),
+    spec = SessionSpec(
+        agent=manifest.agent,
+        provider=manifest.provider,
+        agent_providers=list(manifest.agent_providers),
+        credential_providers=list(manifest.credential_providers),
         gpu=manifest.gpu,
         yolo=manifest.yolo,
         otel_endpoint=manifest.otel_endpoint,
         allowed_domains=manifest.allowed_domains,
-        proxy_image_label=manifest.proxy_image,
+        proxy_image=manifest.proxy_image,
+    )
+    return ResolvedSession(
+        spec=spec,
+        composition=composition_for_spec(spec),
+        workspace=Path(manifest.workspace),
     )
 
 
-def _apply_overrides(state: _ResolvedUpgrade, overrides: UpgradeOverrides) -> None:
+def _apply_overrides(state: ResolvedSession, overrides: UpgradeOverrides) -> None:
     """Apply CLI overrides to a resolved config in place, normalising provider.
 
     Agent-set changes (``--add-agent`` / ``--agents``) and provider remappings
@@ -539,13 +498,13 @@ def _apply_overrides(state: _ResolvedUpgrade, overrides: UpgradeOverrides) -> No
     if overrides.providers is not None:
         from paude.providers import get_provider
 
-        state.credential_providers = list(dict.fromkeys(overrides.providers))
-        for provider in state.credential_providers:
+        state.spec.credential_providers = list(dict.fromkeys(overrides.providers))
+        for provider in state.spec.credential_providers:
             get_provider(provider)
         missing = [
             provider
             for provider in mapped_providers
-            if provider not in state.credential_providers
+            if provider not in state.spec.credential_providers
         ]
         if missing:
             raise ValueError(
@@ -559,32 +518,32 @@ def _apply_overrides(state: _ResolvedUpgrade, overrides: UpgradeOverrides) -> No
         # `remap` so the documented "add + set provider" workflow
         # (--add-agent X --agent-provider X=P) does not drop credential-only
         # providers.
-        state.credential_providers = list(
-            dict.fromkeys([*state.credential_providers, *mapped_providers])
+        state.spec.credential_providers = list(
+            dict.fromkeys([*state.spec.credential_providers, *mapped_providers])
         )
     elif remap:
         # Pure remap (no agent-set change): replace the credential set with the
         # mapped set, dropping any provider no longer referenced by an agent.
-        state.credential_providers = mapped_providers
+        state.spec.credential_providers = mapped_providers
 
     # Keep the primary-agent scalars in sync with the (possibly reordered or
     # extended) composition, so a changed primary is reflected in labels/env.
-    state.agent_name = state.composition.primary.config.name
-    state.provider_name = state.composition.primary.config.provider
+    state.spec.agent = state.composition.primary.config.name
+    state.spec.provider = state.composition.primary.config.provider
     if overrides.gpu is not None:
-        state.gpu = overrides.gpu if overrides.gpu != "" else None
+        state.spec.gpu = overrides.gpu if overrides.gpu != "" else None
     if overrides.yolo is not None:
-        state.yolo = overrides.yolo
+        state.spec.yolo = overrides.yolo
     if overrides.otel_endpoint is not None:
         # Empty string means "remove OTEL".
-        state.otel_endpoint = overrides.otel_endpoint or None
+        state.spec.otel_endpoint = overrides.otel_endpoint or None
     if overrides.allowed_domains is not None:
-        state.allowed_domains = overrides.allowed_domains
+        state.spec.allowed_domains = overrides.allowed_domains
 
 
 def _manifest_from_state(
     name: str,
-    state: _ResolvedUpgrade,
+    state: ResolvedSession,
     to_version: str,
     created_at: str,
 ) -> UpgradeManifest:
@@ -600,15 +559,15 @@ def _manifest_from_state(
         to_version=to_version,
         created_at=created_at,
         workspace=str(state.workspace),
-        agent=state.agent_name,
-        provider=state.provider_name,
+        agent=state.spec.agent,
+        provider=state.spec.provider,
         agent_providers=agent_specs,
-        credential_providers=list(state.credential_providers),
-        gpu=state.gpu,
-        yolo=state.yolo,
-        otel_endpoint=state.otel_endpoint,
-        allowed_domains=state.allowed_domains,
-        proxy_image=state.proxy_image_label,
+        credential_providers=list(state.spec.credential_providers),
+        gpu=state.spec.gpu,
+        yolo=state.spec.yolo,
+        otel_endpoint=state.spec.otel_endpoint,
+        allowed_domains=state.spec.allowed_domains,
+        proxy_image=state.spec.proxy_image,
     )
 
 
@@ -630,12 +589,6 @@ def _upgrade_podman(
     from datetime import UTC, datetime
 
     from paude import __version__, upgrade_state
-    from paude.backends.podman.helpers import (
-        container_name,
-        find_container_by_session_name,
-        network_name,
-        proxy_container_name,
-    )
     from paude.cli.helpers import (
         _detect_dev_script_dir,
         _prepare_session_create,
@@ -651,12 +604,11 @@ def _upgrade_podman(
         state = _resolve_base_from_manifest(manifest)
         created_at = manifest.created_at
     else:
-        container = find_container_by_session_name(backend._runner, name)
-        if container is None:
+        view = backend.resources.labels(name)
+        if view is None:
             typer.echo(f"Container for session '{name}' not found.", err=True)
             raise typer.Exit(1)
-        labels = container.get("Labels", {}) or {}
-        state = _resolve_base_from_labels(backend._runner, name, labels)
+        state = _resolve_base_from_view(view)
         created_at = datetime.now(UTC).isoformat()
 
     _apply_overrides(state, overrides)
@@ -674,21 +626,16 @@ def _upgrade_podman(
     if config_file:
         config = parse_config(config_file)
 
-    engine = backend._engine
+    engine = backend.engine
     agent_instance = composition.primary
     agent_specs = [
         (item.config.name, item.config.provider or "") for item in composition.agents
     ]
 
     # Salvage state written by older images before deleting their writable
-    # layer. Skipped when resuming after the old container is already gone —
+    # layer. A no-op when resuming after the old container is already gone —
     # its state was already copied into the workspace volume.
-    cname = container_name(name)
-    if backend._runner.container_exists(cname):
-        from paude.backends.podman.legacy_state import migrate_legacy_state
-
-        typer.echo("Migrating persistent agent state...", err=True)
-        migrate_legacy_state(backend._runner, cname, composition)
+    backend.resources.migrate_legacy_state(name, composition)
 
     image_manager = ImageManager(
         script_dir=_detect_dev_script_dir(),
@@ -719,21 +666,10 @@ def _upgrade_podman(
     except Exception as e:
         raise RuntimeError(f"building the proxy image failed: {e}") from e
 
-    # Remove old container and proxy resources (but NOT the workspace volume).
-    # All removals are force/tolerant, so re-running after a partial teardown
-    # is safe.
-    typer.echo(f"Removing old container {cname}...", err=True)
-    backend._runner.remove_container(cname, force=True)
-
-    pname = proxy_container_name(name)
-    backend._runner.remove_container(pname, force=True)
-    nname = network_name(name)
-    backend._network_manager.remove_network(nname)
-
-    # Remove CA volume so create_session can recreate it
-    from paude.backends.podman.proxy import ca_volume_name
-
-    backend._volume_manager.remove_volume(ca_volume_name(name), force=True)
+    # Remove the old container and its proxy resources. Deliberately keeps the
+    # workspace volume, the proxy auth volume and the credential secrets — see
+    # SessionResources.teardown_for_rebuild.
+    backend.resources.teardown_for_rebuild(name)
 
     # Build mounts and env
     home = Path.home()
@@ -757,24 +693,24 @@ def _upgrade_podman(
     # allowed_domains=None (old sessions without proxy) is passed as-is to
     # _prepare_session_create, which defaults to ["default"].
     expanded_domains, parsed_args, env, unrestricted = _prepare_session_create(
-        state.allowed_domains,
-        state.yolo,
+        state.spec.allowed_domains,
+        state.spec.yolo,
         None,
         config,
-        agent_name=state.agent_name,
-        provider_name=state.provider_name,
-        otel_endpoint=state.otel_endpoint,
+        agent_name=state.spec.agent,
+        provider_name=state.spec.provider,
+        otel_endpoint=state.spec.otel_endpoint,
         composition=composition,
-        credential_providers=state.credential_providers,
+        credential_providers=state.spec.credential_providers,
     )
     session_domains = expanded_domains
 
     # Compute OTEL proxy ports
     otel_ports: list[int] = []
-    if state.otel_endpoint:
+    if state.spec.otel_endpoint:
         from paude.otel import otel_proxy_ports
 
-        otel_ports = otel_proxy_ports(state.otel_endpoint)
+        otel_ports = otel_proxy_ports(state.spec.otel_endpoint)
 
     # Create new session config with reuse_volume=True
     from paude.backends import SessionConfig
@@ -786,17 +722,17 @@ def _upgrade_podman(
         env=env,
         mounts=mounts,
         allowed_domains=session_domains,
-        yolo=state.yolo,
-        proxy_image=proxy_image or state.proxy_image_label,
-        agent=state.agent_name,
-        provider=state.provider_name,
+        yolo=state.spec.yolo,
+        proxy_image=proxy_image or state.spec.proxy_image,
+        agent=state.spec.agent,
+        provider=state.spec.provider,
         agent_providers=agent_specs,
-        credential_providers=state.credential_providers,
-        gpu=state.gpu,
+        credential_providers=state.spec.credential_providers,
+        gpu=state.spec.gpu,
         reuse_volume=True,
         ports=composition.exposed_ports,
         otel_ports=otel_ports,
-        otel_endpoint=state.otel_endpoint,
+        otel_endpoint=state.spec.otel_endpoint,
     )
 
     backend.create_session(session_config)

--- a/src/paude/cli/upgrade.py
+++ b/src/paude/cli/upgrade.py
@@ -10,7 +10,8 @@ import typer
 
 from paude.backends import SessionNotFoundError
 from paude.cli.app import BackendType, app
-from paude.cli.helpers import called_process_stderr, find_session_backend
+from paude.cli.helpers import find_session_backend
+from paude.subprocess_utils import called_process_stderr
 
 if TYPE_CHECKING:
     from paude.agents.base import AgentComposition
@@ -684,7 +685,7 @@ def _upgrade_podman(
     # its state was already copied into the workspace volume.
     cname = container_name(name)
     if backend._runner.container_exists(cname):
-        from paude.cli.upgrade_persistence import migrate_legacy_state
+        from paude.backends.podman.legacy_state import migrate_legacy_state
 
         typer.echo("Migrating persistent agent state...", err=True)
         migrate_legacy_state(backend._runner, cname, composition)

--- a/src/paude/cli/upgrade.py
+++ b/src/paude/cli/upgrade.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
@@ -10,7 +10,11 @@ import typer
 
 from paude.backends import SessionNotFoundError
 from paude.backends.labels import SessionSpec
-from paude.backends.podman.helpers import composition_for_spec
+from paude.backends.podman.helpers import (
+    agent_specs_for,
+    composition_for_spec,
+    credential_providers_for_spec,
+)
 from paude.cli.app import BackendType, app
 from paude.cli.helpers import find_session_backend
 from paude.subprocess_utils import called_process_stderr
@@ -391,7 +395,14 @@ class ResolvedSession:
 def _resolve_base_from_view(view: LabeledSession) -> ResolvedSession:
     """Read the session's configuration from its container labels."""
     return ResolvedSession(
-        spec=view.spec,
+        # Copied, not aliased: LabeledSession is frozen but its spec is not,
+        # and _apply_overrides mutates what it is handed. Credential providers
+        # are derived rather than read raw, so a session created before the
+        # providers label existed keeps the set its agents imply.
+        spec=replace(
+            view.spec,
+            credential_providers=credential_providers_for_spec(view.spec),
+        ),
         composition=composition_for_spec(view.spec),
         # A session created before the workspace label existed: the current
         # directory is the only guess available, and it is what upgrade has
@@ -532,6 +543,7 @@ def _apply_overrides(state: ResolvedSession, overrides: UpgradeOverrides) -> Non
     # extended) composition, so a changed primary is reflected in labels/env.
     state.spec.agent = state.composition.primary.config.name
     state.spec.provider = state.composition.primary.config.provider
+    state.spec.agent_providers = agent_specs_for(state.composition)
     if overrides.gpu is not None:
         state.spec.gpu = overrides.gpu if overrides.gpu != "" else None
     if overrides.yolo is not None:
@@ -552,10 +564,6 @@ def _manifest_from_state(
     """Capture a resolved config as a durable manifest for crash recovery."""
     from paude.upgrade_state import UpgradeManifest
 
-    agent_specs = [
-        (item.config.name, item.config.provider or "")
-        for item in state.composition.agents
-    ]
     return UpgradeManifest(
         name=name,
         to_version=to_version,
@@ -563,7 +571,7 @@ def _manifest_from_state(
         workspace=str(state.workspace),
         agent=state.spec.agent,
         provider=state.spec.provider,
-        agent_providers=agent_specs,
+        agent_providers=list(state.spec.agent_providers),
         credential_providers=list(state.spec.credential_providers),
         gpu=state.spec.gpu,
         yolo=state.spec.yolo,
@@ -683,7 +691,7 @@ def _recreate_session(
             images=images,
             env=env,
             mounts=prepared.mounts,
-            allowed_domains=expanded_domains,
+            expanded_domains=expanded_domains,
             otel_ports=otel_ports,
             reuse_volume=True,
         )

--- a/src/paude/cli/upgrade.py
+++ b/src/paude/cli/upgrade.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
     from paude.backends.base import Session
     from paude.backends.labels import LabeledSession
     from paude.backends.podman.backend import PodmanBackend
+    from paude.cli.session_rebuild import SessionImages
+    from paude.config.models import PaudeConfig
     from paude.upgrade_state import UpgradeManifest
 
 
@@ -580,119 +582,81 @@ def _upgrade_podman(
     """Upgrade a Podman/Docker session in place.
 
     The whole flow is idempotent and resumable: the resolved configuration is
-    written to a durable manifest before anything is torn down, teardown uses
-    force/tolerant removals, and ``create_session(reuse_volume=True)`` rebuilds
-    from a clean slate while preserving the workspace volume. Re-running after
-    an interruption reads the manifest and converges to a single healthy
-    session.
+    written to a durable manifest before anything is torn down, the images are
+    built before that teardown so a build failure changes nothing, teardown
+    uses force/tolerant removals, and ``create_session(reuse_volume=True)``
+    rebuilds from a clean slate while preserving the workspace volume.
+    Re-running after an interruption reads the manifest and converges to a
+    single healthy session.
     """
-    from datetime import UTC, datetime
-
     from paude import __version__, upgrade_state
-    from paude.cli.helpers import (
-        _detect_dev_script_dir,
-        _prepare_session_create,
-    )
+    from paude.cli.session_rebuild import ImageBuildError, build_session_images
     from paude.config.detector import detect_config
     from paude.config.parser import parse_config
-    from paude.container import ImageManager
-    from paude.mounts import build_mounts
 
-    # Resolve the session config from a manifest (resume) or labels (fresh).
-    manifest = upgrade_state.load(name)
-    if manifest is not None:
-        state = _resolve_base_from_manifest(manifest)
-        created_at = manifest.created_at
-    else:
-        view = backend.resources.labels(name)
-        if view is None:
-            typer.echo(f"Container for session '{name}' not found.", err=True)
-            raise typer.Exit(1)
-        state = _resolve_base_from_view(view)
-        created_at = datetime.now(UTC).isoformat()
-
+    state, created_at = _resolve_upgrade_state(name, backend)
     _apply_overrides(state, overrides)
 
     # Persist the fully-resolved config BEFORE any destructive step, so an
     # interrupt from here on can be finished by re-running the upgrade.
     upgrade_state.save(_manifest_from_state(name, state, __version__, created_at))
 
-    composition = state.composition
-    workspace = state.workspace
-
-    # Detect project config from workspace
     config = None
-    config_file = detect_config(workspace)
+    config_file = detect_config(state.workspace)
     if config_file:
         config = parse_config(config_file)
-
-    engine = backend.engine
-    agent_instance = composition.primary
-    agent_specs = [
-        (item.config.name, item.config.provider or "") for item in composition.agents
-    ]
 
     # Salvage state written by older images before deleting their writable
     # layer. A no-op when resuming after the old container is already gone —
     # its state was already copied into the workspace volume.
-    backend.resources.migrate_legacy_state(name, composition)
-
-    image_manager = ImageManager(
-        script_dir=_detect_dev_script_dir(),
-        agent=agent_instance,
-        composition=composition,
-        engine=engine,
-    )
+    backend.resources.migrate_legacy_state(name, state.composition)
 
     # A build failure here is transient and non-destructive: nothing has been
-    # torn down yet and the manifest is already saved. Raise a plain exception
-    # (not typer.Exit) so session_upgrade's generic handler reports it, tells
-    # the user their data is safe, and points them at re-running to retry — the
-    # bare `except typer.Exit: raise` path would swallow that guidance.
+    # torn down yet and the manifest is already saved. Re-raise as a plain
+    # exception (not typer.Exit) so session_upgrade's generic handler reports
+    # it, tells the user their data is safe, and points them at re-running to
+    # retry — the bare `except typer.Exit: raise` path would swallow that.
     try:
-        if config is not None and config.has_customizations:
-            image = image_manager.ensure_custom_image(
-                config, force_rebuild=True, workspace=workspace
-            )
-        else:
-            image = image_manager.ensure_default_image(force_rebuild=True)
-    except Exception as e:
-        raise RuntimeError(f"building the agent image failed: {e}") from e
+        images = build_session_images(
+            engine=backend.engine,
+            composition=state.composition,
+            config=config,
+            workspace=state.workspace,
+            force_rebuild=True,
+        )
+    except ImageBuildError as e:
+        raise RuntimeError(str(e)) from e
 
-    # Build proxy image (always required — all sessions use proxy)
-    proxy_image: str | None = None
-    try:
-        proxy_image = image_manager.ensure_proxy_image(force_rebuild=True)
-    except Exception as e:
-        raise RuntimeError(f"building the proxy image failed: {e}") from e
-
-    # Remove the old container and its proxy resources. Deliberately keeps the
-    # workspace volume, the proxy auth volume and the credential secrets — see
-    # SessionResources.teardown_for_rebuild.
+    # Only now, with both images in hand, is anything removed. Deliberately
+    # keeps the workspace volume, the proxy auth volume and the credential
+    # secrets — see SessionResources.teardown_for_rebuild.
     backend.resources.teardown_for_rebuild(name)
 
-    # Build mounts and env
-    home = Path.home()
-    mounts = build_mounts(home, composition, include_config=engine.is_remote)
+    _recreate_session(name, backend, state, images, config)
 
-    # For SSH remotes, transfer the local config files referenced by the bind
-    # mounts to the remote host and rewrite the mount sources to the remote
-    # paths — the local (e.g. Mac) source paths don't exist on the remote host,
-    # so podman would fail to create the container ("statfs ...: no such file").
-    # Mirrors the create path (see create_podman.py).
-    if engine.is_remote:
-        from paude.transport.config_sync import remap_mounts, sync_configs_to_remote
-        from paude.transport.ssh import SshTransport
 
-        if isinstance(engine.transport, SshTransport):
-            typer.echo("Syncing configuration to remote host...", err=True)
-            remote_config_paths = sync_configs_to_remote(engine.transport, mounts)
-            mounts = remap_mounts(mounts, remote_config_paths.path_map)
+def _recreate_session(
+    name: str,
+    backend: PodmanBackend,
+    state: ResolvedSession,
+    images: SessionImages,
+    config: PaudeConfig | None,
+) -> None:
+    """Build the replacement container around the preserved volume, and start it."""
+    from paude.cli.helpers import _prepare_session_create
+    from paude.cli.session_rebuild import (
+        prepare_session_mounts,
+        session_config_from_spec,
+    )
 
-    # Expand domains — all sessions get a proxy.
-    # allowed_domains=None (old sessions without proxy) is passed as-is to
-    # _prepare_session_create, which defaults to ["default"].
-    expanded_domains, parsed_args, env, unrestricted = _prepare_session_create(
+    prepared = prepare_session_mounts(
+        engine=backend.engine, composition=state.composition
+    )
+
+    # Expand domains — all sessions get a proxy. allowed_domains=None (an old
+    # session created before that was true) is passed through as-is to
+    # _prepare_session_create, which defaults it to ["default"].
+    expanded_domains, _args, env, _unrestricted = _prepare_session_create(
         state.spec.allowed_domains,
         state.spec.yolo,
         None,
@@ -700,40 +664,52 @@ def _upgrade_podman(
         agent_name=state.spec.agent,
         provider_name=state.spec.provider,
         otel_endpoint=state.spec.otel_endpoint,
-        composition=composition,
+        composition=state.composition,
         credential_providers=state.spec.credential_providers,
     )
-    session_domains = expanded_domains
 
-    # Compute OTEL proxy ports
     otel_ports: list[int] = []
     if state.spec.otel_endpoint:
         from paude.otel import otel_proxy_ports
 
         otel_ports = otel_proxy_ports(state.spec.otel_endpoint)
 
-    # Create new session config with reuse_volume=True
-    from paude.backends import SessionConfig
-
-    session_config = SessionConfig(
-        name=name,
-        workspace=workspace,
-        image=image,
-        env=env,
-        mounts=mounts,
-        allowed_domains=session_domains,
-        yolo=state.spec.yolo,
-        proxy_image=proxy_image or state.spec.proxy_image,
-        agent=state.spec.agent,
-        provider=state.spec.provider,
-        agent_providers=agent_specs,
-        credential_providers=state.spec.credential_providers,
-        gpu=state.spec.gpu,
-        reuse_volume=True,
-        ports=composition.exposed_ports,
-        otel_ports=otel_ports,
-        otel_endpoint=state.spec.otel_endpoint,
+    backend.create_session(
+        session_config_from_spec(
+            state.spec,
+            name=name,
+            workspace=state.workspace,
+            composition=state.composition,
+            images=images,
+            env=env,
+            mounts=prepared.mounts,
+            allowed_domains=expanded_domains,
+            otel_ports=otel_ports,
+            reuse_volume=True,
+        )
     )
-
-    backend.create_session(session_config)
     backend.start_session_no_attach(name)
+
+
+def _resolve_upgrade_state(
+    name: str, backend: PodmanBackend
+) -> tuple[ResolvedSession, str]:
+    """Resolve the session's configuration, and when this upgrade started.
+
+    A leftover manifest means a previous attempt was interrupted: it is the
+    only remaining source of the config once the old container is gone, so it
+    wins over the container's labels and keeps the original start time.
+    """
+    from datetime import UTC, datetime
+
+    from paude import upgrade_state
+
+    manifest = upgrade_state.load(name)
+    if manifest is not None:
+        return _resolve_base_from_manifest(manifest), manifest.created_at
+
+    view = backend.resources.labels(name)
+    if view is None:
+        typer.echo(f"Container for session '{name}' not found.", err=True)
+        raise typer.Exit(1)
+    return _resolve_base_from_view(view), datetime.now(UTC).isoformat()

--- a/src/paude/cli/upgrade.py
+++ b/src/paude/cli/upgrade.py
@@ -421,7 +421,7 @@ def _resolve_base_from_manifest(manifest: UpgradeManifest) -> ResolvedSession:
         agent=manifest.agent,
         provider=manifest.provider,
         agent_providers=list(manifest.agent_providers),
-        credential_providers=list(manifest.credential_providers),
+        credential_providers=list(manifest.credential_providers or []),
         gpu=manifest.gpu,
         yolo=manifest.yolo,
         otel_endpoint=manifest.otel_endpoint,

--- a/src/paude/subprocess_utils.py
+++ b/src/paude/subprocess_utils.py
@@ -7,6 +7,18 @@ import threading
 from typing import IO
 
 
+def called_process_stderr(e: Exception) -> str | None:
+    """Return a CalledProcessError's captured stderr, stripped, if any.
+
+    str(CalledProcessError) omits the captured stderr, so callers reporting a
+    failure via an f-string need this to surface the underlying command's
+    actual explanation instead of just "returned non-zero exit status N".
+    """
+    if isinstance(e, subprocess.CalledProcessError) and e.stderr:
+        return str(e.stderr).strip()
+    return None
+
+
 def drain_pipe(pipe: IO[bytes] | None, chunks: list[bytes]) -> threading.Thread:
     """Start a daemon thread that reads ``pipe`` fully into ``chunks``.
 

--- a/src/paude/upgrade_state.py
+++ b/src/paude/upgrade_state.py
@@ -18,38 +18,36 @@ for remote/SSH sessions, so recovery works even if the connection drops.
 from __future__ import annotations
 
 import logging
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
+from paude.backends.labels import SessionSpec, normalize_agent_providers
 from paude.config.user_config import _paude_config_dir
 from paude.json_store import atomic_write_json, read_json
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class UpgradeManifest:
+@dataclass(kw_only=True)
+class UpgradeManifest(SessionSpec):
     """Everything needed to recreate a session without its container labels.
 
-    Mirrors the configuration derived from container labels in
-    :func:`paude.cli.upgrade._upgrade_podman` so a resumed upgrade can rebuild
-    the session even after the original container (and its labels) are gone.
+    The label-derived configuration is inherited from
+    :class:`~paude.backends.labels.SessionSpec`; this adds only what the
+    session's labels cannot supply once the container is gone -- which session,
+    where, and what version the interrupted upgrade was heading for.
+
+    Inheriting rather than embedding keeps ``asdict()`` flat, so the on-disk
+    JSON keeps the exact key set an earlier paude wrote. A nested ``spec``
+    object would make an in-flight upgrade unresumable across the release that
+    introduced it.
     """
 
     name: str
     to_version: str
     created_at: str
     workspace: str
-    agent: str = "claude"
-    provider: str | None = None
-    agent_providers: list[tuple[str, str]] = field(default_factory=list)
-    credential_providers: list[str] = field(default_factory=list)
-    gpu: str | None = None
-    yolo: bool = False
-    otel_endpoint: str | None = None
-    allowed_domains: list[str] | None = None
-    proxy_image: str | None = None
 
 
 def _manifests_path() -> Path:
@@ -80,9 +78,9 @@ def load(name: str, path: Path | None = None) -> UpgradeManifest | None:
     try:
         entry = dict(raw)
         # JSON stores tuples as lists; normalise agent_providers back to tuples.
-        entry["agent_providers"] = [
-            tuple(item) for item in (entry.get("agent_providers") or [])
-        ]
+        entry["agent_providers"] = normalize_agent_providers(
+            entry.get("agent_providers")
+        )
         return UpgradeManifest(**entry)
     except (TypeError, ValueError):
         logger.warning("Ignoring corrupt upgrade manifest for '%s'", name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,9 +62,10 @@ class _InstantSleep:
         return getattr(self._real, name)
 
 
-# Modules whose retry/poll loops call time.sleep(). Left real, these dominate
-# the unit suite's wall clock: tests drive them with mocked runners that never
-# satisfy the loop's exit condition, so each one burns its full poll budget.
+# Modules that call time.sleep() -- a retry/poll loop in the first two, a fixed
+# post-start settle in proxy_runner. Left real, these dominate the unit suite's
+# wall clock: tests drive them with mocked runners that never satisfy a loop's
+# exit condition, so each one burns its full poll budget.
 _POLL_SLEEP_MODULES = (
     "paude.backends.podman.ca_cert",
     "paude.backends.podman.proxy",
@@ -76,10 +77,16 @@ _POLL_SLEEP_MODULES = (
 def _no_poll_sleep(request, monkeypatch):
     """Make retry/poll sleeps instant for unit tests.
 
-    Safe because every one of these loops bounds itself by counting -- an
-    iteration counter (proxy._get_proxy_ip) or an accumulator incremented by
-    the interval constant (ca_cert), never by wall clock -- so removing the
-    delay preserves timeout semantics exactly, including the warning paths.
+    Safe because no sleep here carries meaning for the code under test. The
+    loops bound themselves by counting -- an iteration counter
+    (proxy._get_proxy_ip) or an accumulator incremented by the interval
+    constant (ca_cert), never by wall clock -- so removing the delay preserves
+    timeout semantics exactly, including the warning paths. proxy_runner has no
+    loop at all: just a fixed settle after starting the proxy, which nothing
+    under test observes.
+
+    A module whose behaviour depends on elapsed wall clock does not belong
+    here.
 
     Skipped for integration tests, which drive a real container engine and
     need real waits.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,23 @@
 """Pytest fixtures for paude tests."""
 
 import importlib
+from pathlib import Path
 from types import ModuleType
 from typing import Any
 
 import pytest
+
+_INTEGRATION_DIR = Path(__file__).parent / "integration"
+
+
+def _is_integration(request) -> bool:
+    """Whether this test lives under tests/integration/.
+
+    Matches the directory rather than the string "integration" anywhere in the
+    path: tests/test_integration.py is a unit test that a substring check
+    wrongly excluded from config isolation.
+    """
+    return _INTEGRATION_DIR in Path(str(request.fspath)).parents
 
 
 @pytest.fixture(autouse=True)
@@ -19,7 +32,7 @@ def _isolate_config(request, tmp_path, monkeypatch):
     Skipped for integration tests which need real container engine
     config (e.g. podman network definitions).
     """
-    if "integration" not in str(request.fspath):
+    if not _is_integration(request):
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-config"))
         monkeypatch.chdir(tmp_path)
 
@@ -71,7 +84,7 @@ def _no_poll_sleep(request, monkeypatch):
     Skipped for integration tests, which drive a real container engine and
     need real waits.
     """
-    if "integration" in str(request.fspath):
+    if _is_integration(request):
         return
     for name in _POLL_SLEEP_MODULES:
         module = importlib.import_module(name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,3 +76,11 @@ def _no_poll_sleep(request, monkeypatch):
     for name in _POLL_SLEEP_MODULES:
         module = importlib.import_module(name)
         monkeypatch.setattr(module, "time", _InstantSleep(module.time))
+
+
+@pytest.fixture
+def backend():
+    """A ``PodmanBackend`` with every collaborator replaced by a double."""
+    from tests.fakes import make_backend
+
+    return make_backend()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
 """Pytest fixtures for paude tests."""
 
+import importlib
+from types import ModuleType
+from typing import Any
+
 import pytest
 
 
@@ -26,3 +30,49 @@ def temp_workspace(tmp_path):
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     return workspace
+
+
+class _InstantSleep:
+    """Stand-in for the ``time`` module whose ``sleep`` returns immediately.
+
+    Every other attribute delegates to the real module, so a poll loop that
+    also reads a clock still behaves normally.
+    """
+
+    def __init__(self, real: ModuleType) -> None:
+        self._real = real
+
+    def sleep(self, seconds: float) -> None:
+        """Return immediately instead of blocking."""
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._real, name)
+
+
+# Modules whose retry/poll loops call time.sleep(). Left real, these dominate
+# the unit suite's wall clock: tests drive them with mocked runners that never
+# satisfy the loop's exit condition, so each one burns its full poll budget.
+_POLL_SLEEP_MODULES = (
+    "paude.backends.podman.ca_cert",
+    "paude.backends.podman.proxy",
+    "paude.container.proxy_runner",
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_poll_sleep(request, monkeypatch):
+    """Make retry/poll sleeps instant for unit tests.
+
+    Safe because every one of these loops bounds itself by counting -- an
+    iteration counter (proxy._get_proxy_ip) or an accumulator incremented by
+    the interval constant (ca_cert), never by wall clock -- so removing the
+    delay preserves timeout semantics exactly, including the warning paths.
+
+    Skipped for integration tests, which drive a real container engine and
+    need real waits.
+    """
+    if "integration" in str(request.fspath):
+        return
+    for name in _POLL_SLEEP_MODULES:
+        module = importlib.import_module(name)
+        monkeypatch.setattr(module, "time", _InstantSleep(module.time))

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 
 from paude.backends.podman.backend import PodmanBackend
 from paude.backends.podman.proxy import PodmanProxyManager
+from paude.backends.podman.resources import SessionResources
 from paude.backends.podman.session_setup import SessionSetup
 from paude.container.engine import ContainerEngine
 from paude.container.network import NetworkManager
@@ -189,8 +190,8 @@ def make_backend(
 
     Every collaborator is substituted, so no test reaches a real container
     engine. Callers may pass their own doubles to assert on interactions; the
-    proxy manager and session setup are rebuilt afterwards so they observe the
-    substituted runner rather than the discarded real one.
+    proxy manager, session setup and session resources are rebuilt afterwards
+    so they observe the substituted runner rather than the discarded real one.
     """
     backend = PodmanBackend(engine=make_engine(engine_binary))
     if runner is None:
@@ -213,5 +214,8 @@ def make_backend(
     backend._volume_manager = volume_manager or MagicMock(spec=VolumeManager)
     backend._proxy = PodmanProxyManager(runner, network_manager)
     backend._setup = SessionSetup(runner, runner.engine)
+    backend._resources = SessionResources(
+        runner, network_manager, backend._volume_manager, backend._proxy
+    )
     backend._port_forward = MagicMock()
     return backend

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import subprocess
+from typing import cast
 from unittest.mock import MagicMock
 
 from paude.backends.podman.backend import PodmanBackend
@@ -39,7 +40,7 @@ class FakePopen:
     def wait(self, timeout: float | None = None) -> int:
         if self._pending_waits > 0:
             self._pending_waits -= 1
-            raise subprocess.TimeoutExpired(cmd="fake", timeout=timeout)
+            raise subprocess.TimeoutExpired(cmd="fake", timeout=timeout or 0)
         return self._returncode
 
     def poll(self) -> int | None:
@@ -48,6 +49,16 @@ class FakePopen:
     def kill(self) -> None:
         self.killed = True
         self._pending_waits = 0
+
+
+def as_popen(proc: FakePopen) -> subprocess.Popen[bytes]:
+    """Present a :class:`FakePopen` where a real ``Popen`` is required.
+
+    FakePopen implements the subset ``subprocess_utils`` actually uses (wait,
+    poll, kill, stdout, stderr). Casting here documents that, rather than
+    widening a production signature to accommodate a test double.
+    """
+    return cast("subprocess.Popen[bytes]", proc)
 
 
 class FakeTransport:
@@ -138,6 +149,20 @@ def make_engine(
         binary,
         transport=transport or FakeTransport(is_remote=is_remote),  # type: ignore[arg-type]
     )
+
+
+def recorded_commands(engine: ContainerEngine) -> list[list[str]]:
+    """Commands the :class:`FakeTransport` behind ``engine`` has recorded.
+
+    ``ContainerEngine.transport`` is typed as the ``Transport`` protocol, which
+    has no ``commands``, so this narrows it in one place instead of at every
+    assertion.
+    """
+    transport = engine.transport
+    assert isinstance(transport, FakeTransport), (
+        f"engine is not backed by a FakeTransport: {transport!r}"
+    )
+    return transport.commands
 
 
 def make_runner(engine: ContainerEngine | None = None, **attrs: object) -> MagicMock:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -199,10 +199,15 @@ def make_backend(
     if runner is None:
         runner = make_runner(make_engine(engine_binary))
     elif not isinstance(getattr(runner.engine, "binary", None), str):
-        # A bare MagicMock() runner whose engine was never configured: give it
-        # a real engine so binary-dependent branches behave like production. A
-        # caller that configured its own engine double (to assert on
-        # engine.run, say) keeps it.
+        # The runner's engine has no str ``binary``, so binary-dependent
+        # branches would see a MagicMock where production sees "podman" --
+        # typically a bare MagicMock() runner whose engine was never
+        # configured. Swap in a real engine so those branches behave like
+        # production.
+        #
+        # This replaces the engine wholesale, so an engine double you mean to
+        # assert on is lost here unless its ``binary`` is a str: build it with
+        # make_engine(), or set ``.binary`` before passing the runner in.
         runner.engine = make_engine(engine_binary)
     backend._runner = runner
     backend._engine = runner.engine

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,9 +1,18 @@
-"""Shared test doubles for subprocess.Popen-based lifecycle tests."""
+"""Shared test doubles for paude's container and transport layers."""
 
 from __future__ import annotations
 
 import io
 import subprocess
+from unittest.mock import MagicMock
+
+from paude.backends.podman.backend import PodmanBackend
+from paude.backends.podman.proxy import PodmanProxyManager
+from paude.backends.podman.session_setup import SessionSetup
+from paude.container.engine import ContainerEngine
+from paude.container.network import NetworkManager
+from paude.container.runner import ContainerRunner
+from paude.container.volume import VolumeManager
 
 
 class FakePopen:
@@ -39,3 +48,145 @@ class FakePopen:
     def kill(self) -> None:
         self.killed = True
         self._pending_waits = 0
+
+
+class FakeTransport:
+    """Transport that records commands instead of executing them.
+
+    Satisfies :class:`paude.transport.base.Transport` so it can back a *real*
+    :class:`~paude.container.engine.ContainerEngine`. That matters: every
+    engine property tests care about (``is_podman``, ``is_remote``,
+    ``default_bridge_network``, ``supports_multi_network_create``, ...) is
+    derived from the binary name and the transport, so driving the real engine
+    exercises the production derivations rather than a reimplementation of
+    them that can silently disagree.
+
+    ``results`` maps a substring of the joined command to the
+    ``CompletedProcess`` to return for it; anything unmatched gets
+    ``default_result``.
+    """
+
+    def __init__(
+        self,
+        *,
+        is_remote: bool = False,
+        host_label: str = "local",
+        results: dict[str, subprocess.CompletedProcess[str]] | None = None,
+        default_result: subprocess.CompletedProcess[str] | None = None,
+    ) -> None:
+        self._is_remote = is_remote
+        self._host_label = host_label
+        self._results = results or {}
+        self._default = default_result or subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        self.commands: list[list[str]] = []
+        self.copies: list[tuple[str, str, str]] = []
+
+    def run(
+        self,
+        cmd: list[str],
+        *,
+        check: bool = True,
+        capture: bool = True,
+        text: bool = True,
+        input: str | None = None,  # noqa: A002
+        timeout: int | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        self.commands.append(list(cmd))
+        joined = " ".join(cmd)
+        for needle, result in self._results.items():
+            if needle in joined:
+                return result
+        return self._default
+
+    def run_interactive(self, cmd: list[str]) -> int:
+        self.commands.append(list(cmd))
+        return 0
+
+    def popen_binary(self, cmd: list[str]) -> subprocess.Popen[bytes]:
+        raise NotImplementedError(
+            "FakeTransport does not stream; use FakePopen directly instead."
+        )
+
+    def machine(self) -> str:
+        return "x86_64"
+
+    def copy_to_host(self, local_path: str, host_path: str) -> None:
+        self.copies.append(("to", local_path, host_path))
+
+    def copy_from_host(self, host_path: str, local_path: str) -> None:
+        self.copies.append(("from", host_path, local_path))
+
+    @property
+    def is_remote(self) -> bool:
+        return self._is_remote
+
+    @property
+    def host_label(self) -> str:
+        return self._host_label
+
+
+def make_engine(
+    binary: str = "podman",
+    *,
+    transport: object | None = None,
+    is_remote: bool = False,
+) -> ContainerEngine:
+    """Build a real ``ContainerEngine`` backed by a :class:`FakeTransport`."""
+    return ContainerEngine(
+        binary,
+        transport=transport or FakeTransport(is_remote=is_remote),  # type: ignore[arg-type]
+    )
+
+
+def make_runner(engine: ContainerEngine | None = None, **attrs: object) -> MagicMock:
+    """Build a ``ContainerRunner`` double with a real engine behind it.
+
+    Specced against the real class, so a typo'd method name fails loudly
+    instead of silently returning a truthy ``MagicMock``. Call assertions work
+    exactly as they do on a bare ``MagicMock``.
+    """
+    runner = MagicMock(spec=ContainerRunner)
+    runner.engine = engine or make_engine()
+    for name, value in attrs.items():
+        getattr(runner, name).return_value = value
+    return runner
+
+
+def make_backend(
+    runner: MagicMock | None = None,
+    network_manager: MagicMock | None = None,
+    volume_manager: MagicMock | None = None,
+    engine_binary: str = "podman",
+) -> PodmanBackend:
+    """Build a ``PodmanBackend`` with its collaborators replaced by doubles.
+
+    Every collaborator is substituted, so no test reaches a real container
+    engine. Callers may pass their own doubles to assert on interactions; the
+    proxy manager and session setup are rebuilt afterwards so they observe the
+    substituted runner rather than the discarded real one.
+    """
+    backend = PodmanBackend(engine=make_engine(engine_binary))
+    if runner is None:
+        runner = make_runner(make_engine(engine_binary))
+    elif not isinstance(getattr(runner.engine, "binary", None), str):
+        # A bare MagicMock() runner whose engine was never configured: give it
+        # a real engine so binary-dependent branches behave like production. A
+        # caller that configured its own engine double (to assert on
+        # engine.run, say) keeps it.
+        runner.engine = make_engine(engine_binary)
+    backend._runner = runner
+    backend._engine = runner.engine
+
+    if network_manager is None:
+        network_manager = MagicMock(spec=NetworkManager)
+    if isinstance(network_manager.get_network_gateway.return_value, MagicMock):
+        network_manager.get_network_gateway.return_value = "10.89.0.1"
+    backend._network_manager = network_manager
+
+    backend._volume_manager = volume_manager or MagicMock(spec=VolumeManager)
+    backend._proxy = PodmanProxyManager(runner, network_manager)
+    backend._setup = SessionSetup(runner, runner.engine)
+    backend._port_forward = MagicMock()
+    return backend

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import io
 import subprocess
+from dataclasses import MISSING, fields
 from typing import cast
 from unittest.mock import MagicMock
 
+from paude.backends.labels import SessionSpec
 from paude.backends.podman.backend import PodmanBackend
 from paude.backends.podman.proxy import PodmanProxyManager
 from paude.backends.podman.resources import SessionResources
@@ -219,3 +221,23 @@ def make_backend(
     )
     backend._port_forward = MagicMock()
     return backend
+
+
+def assert_carries_every_spec_field(manifest: SessionSpec, built_by: str) -> None:
+    """Assert every ``SessionSpec`` field survived the copy into ``manifest``.
+
+    Both manifests inherit ``SessionSpec``, which dedupes the *schema* but not
+    the *copying* -- each builder still assigns the fields explicitly so mypy
+    can check them. A tenth label would therefore persist as its default until
+    someone updated both builders. This fails by name instead, so long as the
+    manifest was built from a spec whose fields are all non-default.
+    """
+    for spec_field in fields(SessionSpec):
+        default = (
+            spec_field.default_factory()
+            if spec_field.default_factory is not MISSING
+            else spec_field.default
+        )
+        assert getattr(manifest, spec_field.name) != default, (
+            f"{built_by} does not carry SessionSpec.{spec_field.name}"
+        )

--- a/tests/integration/test_podman_backend.py
+++ b/tests/integration/test_podman_backend.py
@@ -756,7 +756,7 @@ class TestPodmanProxySetup:
             # Podman internal networks are created with --disable-dns (see
             # session_setup.py), so the agent container can't resolve the
             # proxy by name -- HTTP_PROXY points at its real IP instead.
-            result = subprocess.run(
+            ip_result = subprocess.run(
                 [
                     "podman",
                     "inspect",
@@ -768,11 +768,11 @@ class TestPodmanProxySetup:
                 text=True,
                 check=True,
             )
-            proxy_ip = result.stdout.strip()
+            proxy_ip = ip_result.stdout.strip()
             assert proxy_ip, "Proxy IP should be resolvable on the internal network"
 
             # Verify main container has HTTP_PROXY env var set
-            result = subprocess.run(
+            env_result = subprocess.run(
                 [
                     "podman",
                     "inspect",
@@ -783,7 +783,7 @@ class TestPodmanProxySetup:
                 capture_output=True,
                 text=True,
             )
-            assert f"HTTP_PROXY=http://{proxy_ip}:3128" in result.stdout, (
+            assert f"HTTP_PROXY=http://{proxy_ip}:3128" in env_result.stdout, (
                 "Main container should have HTTP_PROXY pointing to proxy"
             )
 

--- a/tests/integration/test_upgrade_podman.py
+++ b/tests/integration/test_upgrade_podman.py
@@ -218,7 +218,7 @@ class TestPodmanUpgrade:
             assert "legacy-agent-state" in result.stdout
 
             # 7. Verify proxy container exists
-            result = subprocess.run(
+            exists_result = subprocess.run(
                 [
                     "podman",
                     "container",
@@ -227,7 +227,7 @@ class TestPodmanUpgrade:
                 ],
                 capture_output=True,
             )
-            assert result.returncode == 0, "Proxy container should exist"
+            assert exists_result.returncode == 0, "Proxy container should exist"
 
         finally:
             cleanup_session(backend, unique_session_name)

--- a/tests/test_allow_domain.py
+++ b/tests/test_allow_domain.py
@@ -6,9 +6,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from paude.backends.podman import PodmanBackend
 from paude.backends.podman import SessionNotFoundError as PodmanSessionNotFoundError
 from paude.backends.podman.proxy import PodmanProxyManager
+from tests.fakes import make_backend
 
 # ---------------------------------------------------------------------------
 # ProxyManager: get_deployment_domains
@@ -20,37 +20,27 @@ from paude.backends.podman.proxy import PodmanProxyManager
 class TestPodmanGetAllowedDomains:
     """Tests for PodmanBackend.get_allowed_domains method."""
 
-    @patch("paude.backends.podman.backend.ContainerRunner")
-    def test_returns_none_when_no_proxy(self, mock_runner_class: MagicMock) -> None:
+    def test_returns_none_when_no_proxy(self) -> None:
         """get_allowed_domains returns None when no proxy exists (unrestricted)."""
         mock_runner = MagicMock()
         # Main container exists, proxy does not
         mock_runner.container_exists.side_effect = lambda name: (
             name == "paude-my-session"
         )
-        mock_runner_class.return_value = mock_runner
 
-        backend = PodmanBackend()
-        backend._runner = mock_runner
-        backend._proxy._runner = mock_runner
+        backend = make_backend(mock_runner)
 
         result = backend.get_allowed_domains("my-session")
         assert result is None
 
-    @patch("paude.backends.podman.backend.ContainerRunner")
-    def test_returns_domain_list_when_proxy_exists(
-        self, mock_runner_class: MagicMock
-    ) -> None:
+    def test_returns_domain_list_when_proxy_exists(self) -> None:
         """get_allowed_domains returns domains from proxy container env."""
         mock_runner = MagicMock()
         # Both main and proxy containers exist
         mock_runner.container_exists.return_value = True
         mock_runner.get_container_env.return_value = ".googleapis.com,.pypi.org"
-        mock_runner_class.return_value = mock_runner
 
-        backend = PodmanBackend()
-        backend._runner = mock_runner
-        backend._proxy._runner = mock_runner
+        backend = make_backend(mock_runner)
 
         result = backend.get_allowed_domains("my-session")
 
@@ -59,33 +49,23 @@ class TestPodmanGetAllowedDomains:
             "paude-proxy-my-session", "ALLOWED_DOMAINS"
         )
 
-    @patch("paude.backends.podman.backend.ContainerRunner")
-    def test_returns_empty_list_when_proxy_has_no_domains(
-        self, mock_runner_class: MagicMock
-    ) -> None:
+    def test_returns_empty_list_when_proxy_has_no_domains(self) -> None:
         """get_allowed_domains returns empty list when ALLOWED_DOMAINS is empty."""
         mock_runner = MagicMock()
         mock_runner.container_exists.return_value = True
         mock_runner.get_container_env.return_value = ""
-        mock_runner_class.return_value = mock_runner
 
-        backend = PodmanBackend()
-        backend._runner = mock_runner
-        backend._proxy._runner = mock_runner
+        backend = make_backend(mock_runner)
 
         result = backend.get_allowed_domains("my-session")
         assert result == []
 
-    @patch("paude.backends.podman.backend.ContainerRunner")
-    def test_raises_session_not_found(self, mock_runner_class: MagicMock) -> None:
+    def test_raises_session_not_found(self) -> None:
         """get_allowed_domains raises SessionNotFoundError when session missing."""
         mock_runner = MagicMock()
         mock_runner.container_exists.return_value = False
-        mock_runner_class.return_value = mock_runner
 
-        backend = PodmanBackend()
-        backend._runner = mock_runner
-        backend._proxy._runner = mock_runner
+        backend = make_backend(mock_runner)
 
         with pytest.raises(PodmanSessionNotFoundError):
             backend.get_allowed_domains("nonexistent")
@@ -100,12 +80,7 @@ class TestPodmanUpdateAllowedDomains:
     """Tests for PodmanBackend.update_allowed_domains method."""
 
     @patch("paude.backends.podman.proxy.get_podman_machine_dns")
-    @patch("paude.backends.podman.backend.ContainerRunner")
-    def test_recreates_proxy_with_new_domains(
-        self,
-        mock_runner_class: MagicMock,
-        mock_dns: MagicMock,
-    ) -> None:
+    def test_recreates_proxy_with_new_domains(self, mock_dns: MagicMock) -> None:
         """update_allowed_domains recreates proxy with new domain list."""
         mock_runner = MagicMock()
         mock_runner.engine.binary = "podman"
@@ -119,11 +94,9 @@ class TestPodmanUpdateAllowedDomains:
         mock_runner.get_container_image.return_value = "proxy:latest"
         # Disable CA verification polling (not the focus of this test)
         mock_runner.container_running.return_value = False
-        mock_runner_class.return_value = mock_runner
         mock_dns.return_value = None
 
-        backend = PodmanBackend()
-        backend._runner = mock_runner
+        backend = make_backend(mock_runner)
         mock_network = MagicMock()
         mock_network.get_network_gateway.return_value = "10.89.0.1"
         backend._proxy = PodmanProxyManager(mock_runner, mock_network)
@@ -138,35 +111,25 @@ class TestPodmanUpdateAllowedDomains:
         assert any("create" in c for c in engine_calls)
         assert any("start" in c for c in engine_calls)
 
-    @patch("paude.backends.podman.backend.ContainerRunner")
-    def test_raises_session_not_found(self, mock_runner_class: MagicMock) -> None:
+    def test_raises_session_not_found(self) -> None:
         """update_allowed_domains raises SessionNotFoundError when session missing."""
         mock_runner = MagicMock()
         mock_runner.container_exists.return_value = False
-        mock_runner_class.return_value = mock_runner
 
-        backend = PodmanBackend()
-        backend._runner = mock_runner
-        backend._proxy._runner = mock_runner
+        backend = make_backend(mock_runner)
 
         with pytest.raises(PodmanSessionNotFoundError):
             backend.update_allowed_domains("nonexistent", [".example.com"])
 
-    @patch("paude.backends.podman.backend.ContainerRunner")
-    def test_raises_value_error_when_no_proxy(
-        self, mock_runner_class: MagicMock
-    ) -> None:
+    def test_raises_value_error_when_no_proxy(self) -> None:
         """update_allowed_domains raises ValueError when session has no proxy."""
         mock_runner = MagicMock()
         # Main container exists, proxy does not
         mock_runner.container_exists.side_effect = lambda name: (
             name == "paude-my-session"
         )
-        mock_runner_class.return_value = mock_runner
 
-        backend = PodmanBackend()
-        backend._runner = mock_runner
-        backend._proxy._runner = mock_runner
+        backend = make_backend(mock_runner)
 
         with pytest.raises(ValueError, match="no proxy"):
             backend.update_allowed_domains("my-session", [".example.com"])

--- a/tests/test_backend_removal.py
+++ b/tests/test_backend_removal.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
+from paude.backends.podman.backend import PodmanBackend
 from paude.cli import app
 from paude.cli.app import BackendType
 from paude.cli.helpers import _get_backend_instance
@@ -133,6 +134,7 @@ def test_unregister_returns_false_for_missing(tmp_path: Path) -> None:
 def test_local_engine_backend(backend: BackendType) -> None:
     instance = _get_backend_instance(backend)
 
+    assert isinstance(instance, PodmanBackend)
     assert instance.engine.binary == backend.value
     assert isinstance(instance.engine.transport, LocalTransport)
 
@@ -143,7 +145,9 @@ def test_ssh_engine_backend(backend: BackendType) -> None:
         backend, ssh_host="user@example.test:2222", ssh_key="/tmp/test-key"
     )
 
+    assert isinstance(instance, PodmanBackend)
     assert instance.engine.binary == backend.value
-    assert isinstance(instance.engine.transport, SshTransport)
-    assert instance.engine.transport.host == "user@example.test"
-    assert instance.engine.transport.port == 2222
+    transport = instance.engine.transport
+    assert isinstance(transport, SshTransport)
+    assert transport.host == "user@example.test"
+    assert transport.port == 2222

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from paude.backends import PodmanBackend, Session
+from tests.fakes import make_backend
 
 
 class TestSession:
@@ -48,31 +49,21 @@ class TestPodmanBackend:
         backend = PodmanBackend()
         assert backend is not None
 
-    @patch("paude.backends.podman.backend.ContainerRunner")
-    def test_list_sessions_returns_empty(self, mock_runner_class: MagicMock) -> None:
+    def test_list_sessions_returns_empty(self) -> None:
         """list_sessions returns empty list for Podman when no sessions exist."""
         mock_runner = MagicMock()
         mock_runner.list_containers.return_value = []
-        mock_runner_class.return_value = mock_runner
 
-        backend = PodmanBackend()
-        backend._runner = mock_runner
-        backend._proxy._runner = mock_runner
+        backend = make_backend(mock_runner)
 
         sessions = backend.list_sessions()
         assert sessions == []
 
-    @patch("paude.backends.podman.backend.ContainerRunner")
-    def test_stop_container_delegates_to_runner(
-        self, mock_runner_class: MagicMock
-    ) -> None:
+    def test_stop_container_delegates_to_runner(self) -> None:
         """stop_container calls runner.stop_container."""
         mock_runner = MagicMock()
-        mock_runner_class.return_value = mock_runner
 
-        backend = PodmanBackend()
-        backend._runner = mock_runner
-        backend._proxy._runner = mock_runner
+        backend = make_backend(mock_runner)
 
         backend.stop_container("container-name")
 
@@ -84,11 +75,7 @@ class TestPodmanExecInSession:
 
     def _make_backend(self) -> tuple[PodmanBackend, MagicMock]:
         mock_runner = MagicMock()
-        backend = PodmanBackend()
-        backend._runner = mock_runner
-        backend._proxy._runner = mock_runner
-        backend._setup._runner = mock_runner
-        return backend, mock_runner
+        return make_backend(mock_runner), mock_runner
 
     def test_exec_in_session_success(self) -> None:
         """exec_in_session returns (returncode, stdout, stderr) on success."""

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import subprocess
-from dataclasses import MISSING, fields
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -28,7 +27,6 @@ from paude.backends.labels import (
     PAUDE_LABEL_WORKSPACE,
     PAUDE_LABEL_YOLO,
     LabeledSession,
-    SessionSpec,
     encode_agent_providers,
     encode_providers,
     read_labels,
@@ -42,7 +40,13 @@ from paude.backup_state import (
 )
 from paude.cli import app
 from paude.transport.ssh import SshTransport
-from tests.fakes import FakeTransport, make_backend, make_engine, make_runner
+from tests.fakes import (
+    FakeTransport,
+    assert_carries_every_spec_field,
+    make_backend,
+    make_engine,
+    make_runner,
+)
 
 runner = CliRunner()
 
@@ -571,15 +575,7 @@ class TestBuildManifest:
                 view, "s", "img", datetime(2026, 8, 10, tzinfo=UTC), "podman"
             )
 
-        for spec_field in fields(SessionSpec):
-            default = (
-                spec_field.default_factory()
-                if spec_field.default_factory is not MISSING
-                else spec_field.default
-            )
-            assert getattr(manifest, spec_field.name) != default, (
-                f"_build_manifest does not carry SessionSpec.{spec_field.name}"
-            )
+        assert_carries_every_spec_field(manifest, "_build_manifest")
 
 
 class TestWriteBundle:

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import subprocess
+from dataclasses import MISSING, fields
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -12,6 +14,26 @@ from click.testing import Result
 from typer.testing import CliRunner
 
 from paude.backends import PodmanBackend, Session
+from paude.backends.labels import (
+    PAUDE_LABEL_AGENT,
+    PAUDE_LABEL_AGENT_PROVIDERS,
+    PAUDE_LABEL_CREATED,
+    PAUDE_LABEL_DOMAINS,
+    PAUDE_LABEL_GPU,
+    PAUDE_LABEL_OTEL_ENDPOINT,
+    PAUDE_LABEL_PROVIDER,
+    PAUDE_LABEL_PROVIDERS,
+    PAUDE_LABEL_PROXY_IMAGE,
+    PAUDE_LABEL_SESSION,
+    PAUDE_LABEL_WORKSPACE,
+    PAUDE_LABEL_YOLO,
+    LabeledSession,
+    SessionSpec,
+    encode_agent_providers,
+    encode_providers,
+    read_labels,
+)
+from paude.backends.session_env import encode_path
 from paude.backup_state import (
     BACKUP_FORMAT_VERSION,
     MANIFEST_FILENAME,
@@ -41,8 +63,22 @@ def _make_session(name: str = "s", status: str = "stopped") -> Session:
     )
 
 
+def _session_container(name: str = "s", agent: str = "gemini") -> dict[str, object]:
+    """A container dict find_container_by_session_name will match."""
+    return {
+        "Id": "abc123",
+        "Labels": {
+            PAUDE_LABEL_SESSION: name,
+            PAUDE_LABEL_AGENT: agent,
+            PAUDE_LABEL_WORKSPACE: encode_path(Path("/some/project"), url_safe=True),
+            PAUDE_LABEL_CREATED: "2026-01-01T00:00:00Z",
+        },
+    }
+
+
 def _mock_backend(
     *,
+    name: str = "s",
     exists: bool = True,
     running: bool = False,
     image: str | None = "runtime:img",
@@ -63,16 +99,13 @@ def _mock_backend(
         container_exists=exists,
         container_running=running,
         get_container_image=image,
+        # Backup reads the session's labels off its container, so the double
+        # has to have one to find.
+        list_containers=[_session_container(name)],
     )
     backend = make_backend(runner)
     backend.get_session = MagicMock(return_value=_make_session())  # type: ignore[method-assign]
     return backend
-
-
-def _gemini_composition():
-    from paude.agents import get_agent, get_agent_composition
-
-    return get_agent_composition(get_agent("gemini"))
 
 
 class TestBackupCommand:
@@ -91,10 +124,6 @@ class TestBackupCommand:
             patch(
                 "paude.cli.helpers.find_session_backend",
                 return_value=("podman", backend),
-            ),
-            patch(
-                "paude.backends.podman.helpers.get_session_composition",
-                return_value=_gemini_composition(),
             ),
             patch("paude.cli.backup._preflight_disk_space"),
             patch(
@@ -121,7 +150,7 @@ class TestBackupCommand:
         assert "re-login" in _out(result)
 
     def test_backup_auto_selects_when_name_omitted(self) -> None:
-        backend = _mock_backend()
+        backend = _mock_backend(name="auto")
         session = _make_session(name="auto")
         manifest = BackupManifest(
             name="auto", workspace="/w", created_at="t", source_paude_version="v"
@@ -130,10 +159,6 @@ class TestBackupCommand:
             patch(
                 "paude.cli.helpers._auto_select_session",
                 return_value=(session, backend),
-            ),
-            patch(
-                "paude.backends.podman.helpers.get_session_composition",
-                return_value=_gemini_composition(),
             ),
             patch("paude.cli.backup._preflight_disk_space"),
             patch("paude.cli.backup._build_manifest", return_value=manifest),
@@ -150,10 +175,6 @@ class TestBackupCommand:
         )
         with (
             patch("paude.cli.helpers._get_backend_instance", return_value=backend),
-            patch(
-                "paude.backends.podman.helpers.get_session_composition",
-                return_value=_gemini_composition(),
-            ),
             patch("paude.cli.backup._preflight_disk_space"),
             patch("paude.cli.backup._build_manifest", return_value=manifest),
             patch("paude.cli.backup._write_bundle") as mock_write,
@@ -193,10 +214,6 @@ class TestBackupCommand:
             patch(
                 "paude.cli.helpers.find_session_backend",
                 return_value=("podman", backend),
-            ),
-            patch(
-                "paude.backends.podman.helpers.get_session_composition",
-                return_value=_gemini_composition(),
             ),
             patch(
                 "paude.backends.podman.volume_archive.VolumeArchiver.volume_size_bytes",
@@ -299,10 +316,6 @@ class TestRemoteOnlyBackupCommand:
             ) as mock_resolve,
             patch("paude.cli.backup._preflight_disk_space_remote"),
             patch(
-                "paude.backends.podman.helpers.get_session_composition",
-                return_value=_gemini_composition(),
-            ),
-            patch(
                 "paude.cli.backup._build_manifest", return_value=manifest
             ) as mock_build,
             patch("paude.cli.backup._write_bundle_remote") as mock_write,
@@ -371,10 +384,6 @@ class TestRemoteOnlyBackupCommand:
                 return_value="/home/user/.config/paude/backups/s-2026.paude",
             ),
             patch("paude.cli.backup._preflight_disk_space_remote") as mock_preflight,
-            patch(
-                "paude.backends.podman.helpers.get_session_composition",
-                return_value=_gemini_composition(),
-            ),
             patch("paude.cli.backup._build_manifest", return_value=manifest),
             patch("paude.cli.backup._write_bundle_remote"),
         ):
@@ -458,36 +467,28 @@ class TestRestoreCommand:
 
 
 class TestBuildManifest:
-    def test_maps_labels_and_registry_fields(self) -> None:
-        from paude.backends.labels import (
-            PAUDE_LABEL_DOMAINS,
-            PAUDE_LABEL_GPU,
-            PAUDE_LABEL_OTEL_ENDPOINT,
-            PAUDE_LABEL_PROXY_IMAGE,
-            PAUDE_LABEL_YOLO,
+    """The manifest is assembled from one label read plus the registry entry."""
+
+    def _view(self, **labels: str) -> LabeledSession:
+        return read_labels(
+            {
+                PAUDE_LABEL_SESSION: "s",
+                PAUDE_LABEL_AGENT: "claude",
+                PAUDE_LABEL_PROVIDER: "vertex",
+                PAUDE_LABEL_AGENT_PROVIDERS: encode_agent_providers(
+                    [("claude", "vertex")]
+                ),
+                PAUDE_LABEL_PROVIDERS: encode_providers(["vertex"]),
+                PAUDE_LABEL_WORKSPACE: encode_path(Path("/w"), url_safe=True),
+                PAUDE_LABEL_CREATED: "c",
+                **labels,
+            }
         )
+
+    def test_captures_labels_and_registry_fields(self) -> None:
         from paude.cli.backup import _build_manifest
         from paude.registry import RegistryEntry
 
-        backend = make_backend()
-        session = Session(
-            name="s",
-            status="stopped",
-            workspace=Path("/w"),
-            created_at="c",
-            backend_type="podman",
-            agent="claude",
-            provider="vertex",
-            agent_providers=[("claude", "vertex")],
-            credential_providers=["vertex"],
-        )
-        labels = {
-            PAUDE_LABEL_GPU: "all",
-            PAUDE_LABEL_YOLO: "1",
-            PAUDE_LABEL_DOMAINS: "a,b",
-            PAUDE_LABEL_OTEL_ENDPOINT: "http://collector:4318",
-            PAUDE_LABEL_PROXY_IMAGE: "proxy:1",
-        }
         entry = RegistryEntry(
             name="s",
             backend_type="podman",
@@ -499,22 +500,20 @@ class TestBuildManifest:
             ssh_key="/k",
             remote_config_dir="/tmp/cfg",
         )
-        from datetime import UTC, datetime
-
+        view = self._view(
+            **{
+                PAUDE_LABEL_GPU: "all",
+                PAUDE_LABEL_YOLO: "1",
+                PAUDE_LABEL_DOMAINS: "a,b",
+                PAUDE_LABEL_OTEL_ENDPOINT: "http://collector:4318",
+                PAUDE_LABEL_PROXY_IMAGE: "proxy:1",
+            }
+        )
         now = datetime(2026, 8, 10, tzinfo=UTC)
-        with (
-            patch(
-                "paude.backends.podman.helpers.find_container_by_session_name",
-                return_value={"Labels": labels},
-            ),
-            patch(
-                "paude.backends.podman.helpers.build_session_from_container",
-                return_value=session,
-            ),
-            patch("paude.registry.SessionRegistry") as mock_reg,
-        ):
+
+        with patch("paude.registry.SessionRegistry") as mock_reg:
             mock_reg.return_value.get.return_value = entry
-            manifest = _build_manifest(backend, "s", "runtime:img", now)
+            manifest = _build_manifest(view, "s", "runtime:img", now, "podman")
 
         assert manifest.gpu == "all"
         assert manifest.yolo is True
@@ -523,6 +522,8 @@ class TestBuildManifest:
         assert manifest.proxy_image == "proxy:1"
         assert manifest.image == "runtime:img"
         assert manifest.agent_providers == [("claude", "vertex")]
+        assert manifest.workspace == "/w"
+        assert manifest.session_created_at == "c"
         # Registry-only fields the labels don't carry.
         assert manifest.engine == "docker"
         assert manifest.ssh_host == "user@box"
@@ -531,30 +532,54 @@ class TestBuildManifest:
     def test_absent_domains_label_means_none(self) -> None:
         from paude.cli.backup import _build_manifest
 
-        backend = make_backend()
-        from datetime import UTC, datetime
-
-        with (
-            patch(
-                "paude.backends.podman.helpers.find_container_by_session_name",
-                return_value={"Labels": {}},
-            ),
-            patch(
-                "paude.backends.podman.helpers.build_session_from_container",
-                return_value=_make_session(),
-            ),
-            patch("paude.registry.SessionRegistry") as mock_reg,
-        ):
+        with patch("paude.registry.SessionRegistry") as mock_reg:
             mock_reg.return_value.get.return_value = None
             manifest = _build_manifest(
-                backend, "s", "img", datetime(2026, 8, 10, tzinfo=UTC)
+                read_labels({}), "s", "img", datetime(2026, 8, 10, tzinfo=UTC), "podman"
             )
 
         assert manifest.allowed_domains is None
         assert manifest.gpu is None
         assert manifest.yolo is False
-        # No registry entry: engine falls back to the session's backend type.
+        # No registry entry: engine falls back to the backend type.
         assert manifest.engine == "podman"
+        # No workspace label: the placeholder, not a crash.
+        assert manifest.workspace == "/"
+
+    def test_every_spec_field_reaches_the_manifest(self) -> None:
+        """The BackupManifest half of the REFACTOR-007 drift guard.
+
+        Inheriting SessionSpec dedupes the schema, not the copying: a tenth
+        label would persist as its default until _build_manifest carried it.
+        """
+        from paude.cli.backup import _build_manifest
+
+        view = self._view(
+            **{
+                PAUDE_LABEL_AGENT: "codex",
+                PAUDE_LABEL_GPU: "all",
+                PAUDE_LABEL_YOLO: "1",
+                PAUDE_LABEL_DOMAINS: "a,b",
+                PAUDE_LABEL_OTEL_ENDPOINT: "http://collector:4318",
+                PAUDE_LABEL_PROXY_IMAGE: "proxy:1",
+            }
+        )
+
+        with patch("paude.registry.SessionRegistry") as mock_reg:
+            mock_reg.return_value.get.return_value = None
+            manifest = _build_manifest(
+                view, "s", "img", datetime(2026, 8, 10, tzinfo=UTC), "podman"
+            )
+
+        for spec_field in fields(SessionSpec):
+            default = (
+                spec_field.default_factory()
+                if spec_field.default_factory is not MISSING
+                else spec_field.default
+            )
+            assert getattr(manifest, spec_field.name) != default, (
+                f"_build_manifest does not carry SessionSpec.{spec_field.name}"
+            )
 
 
 class TestWriteBundle:

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -19,6 +19,7 @@ from paude.backup_state import (
 )
 from paude.cli import app
 from paude.transport.ssh import SshTransport
+from tests.fakes import FakeTransport, make_backend, make_engine, make_runner
 
 runner = CliRunner()
 
@@ -55,14 +56,15 @@ def _mock_backend(
     transport's ``run`` for whichever calls they don't stub out at a higher
     level.
     """
-    backend = PodmanBackend(engine=MagicMock())
-    backend._runner = MagicMock()
-    backend._runner.container_exists.return_value = exists
-    backend._runner.container_running.return_value = running
-    backend._runner.get_container_image.return_value = image
+    transport = SshTransport("user@host") if remote else FakeTransport()
+    runner = make_runner(
+        make_engine(transport=transport, is_remote=remote),
+        container_exists=exists,
+        container_running=running,
+        get_container_image=image,
+    )
+    backend = make_backend(runner)
     backend.get_session = MagicMock(return_value=_make_session())  # type: ignore[method-assign]
-    backend._engine.is_remote = remote
-    backend._engine.transport = SshTransport("user@host") if remote else MagicMock()
     return backend
 
 
@@ -466,8 +468,7 @@ class TestBuildManifest:
         from paude.cli.backup import _build_manifest
         from paude.registry import RegistryEntry
 
-        backend = PodmanBackend(engine=MagicMock())
-        backend._runner = MagicMock()
+        backend = make_backend()
         session = Session(
             name="s",
             status="stopped",
@@ -529,8 +530,7 @@ class TestBuildManifest:
     def test_absent_domains_label_means_none(self) -> None:
         from paude.cli.backup import _build_manifest
 
-        backend = PodmanBackend(engine=MagicMock())
-        backend._runner = MagicMock()
+        backend = make_backend()
         from datetime import UTC, datetime
 
         with (

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import typer
+from click.testing import Result
 from typer.testing import CliRunner
 
 from paude.backends import PodmanBackend, Session
@@ -24,7 +25,7 @@ from tests.fakes import FakeTransport, make_backend, make_engine, make_runner
 runner = CliRunner()
 
 
-def _out(result) -> str:
+def _out(result: Result) -> str:
     """Combined stdout + stderr, mirroring the rest of the CLI test suite."""
     return result.stdout + (result.stderr or "")
 

--- a/tests/test_backup_state.py
+++ b/tests/test_backup_state.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from paude import backup_state
@@ -77,3 +79,93 @@ class TestBackupManifest:
         bad = f'{{"backup_format_version": {BACKUP_FORMAT_VERSION}, "bogus": 1}}'
         with pytest.raises(BackupFormatError, match="unexpected fields"):
             backup_state.loads(bad)
+
+
+class TestManifestSchema:
+    """Guards on the bundle schema, which older bundles depend on."""
+
+    # A manifest exactly as paude 0.20.2 wrote it, before BackupManifest
+    # inherited SessionSpec: flat, and in the field order of that release.
+    LEGACY_JSON = """
+    {
+        "name": "test-session",
+        "workspace": "/home/user/project",
+        "created_at": "2026-08-10T10:15:00+00:00",
+        "source_paude_version": "0.20.2",
+        "backup_format_version": 1,
+        "session_created_at": "2026-01-01T00:00:00+00:00",
+        "archive_sha256": "deadbeef",
+        "agent": "claude",
+        "provider": "anthropic",
+        "agent_providers": [["claude", "anthropic"]],
+        "credential_providers": ["anthropic"],
+        "gpu": null,
+        "yolo": false,
+        "otel_endpoint": null,
+        "allowed_domains": [".pypi.org"],
+        "proxy_image": "proxy:latest",
+        "image": "runtime:abc123",
+        "backend_type": "podman",
+        "engine": "podman",
+        "ssh_host": null,
+        "ssh_key": null,
+        "remote_config_dir": null
+    }
+    """
+
+    def test_a_bundle_from_an_earlier_release_still_loads(self) -> None:
+        loaded = backup_state.loads(self.LEGACY_JSON)
+
+        assert loaded.name == "test-session"
+        assert loaded.agent_providers == [("claude", "anthropic")]
+        assert loaded.allowed_domains == [".pypi.org"]
+        assert loaded.image == "runtime:abc123"
+        assert loaded.gpu is None
+
+    def test_serialized_json_stays_flat(self) -> None:
+        """Nesting the spec would make every existing bundle unreadable."""
+        entry = json.loads(_manifest().to_json())
+
+        assert "spec" not in entry
+        assert not any(isinstance(value, dict) for value in entry.values())
+        assert set(entry) == {
+            "name",
+            "workspace",
+            "created_at",
+            "source_paude_version",
+            "backup_format_version",
+            "session_created_at",
+            "archive_sha256",
+            "agent",
+            "provider",
+            "agent_providers",
+            "credential_providers",
+            "gpu",
+            "yolo",
+            "otel_endpoint",
+            "allowed_domains",
+            "proxy_image",
+            "image",
+            "backend_type",
+            "engine",
+            "ssh_host",
+            "ssh_key",
+            "remote_config_dir",
+        }
+
+    @pytest.mark.parametrize(
+        "agent_providers",
+        ['[["claude"]]', '["claude"]', "[[1, 2]]", '"claude"'],
+        ids=["short-pair", "bare-string", "non-strings", "string"],
+    )
+    def test_malformed_agent_providers_is_a_format_error(
+        self, agent_providers: str
+    ) -> None:
+        """Better here than as a 1-tuple that blows up where a caller unpacks it."""
+        text = (
+            f'{{"backup_format_version": {BACKUP_FORMAT_VERSION}, '
+            f'"name": "s", "workspace": "/w", "created_at": "t", '
+            f'"source_paude_version": "v", "agent_providers": {agent_providers}}}'
+        )
+        with pytest.raises(BackupFormatError, match="malformed field"):
+            backup_state.loads(text)

--- a/tests/test_blocked_domains.py
+++ b/tests/test_blocked_domains.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
-from paude.backends.podman import PodmanBackend
 from paude.backends.podman import SessionNotFoundError as PodmanSessionNotFoundError
+from tests.fakes import make_backend
 
 # ---------------------------------------------------------------------------
 # PodmanBackend: get_proxy_blocked_log
@@ -17,71 +17,50 @@ from paude.backends.podman import SessionNotFoundError as PodmanSessionNotFoundE
 class TestPodmanGetProxyBlockedLog:
     """Tests for PodmanBackend.get_proxy_blocked_log method."""
 
-    @patch("paude.backends.podman.backend.ContainerRunner")
-    def test_returns_none_when_no_proxy(self, mock_runner_class: MagicMock) -> None:
+    def test_returns_none_when_no_proxy(self) -> None:
         mock_runner = MagicMock()
         mock_runner.container_exists.side_effect = lambda name: (
             name == "paude-my-session"
         )
-        mock_runner_class.return_value = mock_runner
 
-        backend = PodmanBackend()
-        backend._runner = mock_runner
-        backend._proxy._runner = mock_runner
+        backend = make_backend(mock_runner)
 
         result = backend.get_proxy_blocked_log("my-session")
         assert result is None
 
-    @patch("paude.backends.podman.backend.ContainerRunner")
-    def test_raises_session_not_found(self, mock_runner_class: MagicMock) -> None:
+    def test_raises_session_not_found(self) -> None:
         mock_runner = MagicMock()
         mock_runner.container_exists.return_value = False
-        mock_runner_class.return_value = mock_runner
 
-        backend = PodmanBackend()
-        backend._runner = mock_runner
-        backend._proxy._runner = mock_runner
+        backend = make_backend(mock_runner)
 
         with pytest.raises(PodmanSessionNotFoundError):
             backend.get_proxy_blocked_log("nonexistent")
 
-    @patch("paude.backends.podman.backend.ContainerRunner")
-    def test_raises_value_error_when_proxy_not_running(
-        self, mock_runner_class: MagicMock
-    ) -> None:
+    def test_raises_value_error_when_proxy_not_running(self) -> None:
         mock_runner = MagicMock()
         mock_runner.container_exists.return_value = True
         mock_runner.container_running.return_value = False
-        mock_runner_class.return_value = mock_runner
 
-        backend = PodmanBackend()
-        backend._runner = mock_runner
-        backend._proxy._runner = mock_runner
+        backend = make_backend(mock_runner)
 
         with pytest.raises(ValueError, match="not running"):
             backend.get_proxy_blocked_log("my-session")
 
-    @patch("paude.backends.podman.backend.ContainerRunner")
-    def test_returns_empty_string_when_log_file_missing(
-        self, mock_runner_class: MagicMock
-    ) -> None:
+    def test_returns_empty_string_when_log_file_missing(self) -> None:
         mock_runner = MagicMock()
         mock_runner.container_exists.return_value = True
         mock_runner.container_running.return_value = True
         mock_runner.exec_in_container.return_value = MagicMock(
             returncode=1, stdout="", stderr="No such file"
         )
-        mock_runner_class.return_value = mock_runner
 
-        backend = PodmanBackend()
-        backend._runner = mock_runner
-        backend._proxy._runner = mock_runner
+        backend = make_backend(mock_runner)
 
         result = backend.get_proxy_blocked_log("my-session")
         assert result == ""
 
-    @patch("paude.backends.podman.backend.ContainerRunner")
-    def test_returns_log_content(self, mock_runner_class: MagicMock) -> None:
+    def test_returns_log_content(self) -> None:
         log_content = "08/Mar/2026:14:23:45 +0000 10.0.0.2 TCP_DENIED/403 CONNECT evil.com:443 BLOCKED\n"
         mock_runner = MagicMock()
         mock_runner.container_exists.return_value = True
@@ -89,11 +68,8 @@ class TestPodmanGetProxyBlockedLog:
         mock_runner.exec_in_container.return_value = MagicMock(
             returncode=0, stdout=log_content
         )
-        mock_runner_class.return_value = mock_runner
 
-        backend = PodmanBackend()
-        backend._runner = mock_runner
-        backend._proxy._runner = mock_runner
+        backend = make_backend(mock_runner)
 
         result = backend.get_proxy_blocked_log("my-session")
         assert result == log_content

--- a/tests/test_create_podman.py
+++ b/tests/test_create_podman.py
@@ -138,7 +138,6 @@ def _create(**overrides: Any) -> None:
         "config": None,
         "env": {"PAUDE_AGENT": "claude"},
         "expanded_domains": ["github.com", "pypi.org"],
-        "unrestricted": False,
         "parsed_args": ["--verbose"],
         "yolo": False,
         "git": False,
@@ -230,17 +229,11 @@ class TestSessionConfig:
 
 
 class TestImageSelection:
-    """Which image build runs, and whether it is forced."""
+    """What create forwards into the image build.
 
-    def test_plain_config_builds_the_default_image(self) -> None:
-        with _pipeline() as p:
-            _create(config=PaudeConfig())
-
-        p.image_manager.ensure_default_image.assert_called_once_with(
-            force_rebuild=False
-        )
-        p.image_manager.ensure_custom_image.assert_not_called()
-        assert p.config.image == "paude:latest"
+    Which image the build then selects belongs to
+    tests/test_session_rebuild.py, which owns build_session_images.
+    """
 
     def test_customized_config_builds_a_custom_image(self) -> None:
         config = PaudeConfig(packages=["ripgrep"])
@@ -262,24 +255,11 @@ class TestImageSelection:
 
 
 class TestMounts:
-    """Local engines copy configs in; SSH remotes bind-mount synced copies."""
+    """What create does with the mounts it gets back.
 
-    def test_local_engine_skips_config_bind_mounts(self) -> None:
-        with _pipeline() as p:
-            _create()
-
-        assert p.build_mounts.call_args.kwargs["include_config"] is False
-        p.sync.assert_not_called()
-        p.remap.assert_not_called()
-
-    def test_ssh_remote_syncs_configs_and_remaps_mounts(self) -> None:
-        with _pipeline() as p:
-            _create(**_remote_kwargs())
-
-        assert p.build_mounts.call_args.kwargs["include_config"] is True
-        p.sync.assert_called_once()
-        p.remap.assert_called_once()
-        assert p.config.mounts == ["-v", "/remote/cfg:/home/paude/.cfg:ro"]
+    Which mounts those are -- local vs SSH, sync and remap -- belongs to
+    tests/test_session_rebuild.py, which owns prepare_session_mounts.
+    """
 
     def test_ssh_remote_records_the_config_dir_in_the_registry(self) -> None:
         with _pipeline() as p:

--- a/tests/test_create_podman.py
+++ b/tests/test_create_podman.py
@@ -1,0 +1,424 @@
+"""Characterization tests for the Podman/Docker create pipeline.
+
+``create_podman_session`` had no direct coverage (13%, its whole body uncovered)
+while its near-twin ``_upgrade_podman`` sits in a well-tested module. These tests
+pin what create *does* -- the ``SessionConfig`` it assembles, its two
+image-failure paths, its rollback, and its post-create calls -- so the
+session-rebuild consolidation can shrink the function without changing it.
+
+Patch targets are deliberate. Collaborators that ``create_podman_session``
+imports *inside* the function (``ImageManager``, ``build_mounts``, the
+``config_sync`` helpers) are patched at their defining module, so these tests
+keep biting once that code moves into the shared rebuild helpers. Collaborators
+bound at module import (``PodmanBackend``, ``_finalize_session_create``,
+``_run_setup_command``) are patched on ``paude.cli.create_podman``, where they
+stay.
+
+Deliberately *not* asserted: the relative order of the config sync and the proxy
+image build. The consolidation unifies that ordering on purpose.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+
+from paude.backends import SessionConfig, SessionExistsError
+from paude.backends.base import Session
+from paude.cli.create_podman import create_podman_session
+from paude.config.models import PaudeConfig
+from paude.transport.config_sync import RemoteConfigPaths
+from paude.transport.ssh import SshTransport
+
+WORKSPACE = Path("/home/user/project")
+REMOTE_BASE = "/tmp/paude-config-abc123"
+
+# The provider the agent registry resolves for a bare `claude` / `codex`.
+CLAUDE_PROVIDER = "vertex"
+CODEX_PROVIDER = "chatgpt"
+
+
+@dataclass
+class _Pipeline:
+    """Handles on every collaborator ``create_podman_session`` drives."""
+
+    image_manager_cls: MagicMock
+    image_manager: MagicMock
+    build_mounts: MagicMock
+    backend: MagicMock
+    session: Session
+    finalize: MagicMock
+    run_setup: MagicMock
+    sync: MagicMock
+    remap: MagicMock
+    cleanup_remote: MagicMock
+
+    @property
+    def config(self) -> SessionConfig:
+        """The ``SessionConfig`` handed to ``create_session``."""
+        created: SessionConfig = self.backend.create_session.call_args[0][0]
+        return created
+
+
+@contextmanager
+def _pipeline(*, mounts: list[str] | None = None) -> Iterator[_Pipeline]:
+    """Run ``create_podman_session`` against fully substituted collaborators."""
+    session = Session(
+        name="test-session",
+        status="running",
+        workspace=WORKSPACE,
+        created_at="2026-01-01T00:00:00+00:00",
+        backend_type="podman",
+    )
+    image_manager = MagicMock()
+    image_manager.ensure_default_image.return_value = "paude:latest"
+    image_manager.ensure_custom_image.return_value = "paude-custom:latest"
+    image_manager.ensure_proxy_image.return_value = "paude-proxy:latest"
+
+    backend = MagicMock()
+    backend.create_session.return_value = session
+
+    remote = RemoteConfigPaths(
+        remote_base=REMOTE_BASE, path_map={"/local/cfg": "/remote/cfg"}
+    )
+
+    with ExitStack() as stack:
+        enter = stack.enter_context
+        image_manager_cls = enter(
+            patch("paude.container.ImageManager", return_value=image_manager)
+        )
+        build_mounts = enter(
+            patch("paude.mounts.build_mounts", return_value=list(mounts or []))
+        )
+        enter(patch("paude.cli.create_podman.PodmanBackend", return_value=backend))
+        finalize = enter(patch("paude.cli.create_podman._finalize_session_create"))
+        run_setup = enter(patch("paude.cli.create_podman._run_setup_command"))
+        sync = enter(
+            patch(
+                "paude.transport.config_sync.sync_configs_to_remote",
+                return_value=remote,
+            )
+        )
+        remap = enter(
+            patch(
+                "paude.transport.config_sync.remap_mounts",
+                return_value=["-v", "/remote/cfg:/home/paude/.cfg:ro"],
+            )
+        )
+        cleanup_remote = enter(
+            patch("paude.transport.config_sync.cleanup_remote_configs")
+        )
+        yield _Pipeline(
+            image_manager_cls=image_manager_cls,
+            image_manager=image_manager,
+            build_mounts=build_mounts,
+            backend=backend,
+            session=session,
+            finalize=finalize,
+            run_setup=run_setup,
+            sync=sync,
+            remap=remap,
+            cleanup_remote=cleanup_remote,
+        )
+
+
+def _create(**overrides: Any) -> None:
+    """Call ``create_podman_session`` with a plausible default argument set."""
+    kwargs: dict[str, Any] = {
+        "name": "test-session",
+        "workspace": WORKSPACE,
+        "config": None,
+        "env": {"PAUDE_AGENT": "claude"},
+        "expanded_domains": ["github.com", "pypi.org"],
+        "unrestricted": False,
+        "parsed_args": ["--verbose"],
+        "yolo": False,
+        "git": False,
+        "rebuild": False,
+        "platform": None,
+    }
+    kwargs.update(overrides)
+    create_podman_session(**kwargs)
+
+
+def _remote_kwargs() -> dict[str, Any]:
+    """Arguments that put the pipeline on the SSH-remote path."""
+    return {
+        "transport": SshTransport("user@remote"),
+        "ssh_host": "user@remote",
+        "ssh_key": "~/.ssh/id_ed25519",
+    }
+
+
+class TestSessionConfig:
+    """The SessionConfig create assembles from its arguments."""
+
+    def test_maps_every_argument_onto_the_session_config(self) -> None:
+        with _pipeline(mounts=["-v", "/host:/pvc"]) as p:
+            _create(
+                env={"FOO": "bar"},
+                yolo=True,
+                gpu="all",
+                otel_ports=[4317],
+                otel_endpoint="http://otel:4317",
+            )
+
+        config = p.config
+        assert config.name == "test-session"
+        assert config.workspace == WORKSPACE
+        assert config.image == "paude:latest"
+        assert config.env == {"FOO": "bar"}
+        assert config.mounts == ["-v", "/host:/pvc"]
+        assert config.args == ["--verbose"]
+        assert config.workdir == str(WORKSPACE)
+        assert config.allowed_domains == ["github.com", "pypi.org"]
+        assert config.yolo is True
+        assert config.proxy_image == "paude-proxy:latest"
+        assert config.agent == "claude"
+        assert config.provider is None
+        assert config.agent_providers == [("claude", CLAUDE_PROVIDER)]
+        assert config.gpu == "all"
+        assert config.ports == []
+        assert config.otel_ports == [4317]
+        assert config.otel_endpoint == "http://otel:4317"
+        # Create builds a fresh volume; only upgrade/restore reuse one.
+        assert config.reuse_volume is False
+
+    def test_agent_providers_are_resolved_through_the_registry(self) -> None:
+        with _pipeline() as p:
+            _create(agent_providers=[("claude", ""), ("codex", "")])
+
+        assert p.config.agent_providers == [
+            ("claude", CLAUDE_PROVIDER),
+            ("codex", CODEX_PROVIDER),
+        ]
+
+    def test_credential_providers_fall_back_to_the_resolved_providers(self) -> None:
+        with _pipeline() as p:
+            _create(
+                agent_providers=[("claude", ""), ("codex", "")],
+                credential_providers=None,
+            )
+
+        assert p.config.credential_providers == [CLAUDE_PROVIDER, CODEX_PROVIDER]
+
+    def test_explicit_credential_providers_are_kept_verbatim(self) -> None:
+        with _pipeline() as p:
+            _create(credential_providers=["vertex", "openai"])
+
+        assert p.config.credential_providers == ["vertex", "openai"]
+
+    def test_session_is_started_without_attaching(self) -> None:
+        with _pipeline() as p:
+            _create()
+
+        p.backend.start_session_no_attach.assert_called_once_with("test-session")
+
+    def test_platform_reaches_the_image_manager(self) -> None:
+        with _pipeline() as p:
+            _create(platform="linux/amd64")
+
+        assert p.image_manager_cls.call_args.kwargs["platform"] == "linux/amd64"
+
+
+class TestImageSelection:
+    """Which image build runs, and whether it is forced."""
+
+    def test_plain_config_builds_the_default_image(self) -> None:
+        with _pipeline() as p:
+            _create(config=PaudeConfig())
+
+        p.image_manager.ensure_default_image.assert_called_once_with(
+            force_rebuild=False
+        )
+        p.image_manager.ensure_custom_image.assert_not_called()
+        assert p.config.image == "paude:latest"
+
+    def test_customized_config_builds_a_custom_image(self) -> None:
+        config = PaudeConfig(packages=["ripgrep"])
+        with _pipeline() as p:
+            _create(config=config)
+
+        p.image_manager.ensure_custom_image.assert_called_once_with(
+            config, force_rebuild=False, workspace=WORKSPACE
+        )
+        p.image_manager.ensure_default_image.assert_not_called()
+        assert p.config.image == "paude-custom:latest"
+
+    def test_rebuild_forces_both_image_builds(self) -> None:
+        with _pipeline() as p:
+            _create(rebuild=True)
+
+        p.image_manager.ensure_default_image.assert_called_once_with(force_rebuild=True)
+        p.image_manager.ensure_proxy_image.assert_called_once_with(force_rebuild=True)
+
+
+class TestMounts:
+    """Local engines copy configs in; SSH remotes bind-mount synced copies."""
+
+    def test_local_engine_skips_config_bind_mounts(self) -> None:
+        with _pipeline() as p:
+            _create()
+
+        assert p.build_mounts.call_args.kwargs["include_config"] is False
+        p.sync.assert_not_called()
+        p.remap.assert_not_called()
+
+    def test_ssh_remote_syncs_configs_and_remaps_mounts(self) -> None:
+        with _pipeline() as p:
+            _create(**_remote_kwargs())
+
+        assert p.build_mounts.call_args.kwargs["include_config"] is True
+        p.sync.assert_called_once()
+        p.remap.assert_called_once()
+        assert p.config.mounts == ["-v", "/remote/cfg:/home/paude/.cfg:ro"]
+
+    def test_ssh_remote_records_the_config_dir_in_the_registry(self) -> None:
+        with _pipeline() as p:
+            _create(**_remote_kwargs())
+
+        kwargs = p.finalize.call_args.kwargs
+        assert kwargs["remote_config_dir"] == REMOTE_BASE
+        assert kwargs["ssh_host"] == "user@remote"
+        assert kwargs["ssh_key"] == "~/.ssh/id_ed25519"
+
+    def test_local_engine_records_no_config_dir(self) -> None:
+        with _pipeline() as p:
+            _create()
+
+        assert p.finalize.call_args.kwargs["remote_config_dir"] is None
+
+
+class TestFailures:
+    """Every failure path aborts with exit code 1, and what it cleans up."""
+
+    def test_agent_image_failure_aborts_before_create(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with _pipeline() as p:
+            p.image_manager.ensure_default_image.side_effect = RuntimeError("boom")
+            with pytest.raises(typer.Exit) as exc:
+                _create()
+
+        assert exc.value.exit_code == 1
+        assert "Error ensuring image: boom" in capsys.readouterr().err
+        p.backend.create_session.assert_not_called()
+
+    def test_proxy_image_failure_aborts_before_create(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with _pipeline() as p:
+            p.image_manager.ensure_proxy_image.side_effect = RuntimeError("no proxy")
+            with pytest.raises(typer.Exit) as exc:
+                _create()
+
+        assert exc.value.exit_code == 1
+        assert "Error ensuring proxy image: no proxy" in capsys.readouterr().err
+        p.backend.create_session.assert_not_called()
+
+    def test_existing_session_reports_without_deleting_it(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with _pipeline() as p:
+            p.backend.create_session.side_effect = SessionExistsError("already exists")
+            with pytest.raises(typer.Exit) as exc:
+                _create()
+
+        assert exc.value.exit_code == 1
+        assert "Error: already exists" in capsys.readouterr().err
+        # Distinct from the generic path: an existing session is never deleted.
+        p.backend.delete_session.assert_not_called()
+
+    def test_start_failure_rolls_the_session_back(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with _pipeline() as p:
+            p.backend.start_session_no_attach.side_effect = RuntimeError("no start")
+            with pytest.raises(typer.Exit) as exc:
+                _create()
+
+        assert exc.value.exit_code == 1
+        assert "Error creating session: no start" in capsys.readouterr().err
+        p.backend.delete_session.assert_called_once_with("test-session", confirm=True)
+
+    def test_captured_stderr_is_surfaced(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """str(CalledProcessError) omits stderr, so create echoes it separately."""
+        failure = subprocess.CalledProcessError(
+            125, ["podman", "run"], stderr="no such image"
+        )
+        with _pipeline() as p:
+            p.backend.create_session.side_effect = failure
+            with pytest.raises(typer.Exit):
+                _create()
+
+        err = capsys.readouterr().err
+        assert "Error creating session:" in err
+        assert "no such image" in err
+
+    def test_create_failure_does_not_roll_back(self) -> None:
+        """A create_session failure leaves no rollback -- `session` is unbound.
+
+        The cleanup calls ``delete_session(session.name, ...)``, which raises
+        ``UnboundLocalError`` into the best-effort ``except Exception: pass``.
+        Characterized, not endorsed; see KNOWN_ISSUES.
+        """
+        with _pipeline() as p:
+            p.backend.create_session.side_effect = RuntimeError("no create")
+            with pytest.raises(typer.Exit):
+                _create()
+
+        p.backend.delete_session.assert_not_called()
+
+    def test_create_failure_cleans_up_synced_remote_configs(self) -> None:
+        with _pipeline() as p:
+            p.backend.create_session.side_effect = RuntimeError("no create")
+            with pytest.raises(typer.Exit):
+                _create(**_remote_kwargs())
+
+        assert p.cleanup_remote.call_args.args[1] == REMOTE_BASE
+
+    def test_local_failure_has_no_remote_configs_to_clean(self) -> None:
+        with _pipeline() as p:
+            p.backend.create_session.side_effect = RuntimeError("no create")
+            with pytest.raises(typer.Exit):
+                _create()
+
+        p.cleanup_remote.assert_not_called()
+
+
+class TestPostCreate:
+    """Registration and the optional setup command."""
+
+    def test_registers_the_session_with_its_domains(self) -> None:
+        with _pipeline() as p:
+            _create(yolo=True, git=True, no_clone_origin=True)
+
+        kwargs = p.finalize.call_args.kwargs
+        assert kwargs["session"] is p.session
+        assert kwargs["expanded_domains"] == ["github.com", "pypi.org"]
+        assert kwargs["yolo"] is True
+        assert kwargs["git"] is True
+        assert kwargs["no_clone_origin"] is True
+
+    def test_setup_command_runs_after_create(self) -> None:
+        config = PaudeConfig(setup_command="make install")
+        with _pipeline() as p:
+            _create(config=config)
+
+        p.run_setup.assert_called_once_with(p.backend, "test-session", "make install")
+
+    def test_no_setup_command_stays_quiet(self) -> None:
+        with _pipeline() as p:
+            _create(config=PaudeConfig())
+
+        p.run_setup.assert_not_called()

--- a/tests/test_docker_compat.py
+++ b/tests/test_docker_compat.py
@@ -309,7 +309,8 @@ class TestDockerVolumePermissions:
             if "exec" in c[0][0] and "--user" in c[0][0]
         ]
         assert len(exec_calls) == 1, exec_calls
-        return exec_calls[0]
+        argv: list[str] = exec_calls[0]
+        return argv
 
     @patch("subprocess.run")
     def test_docker_reconciles_volume_ownership_on_start(

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -1,0 +1,126 @@
+"""Tests for the shared test doubles in tests/fakes.py.
+
+These guard the doubles themselves: a fake that drifts from the real class it
+stands in for silently weakens every test that relies on it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from paude.backends.podman.backend import PodmanBackend
+from paude.container.engine import ContainerEngine
+from tests.fakes import FakeTransport, make_backend, make_engine, make_runner
+
+
+class TestFakeTransport:
+    """Tests for FakeTransport."""
+
+    def test_records_commands_without_executing(self) -> None:
+        """run() records the command and returns the default result."""
+        transport = FakeTransport()
+        result = transport.run(["podman", "ps"])
+
+        assert transport.commands == [["podman", "ps"]]
+        assert result.returncode == 0
+
+    def test_matches_scripted_result_by_substring(self) -> None:
+        """A command containing a configured needle gets that result."""
+        scripted = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="boom", stderr="err"
+        )
+        transport = FakeTransport(results={"network inspect": scripted})
+
+        assert transport.run(["podman", "network", "inspect", "n"]).stdout == "boom"
+        assert transport.run(["podman", "ps"]).returncode == 0
+
+    def test_streaming_is_refused_rather_than_faked(self) -> None:
+        """popen_binary raises instead of returning a half-working double."""
+        with pytest.raises(NotImplementedError):
+            FakeTransport().popen_binary(["podman", "ps"])
+
+
+class TestMakeEngine:
+    """Tests for make_engine."""
+
+    def test_engine_derives_real_properties(self) -> None:
+        """Properties come from the real ContainerEngine, not a reimplementation."""
+        podman = make_engine("podman")
+        docker = make_engine("docker")
+
+        assert isinstance(podman, ContainerEngine)
+        assert podman.is_podman
+        assert not docker.is_podman
+        assert podman.default_bridge_network == "podman"
+        assert docker.default_bridge_network == "bridge"
+        assert podman.supports_multi_network_create
+        assert not docker.supports_multi_network_create
+
+    def test_is_remote_follows_the_transport(self) -> None:
+        """The engine reads is_remote off the transport it was given."""
+        assert not make_engine().is_remote
+        assert make_engine(transport=FakeTransport(is_remote=True)).is_remote
+
+    def test_engine_run_reaches_the_transport(self) -> None:
+        """engine.run prepends the binary and routes through the transport."""
+        engine = make_engine("docker")
+        engine.run("ps", "-a")
+
+        assert engine.transport.commands == [["docker", "ps", "-a"]]
+
+
+class TestMakeRunner:
+    """Tests for make_runner."""
+
+    def test_specced_against_the_real_runner(self) -> None:
+        """A method that does not exist on ContainerRunner raises."""
+        runner = make_runner()
+
+        runner.container_exists("x")
+        with pytest.raises(AttributeError):
+            runner.container_exsits("x")  # noqa: B018 - deliberate typo
+
+    def test_return_values_can_be_set_by_keyword(self) -> None:
+        """Keyword arguments configure method return values."""
+        runner = make_runner(container_exists=True, container_running=False)
+
+        assert runner.container_exists("x") is True
+        assert runner.container_running("x") is False
+
+
+class TestMakeBackend:
+    """Tests for make_backend."""
+
+    def test_no_collaborator_reaches_a_real_engine(self) -> None:
+        """Runner, proxy and setup all observe the substituted doubles."""
+        backend = make_backend()
+
+        assert isinstance(backend, PodmanBackend)
+        assert backend._proxy._runner is backend._runner
+        assert backend._setup._runner is backend._runner
+        assert backend.engine is backend._runner.engine
+        assert isinstance(backend.engine.transport, FakeTransport)
+
+    def test_engine_binary_reaches_the_backend(self) -> None:
+        """backend_type reflects the requested engine binary."""
+        assert make_backend(engine_binary="docker").backend_type == "docker"
+
+    def test_caller_supplied_engine_double_is_preserved(self) -> None:
+        """A runner whose engine the caller configured is left alone."""
+        runner = make_runner()
+        configured = runner.engine
+        backend = make_backend(runner)
+
+        assert backend.engine is configured
+
+    def test_gateway_default_is_only_a_default(self) -> None:
+        """An explicitly configured gateway is not overwritten."""
+        from unittest.mock import MagicMock
+
+        network = MagicMock()
+        network.get_network_gateway.return_value = "10.1.2.1"
+
+        assert make_backend(network_manager=network)._network_manager is network
+        assert network.get_network_gateway.return_value == "10.1.2.1"

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -12,7 +12,13 @@ import pytest
 
 from paude.backends.podman.backend import PodmanBackend
 from paude.container.engine import ContainerEngine
-from tests.fakes import FakeTransport, make_backend, make_engine, make_runner
+from tests.fakes import (
+    FakeTransport,
+    make_backend,
+    make_engine,
+    make_runner,
+    recorded_commands,
+)
 
 
 class TestFakeTransport:
@@ -68,7 +74,7 @@ class TestMakeEngine:
         engine = make_engine("docker")
         engine.run("ps", "-a")
 
-        assert engine.transport.commands == [["docker", "ps", "-a"]]
+        assert recorded_commands(engine) == [["docker", "ps", "-a"]]
 
 
 class TestMakeRunner:

--- a/tests/test_git_remote.py
+++ b/tests/test_git_remote.py
@@ -36,6 +36,7 @@ from paude.git_remote import (
     setup_precommit_in_container,
     ssh_url_to_https,
 )
+from paude.transport.ssh import SshTransport
 
 
 class TestBuildPodmanRemoteUrl:
@@ -1318,7 +1319,7 @@ class TestResolveSessionRemote:
             "ext::ssh -i /home/user/.ssh/id_ed25519 -p 2222 user@gpu-server "
             "docker exec -i paude-my-session %S /pvc/workspace"
         )
-        assert transport is not None
+        assert isinstance(transport, SshTransport)
         assert transport.host == "user@gpu-server"
         assert transport.port == 2222
         assert transport.key == "/home/user/.ssh/id_ed25519"

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -42,7 +42,9 @@ class TestDetectPlatformTransport:
         assert _detect_platform(transport) == "linux/amd64"
 
     @patch("platform.machine", return_value="x86_64")
-    def test_transport_failure_falls_back_to_local(self, mock_machine: object) -> None:
+    def test_transport_failure_falls_back_to_local(
+        self, mock_machine: MagicMock
+    ) -> None:
         transport = MagicMock()
         transport.machine.side_effect = RuntimeError("could not determine arch")
         assert _detect_platform(transport) == "linux/amd64"

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,231 @@
+"""Tests for the container-label codec and the typed spec it produces.
+
+These pin the parse that ``paude upgrade``, ``paude backup`` and ``paude list``
+all used to implement separately, including the two distinctions that were
+easy to lose when it was written three times: absent-vs-empty for the domains
+label, and raw-vs-derived for credential providers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from paude.backends.labels import (
+    PAUDE_LABEL_AGENT,
+    PAUDE_LABEL_AGENT_PROVIDERS,
+    PAUDE_LABEL_CREATED,
+    PAUDE_LABEL_DOMAINS,
+    PAUDE_LABEL_GPU,
+    PAUDE_LABEL_OTEL_ENDPOINT,
+    PAUDE_LABEL_PROVIDER,
+    PAUDE_LABEL_PROVIDERS,
+    PAUDE_LABEL_PROXY_IMAGE,
+    PAUDE_LABEL_VERSION,
+    PAUDE_LABEL_WORKSPACE,
+    PAUDE_LABEL_YOLO,
+    SessionSpec,
+    decode_json_label,
+    encode_agent_providers,
+    encode_json_label,
+    encode_providers,
+    normalize_agent_providers,
+    parse_agent_providers_label,
+    parse_domains_label,
+    parse_providers_label,
+    read_labels,
+    spec_from_labels,
+    workspace_from_labels,
+)
+from paude.backends.session_env import encode_path
+
+
+class TestSpecFromLabels:
+    """Reading a session's declared configuration back out of its labels."""
+
+    def test_empty_labels_give_the_documented_defaults(self) -> None:
+        assert spec_from_labels({}) == SessionSpec()
+
+    def test_reads_every_label(self) -> None:
+        spec = spec_from_labels(
+            {
+                PAUDE_LABEL_AGENT: "codex",
+                PAUDE_LABEL_PROVIDER: "openai",
+                PAUDE_LABEL_AGENT_PROVIDERS: encode_agent_providers(
+                    [("codex", "openai"), ("claude", "vertex")]
+                ),
+                PAUDE_LABEL_PROVIDERS: encode_providers(["openai", "vertex"]),
+                PAUDE_LABEL_GPU: "all",
+                PAUDE_LABEL_YOLO: "1",
+                PAUDE_LABEL_OTEL_ENDPOINT: "http://otel:4317",
+                PAUDE_LABEL_DOMAINS: "github.com,pypi.org",
+                PAUDE_LABEL_PROXY_IMAGE: "paude-proxy:1.2.3",
+            }
+        )
+        assert spec == SessionSpec(
+            agent="codex",
+            provider="openai",
+            agent_providers=[("codex", "openai"), ("claude", "vertex")],
+            credential_providers=["openai", "vertex"],
+            gpu="all",
+            yolo=True,
+            otel_endpoint="http://otel:4317",
+            allowed_domains=["github.com", "pypi.org"],
+            proxy_image="paude-proxy:1.2.3",
+        )
+
+    @pytest.mark.parametrize(
+        ("label", "attribute"),
+        [
+            (PAUDE_LABEL_GPU, "gpu"),
+            (PAUDE_LABEL_OTEL_ENDPOINT, "otel_endpoint"),
+            (PAUDE_LABEL_PROXY_IMAGE, "proxy_image"),
+            (PAUDE_LABEL_PROVIDER, "provider"),
+        ],
+    )
+    def test_empty_optional_labels_read_back_as_none(
+        self, label: str, attribute: str
+    ) -> None:
+        """An empty value is normalized to None so it never reaches a manifest."""
+        assert getattr(spec_from_labels({label: ""}), attribute) is None
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [("1", True), ("0", False), ("true", False), ("", False)],
+    )
+    def test_yolo_is_only_the_literal_one(self, value: str, expected: bool) -> None:
+        assert spec_from_labels({PAUDE_LABEL_YOLO: value}).yolo is expected
+
+    def test_credential_providers_are_the_raw_label(self) -> None:
+        """No derive-from-composition fallback: the spec records what was declared."""
+        spec = spec_from_labels(
+            {
+                PAUDE_LABEL_AGENT: "claude",
+                PAUDE_LABEL_AGENT_PROVIDERS: encode_agent_providers(
+                    [("claude", "vertex")]
+                ),
+            }
+        )
+        assert spec.credential_providers == []
+
+
+class TestDomainsLabel:
+    """Absent and empty mean different things and must not collapse."""
+
+    def test_absent_label_is_none(self) -> None:
+        """A legacy session predating the always-on proxy; callers expand it."""
+        assert parse_domains_label(None) is None
+        assert spec_from_labels({}).allowed_domains is None
+
+    def test_empty_label_is_an_empty_list(self) -> None:
+        """A proxy session that allows nothing."""
+        assert parse_domains_label("") == []
+        assert spec_from_labels({PAUDE_LABEL_DOMAINS: ""}).allowed_domains == []
+
+    def test_comma_separated_values_split(self) -> None:
+        assert parse_domains_label("a.com,b.org") == ["a.com", "b.org"]
+
+
+class TestWorkspaceLabel:
+    """Decoded on demand, with no default applied here."""
+
+    def test_absent_label_is_none(self) -> None:
+        assert workspace_from_labels({}) is None
+
+    def test_empty_label_is_none(self) -> None:
+        assert workspace_from_labels({PAUDE_LABEL_WORKSPACE: ""}) is None
+
+    def test_round_trips_an_encoded_path(self) -> None:
+        workspace = Path("/home/user/my project")
+        labels = {PAUDE_LABEL_WORKSPACE: encode_path(workspace, url_safe=True)}
+        assert workspace_from_labels(labels) == workspace
+
+
+class TestJsonLabelCodec:
+    """Structured labels are base64 JSON, with a raw-JSON fallback for legacy."""
+
+    def test_agent_providers_round_trip(self) -> None:
+        specs = [("claude", "vertex"), ("codex", "chatgpt")]
+        assert parse_agent_providers_label(encode_agent_providers(specs)) == specs
+
+    def test_providers_round_trip(self) -> None:
+        providers = ["vertex", "chatgpt"]
+        assert parse_providers_label(encode_providers(providers)) == providers
+
+    def test_providers_are_deduplicated(self) -> None:
+        raw = encode_providers(["vertex", "chatgpt", "vertex"])
+        assert parse_providers_label(raw) == ["vertex", "chatgpt"]
+
+    def test_legacy_raw_json_still_decodes(self) -> None:
+        """Labels predating the base64 encoding were plain JSON."""
+        assert decode_json_label('[["claude", "vertex"]]') == [["claude", "vertex"]]
+        assert parse_agent_providers_label('[["claude", "vertex"]]') == [
+            ("claude", "vertex")
+        ]
+
+    @pytest.mark.parametrize(
+        "raw", ["", "not-base64-or-json", encode_json_label("nope")]
+    )
+    def test_unparseable_labels_are_empty_not_fatal(self, raw: str) -> None:
+        """A container we cannot fully read is still a container we can list."""
+        assert parse_agent_providers_label(raw) == []
+        assert parse_providers_label(raw) == []
+
+    def test_malformed_pairs_are_skipped(self) -> None:
+        raw = encode_json_label([["claude", "vertex"], ["codex"], "codex", [1, 2]])
+        assert parse_agent_providers_label(raw) == [("claude", "vertex")]
+
+
+class TestNormalizeAgentProviders:
+    """The manifest-side normalizer is strict where the label parse is lenient."""
+
+    def test_none_and_empty_are_empty(self) -> None:
+        assert normalize_agent_providers(None) == []
+        assert normalize_agent_providers([]) == []
+
+    def test_json_lists_become_tuples(self) -> None:
+        assert normalize_agent_providers([["claude", "vertex"]]) == [
+            ("claude", "vertex")
+        ]
+
+    def test_tuples_pass_through(self) -> None:
+        assert normalize_agent_providers([("claude", "vertex")]) == [
+            ("claude", "vertex")
+        ]
+
+    @pytest.mark.parametrize(
+        "value",
+        [[["claude"]], ["claude"], [[1, 2]], [["a", "b", "c"]], "claude", {}],
+        ids=["short-pair", "bare-string", "non-strings", "long-pair", "string", "dict"],
+    )
+    def test_malformed_input_raises(self, value: object) -> None:
+        """A manifest is a contract; its loader translates this into its own error."""
+        with pytest.raises(ValueError, match="agent_providers"):
+            normalize_agent_providers(value)
+
+
+class TestReadLabels:
+    """The whole of one container fetch."""
+
+    def test_reads_spec_and_identity_together(self) -> None:
+        workspace = Path("/home/user/project")
+        view = read_labels(
+            {
+                PAUDE_LABEL_AGENT: "claude",
+                PAUDE_LABEL_WORKSPACE: encode_path(workspace, url_safe=True),
+                PAUDE_LABEL_CREATED: "2026-01-01T00:00:00+00:00",
+                PAUDE_LABEL_VERSION: "0.20.2",
+            }
+        )
+        assert view.spec.agent == "claude"
+        assert view.workspace == workspace
+        assert view.created_at == "2026-01-01T00:00:00+00:00"
+        assert view.version == "0.20.2"
+
+    def test_bare_container_reads_back_empty(self) -> None:
+        view = read_labels({})
+        assert view.spec == SessionSpec()
+        assert view.workspace is None
+        assert view.created_at == ""
+        assert view.version is None

--- a/tests/test_legacy_state.py
+++ b/tests/test_legacy_state.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, call
 import pytest
 
 from paude.agents import get_agents
-from paude.cli.upgrade_persistence import (
+from paude.backends.podman.legacy_state import (
     _MIGRATE_SCRIPT,
     migrate_legacy_state,
     persistent_state_paths,

--- a/tests/test_podman_proxy.py
+++ b/tests/test_podman_proxy.py
@@ -157,10 +157,9 @@ class TestProxyManagerFixedIp:
         assert nname == "paude-net-test-session"
         assert proxy_ip == "10.89.0.2"
 
-    @patch("paude.backends.podman.proxy.time.sleep")
     @patch("paude.backends.podman.proxy.get_podman_machine_dns")
     def test_create_proxy_docker_returns_none_ip_when_no_gateway(
-        self, mock_dns: MagicMock, mock_sleep: MagicMock
+        self, mock_dns: MagicMock
     ) -> None:
         """On Docker, create_proxy returns None IP (hostname fallback is ok)."""
         mock_dns.return_value = None
@@ -180,10 +179,9 @@ class TestProxyManagerFixedIp:
         assert proxy_ip is None
         mock_network.remove_network.assert_not_called()
 
-    @patch("paude.backends.podman.proxy.time.sleep")
     @patch("paude.backends.podman.proxy.get_podman_machine_dns")
     def test_create_proxy_raises_on_podman_when_ip_unavailable(
-        self, mock_dns: MagicMock, mock_sleep: MagicMock
+        self, mock_dns: MagicMock
     ) -> None:
         """On Podman, create_proxy aborts and removes the network if no IP."""
         mock_dns.return_value = None
@@ -235,8 +233,7 @@ class TestProxyManagerFixedIp:
 class TestResolveProxyIpGuard:
     """Direct tests for the shared _resolve_proxy_ip reachability guard."""
 
-    @patch("paude.backends.podman.proxy.time.sleep")
-    def test_raises_and_removes_network_when_owned(self, mock_sleep: MagicMock) -> None:
+    def test_raises_and_removes_network_when_owned(self) -> None:
         """On disable-dns with no IP, raise and remove a just-created network."""
         mock_runner = _make_mock_runner()
         mock_network = MagicMock()
@@ -250,8 +247,7 @@ class TestResolveProxyIpGuard:
 
         mock_network.remove_network.assert_called_once_with("paude-net-test")
 
-    @patch("paude.backends.podman.proxy.time.sleep")
-    def test_raises_without_removing_live_network(self, mock_sleep: MagicMock) -> None:
+    def test_raises_without_removing_live_network(self) -> None:
         """A live network is not torn down on a transient inspect failure."""
         mock_runner = _make_mock_runner()
         mock_network = MagicMock()
@@ -265,10 +261,7 @@ class TestResolveProxyIpGuard:
 
         mock_network.remove_network.assert_not_called()
 
-    @patch("paude.backends.podman.proxy.time.sleep")
-    def test_returns_none_without_raising_when_dns_enabled(
-        self, mock_sleep: MagicMock
-    ) -> None:
+    def test_returns_none_without_raising_when_dns_enabled(self) -> None:
         """With DNS the hostname fallback is legitimate, so None passes through."""
         mock_runner = _make_mock_runner("docker")
         mock_network = MagicMock()
@@ -296,10 +289,9 @@ class TestResolveProxyIpGuard:
         assert result == "10.89.0.2"
         mock_network.remove_network.assert_not_called()
 
-    @patch("paude.backends.podman.proxy.time.sleep")
     @patch("paude.backends.podman.proxy._get_host_dns")
     def test_start_if_needed_raises_on_podman_when_ip_unavailable(
-        self, mock_dns: MagicMock, mock_sleep: MagicMock
+        self, mock_dns: MagicMock
     ) -> None:
         """Recreating a missing proxy aborts without IP, but leaves the
         network alone since the session's agent container may still be
@@ -329,10 +321,9 @@ class TestResolveProxyIpGuard:
         ]
         assert not create_calls
 
-    @patch("paude.backends.podman.proxy.time.sleep")
     @patch("paude.backends.podman.proxy._get_host_dns")
     def test_update_domains_raises_on_podman_when_ip_unavailable(
-        self, mock_dns: MagicMock, mock_sleep: MagicMock
+        self, mock_dns: MagicMock
     ) -> None:
         """update_domains aborts without tearing down the live network."""
         mock_dns.return_value = None
@@ -1109,10 +1100,9 @@ class TestSourceIpFiltering:
         env_vals = [call_args[i + 1] for i in env_indices]
         assert "PAUDE_PROXY_ALLOWED_CLIENTS=10.89.0.3" in env_vals
 
-    @patch("paude.backends.podman.proxy.time.sleep")
     @patch("paude.backends.podman.proxy.get_podman_machine_dns")
     def test_create_proxy_no_allowed_clients_when_no_gateway(
-        self, mock_dns: MagicMock, mock_sleep: MagicMock
+        self, mock_dns: MagicMock
     ) -> None:
         """create_proxy omits allowed_clients when gateway is unavailable.
 

--- a/tests/test_podman_session.py
+++ b/tests/test_podman_session.py
@@ -19,6 +19,7 @@ from paude.backends.labels import (
     PAUDE_LABEL_PROXY_IMAGE,
     PAUDE_LABEL_SESSION,
     PAUDE_LABEL_WORKSPACE,
+    encode_agent_providers,
 )
 from paude.backends.podman import (
     PodmanBackend,
@@ -1704,6 +1705,32 @@ class TestBuildSessionFromContainer:
         assert session.workspace == Path("/")
         assert session.status == "stopped"
 
+    def test_credential_providers_are_the_raw_label(self) -> None:
+        """A listing reports what a session declared, not what its agents imply.
+
+        get_session_credential_providers derives providers for a session
+        predating the providers label; build_session_from_container must not,
+        or `paude list` would show credentials that were never provisioned.
+        """
+        mock_runner = MagicMock()
+        mock_runner.container_exists.return_value = False
+        container = {
+            "Id": "abc123",
+            "Labels": {
+                PAUDE_LABEL_SESSION: "my-session",
+                PAUDE_LABEL_AGENT: "claude",
+                PAUDE_LABEL_AGENT_PROVIDERS: encode_agent_providers(
+                    [("claude", "vertex")]
+                ),
+            },
+            "State": "exited",
+        }
+
+        session = build_session_from_container("my-session", container, mock_runner)
+
+        assert session.agent_providers == [("claude", "vertex")]
+        assert session.credential_providers == []
+
     def test_includes_proxy_health_check(self) -> None:
         """Status is degraded when proxy is expected but missing."""
         mock_runner = MagicMock()
@@ -2042,6 +2069,29 @@ class TestSessionLabelPersistence:
             "anthropic",
             "openai",
         ]
+        # The derivation used to re-fetch the labels it was already reading.
+        # One container fetch is one SSH round trip on a --host session.
+        assert runner.list_containers.call_count == 1
+
+    def test_legacy_session_without_a_composition_label_expands_bundled_agents(
+        self,
+    ) -> None:
+        """The no-agent-providers branch is not interchangeable with the other.
+
+        A session created before multi-agent support records only its primary
+        agent. Resolving that through get_agent_composition pulls in the
+        agent's bundled_agents; deriving the composition from the (empty)
+        agent-providers list instead would come back with one agent where
+        three belong, and the rebuild would install the wrong toolchain.
+        """
+        runner = MagicMock()
+        runner.list_containers.return_value = [
+            {"Labels": {PAUDE_LABEL_SESSION: "s", PAUDE_LABEL_AGENT: "gascity"}}
+        ]
+
+        composition = get_session_composition(runner, "s")
+
+        assert composition.names == ["gascity", "claude", "gemini"]
 
     def test_legacy_json_composition_labels_still_parse(self) -> None:
         config = SessionConfig(

--- a/tests/test_podman_session.py
+++ b/tests/test_podman_session.py
@@ -89,11 +89,6 @@ def _make_backend(
     from paude.backends.podman.proxy import PodmanProxyManager
 
     backend._proxy = PodmanProxyManager(runner, network)
-    # No-op CA distribution to avoid 30s polling timeouts in tests
-    # that don't test CA distribution. Tests in test_podman_proxy.py
-    # create their own PodmanProxyManager with proper mocks.
-    backend._proxy.distribute_ca_cert = MagicMock()  # type: ignore[method-assign]
-    backend._proxy._redistribute_ca_if_needed = MagicMock()  # type: ignore[method-assign]
     engine = mock_runner.engine if mock_runner is not None else backend._engine
     backend._setup = SessionSetup(runner, engine)
     backend._port_forward = MagicMock()
@@ -1189,14 +1184,12 @@ class TestPodmanBackendCreateSessionWithProxy:
         assert call_kwargs["dns"] == ["10.89.0.2"]
         assert call_kwargs["network"] == "paude-net-dns-session"
 
-    @patch("paude.backends.podman.proxy.time.sleep")
     @patch("paude.backends.podman.proxy.get_podman_machine_dns")
     @patch("paude.backends.podman.backend.ContainerRunner")
     def test_create_session_no_dns_false_when_no_proxy_ip(
         self,
         mock_runner_class: MagicMock,
         mock_dns: MagicMock,
-        mock_sleep: MagicMock,
     ) -> None:
         """On Docker, the network keeps its plain name when the proxy IP
         cannot be determined: the DNS-enabled network makes the hostname

--- a/tests/test_podman_session.py
+++ b/tests/test_podman_session.py
@@ -36,6 +36,7 @@ from paude.backends.podman.session_setup import SessionSetup
 from paude.backends.proxy_config import ProxyCredentials
 from paude.backends.session_env import decode_path as _decode_path_raw
 from paude.backends.session_env import encode_path as _encode_path_raw
+from tests.fakes import make_backend
 
 
 def encode_path(path: Path) -> str:
@@ -46,53 +47,6 @@ def encode_path(path: Path) -> str:
 def decode_path(encoded: str) -> Path:
     """Decode path with url_safe=True (matches Podman backend usage)."""
     return _decode_path_raw(encoded, url_safe=True)
-
-
-def _make_backend(
-    mock_runner: MagicMock | None = None,
-    mock_network_manager: MagicMock | None = None,
-    mock_volume_manager: MagicMock | None = None,
-    engine_binary: str = "podman",
-) -> PodmanBackend:
-    """Create a PodmanBackend with mocked runner, network, and volume manager."""
-    backend = PodmanBackend()
-    if mock_runner is not None:
-        # Ensure engine attributes are set for ProxyRunner compatibility
-        if not hasattr(mock_runner.engine, "binary") or isinstance(
-            mock_runner.engine.binary, MagicMock
-        ):
-            is_podman = engine_binary != "docker"
-            mock_runner.engine.binary = engine_binary
-            mock_runner.engine.is_podman = is_podman
-            mock_runner.engine.supports_multi_network_create = is_podman
-            mock_runner.engine.default_bridge_network = (
-                "podman" if is_podman else "bridge"
-            )
-            mock_runner.engine.is_remote = False
-            mock_runner.engine.run.return_value = MagicMock(
-                returncode=0, stdout="", stderr=""
-            )
-        backend._runner = mock_runner
-        backend._engine = mock_runner.engine
-    if mock_network_manager is not None:
-        # Ensure get_network_gateway returns a valid IP for proxy IP derivation
-        if not hasattr(mock_network_manager, "_mock_children") or isinstance(
-            mock_network_manager.get_network_gateway.return_value, MagicMock
-        ):
-            mock_network_manager.get_network_gateway.return_value = "10.89.0.1"
-        backend._network_manager = mock_network_manager
-    # Always mock volume manager to prevent real podman calls
-    backend._volume_manager = mock_volume_manager or MagicMock()
-    # Rebuild proxy manager with the mocked runner and network
-    runner = mock_runner or backend._runner
-    network = mock_network_manager or backend._network_manager
-    from paude.backends.podman.proxy import PodmanProxyManager
-
-    backend._proxy = PodmanProxyManager(runner, network)
-    engine = mock_runner.engine if mock_runner is not None else backend._engine
-    backend._setup = SessionSetup(runner, engine)
-    backend._port_forward = MagicMock()
-    return backend
 
 
 class TestHelperFunctions:
@@ -157,7 +111,7 @@ def _make_create_session_backend(
     Mocks _gather_proxy_credentials and _proxy.create_proxy so tests
     don't need proxy_image or real credentials.
     """
-    backend = _make_backend(mock_runner, MagicMock(), mock_volume)
+    backend = make_backend(mock_runner, MagicMock(), mock_volume)
     backend._setup.gather_proxy_credentials = MagicMock(return_value={})  # type: ignore[method-assign]
     backend._proxy.create_proxy = MagicMock(  # type: ignore[method-assign]
         return_value=("paude-net-test", "10.89.0.2")
@@ -180,7 +134,7 @@ class TestPodmanBackendStartNoAttach:
         mock_runner.container_running.return_value = False
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
         backend._setup = MagicMock()
 
         backend.start_session_no_attach("test-session")
@@ -198,7 +152,7 @@ class TestPodmanBackendStartNoAttach:
         mock_runner.container_running.return_value = True
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
         backend._setup = MagicMock()
 
         backend.start_session_no_attach("test-session")
@@ -473,7 +427,7 @@ class TestPodmanBackendDeleteSession:
         mock_runner_class.return_value = mock_runner
         mock_volume = MagicMock()
 
-        backend = _make_backend(mock_runner, MagicMock(), mock_volume)
+        backend = make_backend(mock_runner, MagicMock(), mock_volume)
 
         backend.delete_session("my-session", confirm=True)
 
@@ -497,7 +451,7 @@ class TestPodmanBackendDeleteSession:
         mock_runner.container_running.return_value = True
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner, MagicMock())
+        backend = make_backend(mock_runner, MagicMock())
 
         backend.delete_session("running-session", confirm=True)
 
@@ -514,7 +468,7 @@ class TestPodmanBackendDeleteSession:
         mock_volume = MagicMock()
         mock_volume.volume_exists.return_value = False
 
-        backend = _make_backend(mock_runner, MagicMock(), mock_volume)
+        backend = make_backend(mock_runner, MagicMock(), mock_volume)
 
         with pytest.raises(SessionNotFoundError) as excinfo:
             backend.delete_session("nonexistent", confirm=True)
@@ -531,7 +485,7 @@ class TestPodmanBackendDeleteSession:
         mock_volume = MagicMock()
         mock_volume.volume_exists.return_value = True
 
-        backend = _make_backend(mock_runner, MagicMock(), mock_volume)
+        backend = make_backend(mock_runner, MagicMock(), mock_volume)
 
         backend.delete_session("orphaned", confirm=True)
 
@@ -553,7 +507,7 @@ class TestPodmanBackendDeleteSession:
         )
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner, MagicMock())
+        backend = make_backend(mock_runner, MagicMock())
 
         with pytest.raises(RuntimeError, match="Failed to remove container"):
             backend.delete_session("stuck-session", confirm=True)
@@ -574,7 +528,7 @@ class TestPodmanBackendDeleteSession:
             "Failed to remove volume"
         )
 
-        backend = _make_backend(mock_runner, MagicMock(), mock_volume)
+        backend = make_backend(mock_runner, MagicMock(), mock_volume)
 
         with pytest.raises(RuntimeError, match="Failed to remove volume"):
             backend.delete_session("vol-stuck", confirm=True)
@@ -598,7 +552,7 @@ class TestPodmanBackendStartSession:
         mock_runner.attach_container.return_value = 0
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
 
         exit_code = backend.start_session("my-session")
 
@@ -624,7 +578,7 @@ class TestPodmanBackendStartSession:
         mock_runner.exec_in_container.return_value = MagicMock(returncode=0)
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
 
         exit_code = backend.start_session("running-session")
 
@@ -645,7 +599,7 @@ class TestPodmanBackendStartSession:
         mock_runner.get_container_state.return_value = "running"
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
         backend.connect_session = MagicMock(return_value=0)  # type: ignore[method-assign]
 
         exit_code = backend.start_session(
@@ -691,7 +645,7 @@ class TestPodmanBackendStopSession:
         mock_runner.container_running.return_value = True
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
 
         backend.stop_session("my-session")
 
@@ -709,7 +663,7 @@ class TestPodmanBackendStopSession:
         mock_runner.container_running.return_value = False
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
 
         backend.stop_session("stopped-session")
 
@@ -722,7 +676,7 @@ class TestPodmanBackendStopSession:
         mock_runner.container_exists.return_value = False
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
 
         # Should not raise, just print and return
         backend.stop_session("nonexistent")
@@ -828,7 +782,7 @@ class TestPodmanBackendConnectSession:
         ]
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
 
         with patch.object(backend._setup, "sync_host_config"):
             exit_code = backend.connect_session("my-session")
@@ -1097,7 +1051,7 @@ class TestPodmanBackendCreateSessionWithProxy:
         mock_dns.return_value = None
         mock_network = MagicMock()
 
-        backend = _make_backend(mock_runner, mock_network)
+        backend = make_backend(mock_runner, mock_network)
 
         config = SessionConfig(
             name="my-session",
@@ -1114,7 +1068,7 @@ class TestPodmanBackendCreateSessionWithProxy:
         )
 
         # Proxy container should be created via engine.run
-        engine_calls = [str(c) for c in mock_runner.engine.run.call_args_list]
+        engine_calls = [" ".join(c) for c in backend.engine.transport.commands]
         assert any("create" in c for c in engine_calls)
 
         # Main container should be on the internal network
@@ -1139,7 +1093,7 @@ class TestPodmanBackendCreateSessionWithProxy:
         mock_runner_class.return_value = mock_runner
         mock_dns.return_value = None
 
-        backend = _make_backend(mock_runner, MagicMock())
+        backend = make_backend(mock_runner, MagicMock())
 
         config = SessionConfig(
             name="my-session",
@@ -1169,7 +1123,7 @@ class TestPodmanBackendCreateSessionWithProxy:
         mock_network = MagicMock()
         mock_network.get_network_gateway.return_value = "10.89.0.1"
 
-        backend = _make_backend(mock_runner, mock_network)
+        backend = make_backend(mock_runner, mock_network)
 
         config = SessionConfig(
             name="dns-session",
@@ -1203,7 +1157,7 @@ class TestPodmanBackendCreateSessionWithProxy:
         mock_network = MagicMock()
         mock_network.get_network_gateway.return_value = None
 
-        backend = _make_backend(mock_runner, mock_network, engine_binary="docker")
+        backend = make_backend(mock_runner, mock_network, engine_binary="docker")
 
         config = SessionConfig(
             name="no-ip-session",
@@ -1232,7 +1186,7 @@ class TestPodmanBackendCreateSessionWithProxy:
         mock_network = MagicMock()
         mock_volume = MagicMock()
 
-        backend = _make_backend(mock_runner, mock_network, mock_volume)
+        backend = make_backend(mock_runner, mock_network, mock_volume)
 
         config = SessionConfig(
             name="my-session",
@@ -1270,12 +1224,12 @@ class TestPodmanBackendStartSessionWithProxy:
         mock_runner.attach_container.return_value = 0
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
 
         backend.start_session("my-session")
 
         # Proxy should be started via engine.run
-        engine_calls = [str(c) for c in mock_runner.engine.run.call_args_list]
+        engine_calls = [" ".join(c) for c in backend.engine.transport.commands]
         assert any("start" in c for c in engine_calls)
         mock_runner.start_container.assert_called_once_with("paude-my-session")
 
@@ -1294,7 +1248,7 @@ class TestPodmanBackendStartSessionWithProxy:
         mock_runner.attach_container.return_value = 0
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
 
         backend.start_session("my-session")
 
@@ -1356,7 +1310,7 @@ class TestPodmanBackendStopSessionWithProxy:
         mock_runner.container_running.return_value = True
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
 
         backend.stop_session("my-session")
 
@@ -1379,7 +1333,7 @@ class TestPodmanBackendDeleteSessionWithProxy:
         mock_runner_class.return_value = mock_runner
         mock_network = MagicMock()
 
-        backend = _make_backend(mock_runner, mock_network)
+        backend = make_backend(mock_runner, mock_network)
 
         backend.delete_session("my-session", confirm=True)
 
@@ -1422,7 +1376,7 @@ class TestProxyHealthCheck:
         )
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
         sessions = backend.list_sessions()
 
         assert len(sessions) == 1
@@ -1453,7 +1407,7 @@ class TestProxyHealthCheck:
         )
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
         sessions = backend.list_sessions()
 
         assert len(sessions) == 1
@@ -1482,7 +1436,7 @@ class TestProxyHealthCheck:
         mock_runner.container_running.return_value = True
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
         sessions = backend.list_sessions()
 
         assert len(sessions) == 1
@@ -1507,7 +1461,7 @@ class TestProxyHealthCheck:
         ]
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
         sessions = backend.list_sessions()
 
         assert len(sessions) == 1
@@ -1536,7 +1490,7 @@ class TestProxyHealthCheck:
         ]
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
         session = backend.get_session("my-session")
 
         assert session is not None
@@ -1576,11 +1530,11 @@ class TestProxyRecreation:
         mock_runner_class.return_value = mock_runner
         mock_network = MagicMock()
 
-        backend = _make_backend(mock_runner, mock_network)
+        backend = make_backend(mock_runner, mock_network)
         backend.start_session("my-session")
 
         # Proxy should be recreated via engine.run (create + start)
-        engine_calls = [str(c) for c in mock_runner.engine.run.call_args_list]
+        engine_calls = [" ".join(c) for c in backend.engine.transport.commands]
         assert any("create" in c for c in engine_calls)
         assert any("start" in c for c in engine_calls)
 
@@ -1609,7 +1563,7 @@ class TestProxyRecreation:
         ]
         mock_runner_class.return_value = mock_runner
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
         backend.start_session("my-session")
 
         mock_runner.create_session_proxy.assert_not_called()
@@ -1649,11 +1603,11 @@ class TestProxyRecreation:
         mock_runner_class.return_value = mock_runner
         mock_network = MagicMock()
 
-        backend = _make_backend(mock_runner, mock_network)
+        backend = make_backend(mock_runner, mock_network)
         backend.connect_session("my-session")
 
         # Proxy should be recreated via engine.run (create + start)
-        engine_calls = [str(c) for c in mock_runner.engine.run.call_args_list]
+        engine_calls = [" ".join(c) for c in backend.engine.transport.commands]
         assert any("create" in c for c in engine_calls)
         assert any("start" in c for c in engine_calls)
 
@@ -1786,7 +1740,7 @@ class TestPodmanBackendSyncHostConfig:
         mock_runner.engine.run.return_value = MagicMock(
             returncode=0, stdout="", stderr=""
         )
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
         backend._engine = mock_runner.engine
 
         with patch("paude.backends.sync_base.Path.home", return_value=tmp_path):
@@ -1814,7 +1768,7 @@ class TestPodmanBackendSyncHostConfig:
         mock_runner.engine.run.return_value = MagicMock(
             returncode=0, stdout="", stderr=""
         )
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
         backend._engine = mock_runner.engine
 
         with patch("paude.backends.sync_base.Path.home", return_value=tmp_path):
@@ -1840,7 +1794,7 @@ class TestPodmanBackendSyncHostConfig:
         mock_runner.engine.run.return_value = MagicMock(
             returncode=0, stdout="", stderr=""
         )
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
         backend._engine = mock_runner.engine
 
         with patch("paude.backends.sync_base.Path.home", return_value=tmp_path):
@@ -1867,7 +1821,7 @@ class TestPodmanBackendSyncHostConfig:
         mock_runner.engine.run.return_value = MagicMock(
             returncode=0, stdout="", stderr=""
         )
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
         backend._engine = mock_runner.engine
 
         with patch("paude.backends.sync_base.Path.home", return_value=tmp_path):
@@ -1901,7 +1855,7 @@ class TestPodmanBackendSyncHostConfig:
             return MagicMock(returncode=0, stdout="", stderr="")
 
         mock_runner.engine.run.side_effect = run_side_effect
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
         backend._engine = mock_runner.engine
 
         with patch("paude.backends.sync_base.Path.home", return_value=tmp_path):
@@ -1930,7 +1884,7 @@ class TestPodmanBackendSyncHostConfig:
             }
         ]
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
         backend._engine = MagicMock()
         backend._engine.is_remote = False
         backend._engine.supports_secrets = True
@@ -1958,7 +1912,7 @@ class TestPodmanBackendSyncHostConfig:
             }
         ]
 
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
         backend._engine = MagicMock()
         backend._engine.is_remote = False
         backend._engine.run.return_value = MagicMock(returncode=0, stdout="", stderr="")
@@ -1982,7 +1936,7 @@ class TestPodmanPortUrls:
         mock_runner.engine.run.return_value = MagicMock(
             returncode=0, stdout="", stderr=""
         )
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
 
         mock_agent = MagicMock()
         mock_agent.config.exposed_ports = [(18789, 18789)]
@@ -2001,7 +1955,7 @@ class TestPodmanPortUrls:
         mock_runner.engine.run.return_value = MagicMock(
             returncode=0, stdout="", stderr=""
         )
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
 
         mock_agent = MagicMock()
         mock_agent.config.exposed_ports = []
@@ -2020,7 +1974,7 @@ class TestPodmanPortUrls:
         mock_runner.engine.run.return_value = MagicMock(
             returncode=0, stdout="", stderr=""
         )
-        backend = _make_backend(mock_runner)
+        backend = make_backend(mock_runner)
 
         mock_agent = MagicMock()
         mock_agent.config.exposed_ports = [(18789, 18789)]
@@ -2119,7 +2073,7 @@ class TestCollectForwardPorts:
     def test_collect_forward_ports_merges_and_dedups(self) -> None:
         """User forwards take precedence over agent ports on host-bind conflict."""
         runner = MagicMock()
-        backend = _make_backend(mock_runner=runner)
+        backend = make_backend(runner=runner)
         agent = MagicMock()
         agent.config.exposed_ports = [(18789, 18789), (8372, 8372)]
 
@@ -2139,7 +2093,7 @@ class TestCollectForwardPorts:
     def test_collect_forward_ports_agent_only(self) -> None:
         """Without CLI forwards, only agent-declared ports are forwarded."""
         runner = MagicMock()
-        backend = _make_backend(mock_runner=runner)
+        backend = make_backend(runner=runner)
         agent = MagicMock()
         agent.config.exposed_ports = [(18789, 18789)]
 
@@ -2150,7 +2104,7 @@ class TestCollectForwardPorts:
     def test_collect_forward_ports_none_when_nothing_declared(self) -> None:
         """No CLI forwards and no agent ports yields an empty list."""
         runner = MagicMock()
-        backend = _make_backend(mock_runner=runner)
+        backend = make_backend(runner=runner)
         agent = MagicMock()
         agent.config.exposed_ports = []
 

--- a/tests/test_podman_session.py
+++ b/tests/test_podman_session.py
@@ -36,7 +36,7 @@ from paude.backends.podman.session_setup import SessionSetup
 from paude.backends.proxy_config import ProxyCredentials
 from paude.backends.session_env import decode_path as _decode_path_raw
 from paude.backends.session_env import encode_path as _encode_path_raw
-from tests.fakes import make_backend
+from tests.fakes import make_backend, recorded_commands
 
 
 def encode_path(path: Path) -> str:
@@ -1068,7 +1068,7 @@ class TestPodmanBackendCreateSessionWithProxy:
         )
 
         # Proxy container should be created via engine.run
-        engine_calls = [" ".join(c) for c in backend.engine.transport.commands]
+        engine_calls = [" ".join(c) for c in recorded_commands(backend.engine)]
         assert any("create" in c for c in engine_calls)
 
         # Main container should be on the internal network
@@ -1229,7 +1229,7 @@ class TestPodmanBackendStartSessionWithProxy:
         backend.start_session("my-session")
 
         # Proxy should be started via engine.run
-        engine_calls = [" ".join(c) for c in backend.engine.transport.commands]
+        engine_calls = [" ".join(c) for c in recorded_commands(backend.engine)]
         assert any("start" in c for c in engine_calls)
         mock_runner.start_container.assert_called_once_with("paude-my-session")
 
@@ -1534,7 +1534,7 @@ class TestProxyRecreation:
         backend.start_session("my-session")
 
         # Proxy should be recreated via engine.run (create + start)
-        engine_calls = [" ".join(c) for c in backend.engine.transport.commands]
+        engine_calls = [" ".join(c) for c in recorded_commands(backend.engine)]
         assert any("create" in c for c in engine_calls)
         assert any("start" in c for c in engine_calls)
 
@@ -1607,7 +1607,7 @@ class TestProxyRecreation:
         backend.connect_session("my-session")
 
         # Proxy should be recreated via engine.run (create + start)
-        engine_calls = [" ".join(c) for c in backend.engine.transport.commands]
+        engine_calls = [" ".join(c) for c in recorded_commands(backend.engine)]
         assert any("create" in c for c in engine_calls)
         assert any("start" in c for c in engine_calls)
 

--- a/tests/test_port_forward_proxy.py
+++ b/tests/test_port_forward_proxy.py
@@ -26,7 +26,8 @@ def _find_free_port() -> int:
     """Find an available TCP port."""
     with socket.socket() as s:
         s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
+        port: int = s.getsockname()[1]
+        return port
 
 
 def _cleanup_proxy(proc: subprocess.Popen[bytes]) -> None:

--- a/tests/test_session_rebuild.py
+++ b/tests/test_session_rebuild.py
@@ -1,0 +1,248 @@
+"""Tests for the rebuild steps shared by create and upgrade."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from paude.agents import get_agents
+from paude.backends.labels import SessionSpec
+from paude.cli.session_rebuild import (
+    ImageBuildError,
+    SessionImages,
+    build_session_images,
+    prepare_session_mounts,
+    session_config_from_spec,
+)
+from paude.config.models import PaudeConfig
+from paude.transport.config_sync import RemoteConfigPaths
+from paude.transport.ssh import SshTransport
+from tests.fakes import FakeTransport, make_engine
+
+WORKSPACE = Path("/home/user/project")
+
+
+def _composition(*names: str):
+    return get_agents(list(names) or ["claude"], providers={}, include_bundled=False)
+
+
+class TestBuildSessionImages:
+    """Which image is built, whether it is forced, and how failure is reported."""
+
+    def _manager(self) -> MagicMock:
+        manager = MagicMock()
+        manager.ensure_default_image.return_value = "paude:latest"
+        manager.ensure_custom_image.return_value = "paude-custom:latest"
+        manager.ensure_proxy_image.return_value = "paude-proxy:latest"
+        return manager
+
+    def _build(self, manager: MagicMock, **kwargs: object) -> SessionImages:
+        with patch("paude.container.ImageManager", return_value=manager) as cls:
+            images = build_session_images(
+                engine=make_engine(),
+                composition=_composition(),
+                config=kwargs.pop("config", None),  # type: ignore[arg-type]
+                workspace=WORKSPACE,
+                force_rebuild=bool(kwargs.pop("force_rebuild", False)),
+                platform=kwargs.pop("platform", None),  # type: ignore[arg-type]
+            )
+        self.manager_cls = cls
+        return images
+
+    def test_plain_config_builds_the_default_image(self) -> None:
+        manager = self._manager()
+
+        images = self._build(manager, config=PaudeConfig())
+
+        assert images == SessionImages(agent="paude:latest", proxy="paude-proxy:latest")
+        manager.ensure_custom_image.assert_not_called()
+
+    def test_customized_config_builds_a_custom_image(self) -> None:
+        manager = self._manager()
+        config = PaudeConfig(packages=["ripgrep"])
+
+        images = self._build(manager, config=config)
+
+        assert images.agent == "paude-custom:latest"
+        manager.ensure_custom_image.assert_called_once_with(
+            config, force_rebuild=False, workspace=WORKSPACE
+        )
+
+    def test_force_rebuild_reaches_both_builds(self) -> None:
+        manager = self._manager()
+
+        self._build(manager, force_rebuild=True)
+
+        manager.ensure_default_image.assert_called_once_with(force_rebuild=True)
+        manager.ensure_proxy_image.assert_called_once_with(force_rebuild=True)
+
+    def test_platform_reaches_the_image_manager(self) -> None:
+        manager = self._manager()
+
+        self._build(manager, platform="linux/amd64")
+
+        assert self.manager_cls.call_args.kwargs["platform"] == "linux/amd64"
+
+    def test_agent_build_failure_names_its_stage(self) -> None:
+        manager = self._manager()
+        cause = RuntimeError("boom")
+        manager.ensure_default_image.side_effect = cause
+
+        with pytest.raises(ImageBuildError) as exc:
+            self._build(manager)
+
+        assert exc.value.stage == "agent"
+        assert exc.value.cause is cause
+        # Reproduces upgrade's user-visible wording exactly.
+        assert str(exc.value) == "building the agent image failed: boom"
+        manager.ensure_proxy_image.assert_not_called()
+
+    def test_proxy_build_failure_names_its_stage(self) -> None:
+        manager = self._manager()
+        manager.ensure_proxy_image.side_effect = RuntimeError("no proxy")
+
+        with pytest.raises(ImageBuildError) as exc:
+            self._build(manager)
+
+        assert exc.value.stage == "proxy"
+        assert str(exc.value) == "building the proxy image failed: no proxy"
+
+
+class TestPrepareSessionMounts:
+    """Local engines copy configs in; SSH remotes bind-mount synced copies."""
+
+    def test_local_engine_skips_config_mounts_and_does_not_sync(self) -> None:
+        with (
+            patch("paude.mounts.build_mounts", return_value=["-v", "/a:/b"]) as build,
+            patch("paude.transport.config_sync.sync_configs_to_remote") as sync,
+        ):
+            result = prepare_session_mounts(
+                engine=make_engine(), composition=_composition()
+            )
+
+        assert result.mounts == ["-v", "/a:/b"]
+        assert result.remote_config is None
+        assert build.call_args.kwargs["include_config"] is False
+        sync.assert_not_called()
+
+    def test_ssh_remote_syncs_and_remaps(self) -> None:
+        remote = RemoteConfigPaths(remote_base="/tmp/cfg", path_map={"/a": "/r/a"})
+        engine = make_engine(transport=SshTransport("user@host"), is_remote=True)
+        with (
+            patch("paude.mounts.build_mounts", return_value=["-v", "/a:/b"]) as build,
+            patch(
+                "paude.transport.config_sync.sync_configs_to_remote",
+                return_value=remote,
+            ) as sync,
+            patch(
+                "paude.transport.config_sync.remap_mounts",
+                return_value=["-v", "/r/a:/b"],
+            ) as remap,
+        ):
+            result = prepare_session_mounts(engine=engine, composition=_composition())
+
+        assert build.call_args.kwargs["include_config"] is True
+        sync.assert_called_once()
+        remap.assert_called_once()
+        assert result.mounts == ["-v", "/r/a:/b"]
+        assert result.remote_config is remote
+
+    def test_remote_without_an_ssh_transport_does_not_sync(self) -> None:
+        """is_remote is transport-derived; only SSH has anything to sync."""
+        engine = make_engine(transport=FakeTransport(is_remote=True), is_remote=True)
+        with (
+            patch("paude.mounts.build_mounts", return_value=[]),
+            patch("paude.transport.config_sync.sync_configs_to_remote") as sync,
+        ):
+            result = prepare_session_mounts(engine=engine, composition=_composition())
+
+        assert result.remote_config is None
+        sync.assert_not_called()
+
+
+class TestSessionConfigFromSpec:
+    """The spec plus this build's outputs become a SessionConfig."""
+
+    def _config(self, spec: SessionSpec, **kwargs: object):
+        composition = kwargs.pop("composition", None) or _composition()
+        return session_config_from_spec(
+            spec,
+            name="s",
+            workspace=WORKSPACE,
+            composition=composition,  # type: ignore[arg-type]
+            images=SessionImages(agent="img:1", proxy="proxy:1"),
+            env={"FOO": "bar"},
+            mounts=["-v", "/a:/b"],
+            allowed_domains=["github.com"],
+            otel_ports=[4317],
+            **kwargs,  # type: ignore[arg-type]
+        )
+
+    def test_carries_the_spec_onto_the_config(self) -> None:
+        spec = SessionSpec(
+            agent="codex",
+            provider="openai",
+            credential_providers=["openai"],
+            gpu="all",
+            yolo=True,
+            otel_endpoint="http://otel:4317",
+        )
+
+        config = self._config(spec, composition=_composition("codex"))
+
+        assert config.agent == "codex"
+        assert config.provider == "openai"
+        assert config.credential_providers == ["openai"]
+        assert config.gpu == "all"
+        assert config.yolo is True
+        assert config.otel_endpoint == "http://otel:4317"
+        assert config.image == "img:1"
+        assert config.proxy_image == "proxy:1"
+        assert config.env == {"FOO": "bar"}
+        assert config.mounts == ["-v", "/a:/b"]
+        assert config.allowed_domains == ["github.com"]
+        assert config.otel_ports == [4317]
+
+    def test_agent_providers_come_from_the_composition(self) -> None:
+        """Not from the spec: an upgrade may have just changed the agent set."""
+        config = self._config(
+            SessionSpec(), composition=_composition("claude", "codex")
+        )
+
+        assert [name for name, _p in config.agent_providers] == ["claude", "codex"]
+
+    def test_credential_providers_fall_back_to_the_agents_own(self) -> None:
+        config = self._config(SessionSpec(), composition=_composition("claude"))
+
+        assert config.credential_providers == ["vertex"]
+
+    def test_recorded_proxy_image_is_the_fallback(self) -> None:
+        """A rebuild whose proxy build produced nothing keeps the old label."""
+        config = session_config_from_spec(
+            SessionSpec(proxy_image="recorded:1"),
+            name="s",
+            workspace=WORKSPACE,
+            composition=_composition(),
+            images=SessionImages(agent="img:1", proxy=None),
+            env={},
+            mounts=[],
+            allowed_domains=[],
+            otel_ports=[],
+        )
+
+        assert config.proxy_image == "recorded:1"
+
+    def test_args_workdir_and_reuse_volume_default_off(self) -> None:
+        config = self._config(SessionSpec())
+
+        assert config.args == []
+        assert config.workdir is None
+        assert config.reuse_volume is False
+
+    def test_create_passes_args_and_workdir(self) -> None:
+        config = self._config(SessionSpec(), args=["--verbose"], workdir=str(WORKSPACE))
+
+        assert config.args == ["--verbose"]
+        assert config.workdir == str(WORKSPACE)

--- a/tests/test_session_rebuild.py
+++ b/tests/test_session_rebuild.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from paude.agents import get_agents
+from paude.agents.base import AgentComposition
+from paude.backends.base import SessionConfig
 from paude.backends.labels import SessionSpec
 from paude.cli.session_rebuild import (
     ImageBuildError,
@@ -24,7 +26,7 @@ from tests.fakes import FakeTransport, make_engine
 WORKSPACE = Path("/home/user/project")
 
 
-def _composition(*names: str):
+def _composition(*names: str) -> AgentComposition:
     return get_agents(list(names) or ["claude"], providers={}, include_bundled=False)
 
 
@@ -38,23 +40,29 @@ class TestBuildSessionImages:
         manager.ensure_proxy_image.return_value = "paude-proxy:latest"
         return manager
 
-    def _build(self, manager: MagicMock, **kwargs: object) -> SessionImages:
+    def _build(
+        self,
+        manager: MagicMock,
+        *,
+        config: PaudeConfig | None = None,
+        force_rebuild: bool = False,
+        platform: str | None = None,
+    ) -> tuple[SessionImages, MagicMock]:
         with patch("paude.container.ImageManager", return_value=manager) as cls:
             images = build_session_images(
                 engine=make_engine(),
                 composition=_composition(),
-                config=kwargs.pop("config", None),  # type: ignore[arg-type]
+                config=config,
                 workspace=WORKSPACE,
-                force_rebuild=bool(kwargs.pop("force_rebuild", False)),
-                platform=kwargs.pop("platform", None),  # type: ignore[arg-type]
+                force_rebuild=force_rebuild,
+                platform=platform,
             )
-        self.manager_cls = cls
-        return images
+        return images, cls
 
     def test_plain_config_builds_the_default_image(self) -> None:
         manager = self._manager()
 
-        images = self._build(manager, config=PaudeConfig())
+        images, _ = self._build(manager, config=PaudeConfig())
 
         assert images == SessionImages(agent="paude:latest", proxy="paude-proxy:latest")
         manager.ensure_custom_image.assert_not_called()
@@ -63,7 +71,7 @@ class TestBuildSessionImages:
         manager = self._manager()
         config = PaudeConfig(packages=["ripgrep"])
 
-        images = self._build(manager, config=config)
+        images, _ = self._build(manager, config=config)
 
         assert images.agent == "paude-custom:latest"
         manager.ensure_custom_image.assert_called_once_with(
@@ -81,9 +89,9 @@ class TestBuildSessionImages:
     def test_platform_reaches_the_image_manager(self) -> None:
         manager = self._manager()
 
-        self._build(manager, platform="linux/amd64")
+        _, manager_cls = self._build(manager, platform="linux/amd64")
 
-        assert self.manager_cls.call_args.kwargs["platform"] == "linux/amd64"
+        assert manager_cls.call_args.kwargs["platform"] == "linux/amd64"
 
     def test_agent_build_failure_names_its_stage(self) -> None:
         manager = self._manager()
@@ -165,19 +173,26 @@ class TestPrepareSessionMounts:
 class TestSessionConfigFromSpec:
     """The spec plus this build's outputs become a SessionConfig."""
 
-    def _config(self, spec: SessionSpec, **kwargs: object):
-        composition = kwargs.pop("composition", None) or _composition()
+    def _config(
+        self,
+        spec: SessionSpec,
+        *,
+        composition: AgentComposition | None = None,
+        args: list[str] | None = None,
+        workdir: str | None = None,
+    ) -> SessionConfig:
         return session_config_from_spec(
             spec,
             name="s",
             workspace=WORKSPACE,
-            composition=composition,  # type: ignore[arg-type]
+            composition=composition or _composition(),
             images=SessionImages(agent="img:1", proxy="proxy:1"),
             env={"FOO": "bar"},
             mounts=["-v", "/a:/b"],
-            allowed_domains=["github.com"],
+            expanded_domains=["github.com"],
             otel_ports=[4317],
-            **kwargs,  # type: ignore[arg-type]
+            args=args,
+            workdir=workdir,
         )
 
     def test_carries_the_spec_onto_the_config(self) -> None:
@@ -205,34 +220,22 @@ class TestSessionConfigFromSpec:
         assert config.allowed_domains == ["github.com"]
         assert config.otel_ports == [4317]
 
-    def test_agent_providers_come_from_the_composition(self) -> None:
-        """Not from the spec: an upgrade may have just changed the agent set."""
-        config = self._config(
-            SessionSpec(), composition=_composition("claude", "codex")
+    def test_agent_and_credential_providers_are_read_verbatim(self) -> None:
+        """No caller-specific defaults live here.
+
+        Both callers normalise their spec first -- create fills in the agents'
+        own providers, upgrade derives them for a session predating the
+        providers label -- so this reads what it is given.
+        """
+        spec = SessionSpec(
+            agent_providers=[("claude", "vertex"), ("codex", "chatgpt")],
+            credential_providers=["vertex", "chatgpt"],
         )
 
-        assert [name for name, _p in config.agent_providers] == ["claude", "codex"]
+        config = self._config(spec, composition=_composition("claude", "codex"))
 
-    def test_credential_providers_fall_back_to_the_agents_own(self) -> None:
-        config = self._config(SessionSpec(), composition=_composition("claude"))
-
-        assert config.credential_providers == ["vertex"]
-
-    def test_recorded_proxy_image_is_the_fallback(self) -> None:
-        """A rebuild whose proxy build produced nothing keeps the old label."""
-        config = session_config_from_spec(
-            SessionSpec(proxy_image="recorded:1"),
-            name="s",
-            workspace=WORKSPACE,
-            composition=_composition(),
-            images=SessionImages(agent="img:1", proxy=None),
-            env={},
-            mounts=[],
-            allowed_domains=[],
-            otel_ports=[],
-        )
-
-        assert config.proxy_image == "recorded:1"
+        assert config.agent_providers == [("claude", "vertex"), ("codex", "chatgpt")]
+        assert config.credential_providers == ["vertex", "chatgpt"]
 
     def test_args_workdir_and_reuse_volume_default_off(self) -> None:
         config = self._config(SessionSpec())

--- a/tests/test_session_resources.py
+++ b/tests/test_session_resources.py
@@ -1,0 +1,280 @@
+"""Tests for SessionResources -- the three teardowns, side by side.
+
+The point of reading them together: they are *not* the same operation, and the
+difference is what stops an upgrade from deleting a user's workspace. Every
+"never removes" assertion below is load-bearing, not defensive.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from paude.backends.base import SessionConfig
+from paude.backends.labels import PAUDE_LABEL_AGENT, PAUDE_LABEL_SESSION
+from paude.backends.podman.helpers import (
+    auth_volume_name,
+    ca_volume_name,
+    container_name,
+    network_name,
+    proxy_container_name,
+    volume_name,
+)
+from paude.backends.podman.proxy import PodmanProxyManager
+from paude.backends.podman.resources import SessionResources
+from paude.container.network import NetworkManager
+from paude.container.volume import VolumeManager
+from tests.fakes import make_runner
+
+SESSION = "test-session"
+
+
+@pytest.fixture
+def volumes() -> MagicMock:
+    return MagicMock(spec=VolumeManager)
+
+
+@pytest.fixture
+def networks() -> MagicMock:
+    return MagicMock(spec=NetworkManager)
+
+
+@pytest.fixture
+def proxy() -> MagicMock:
+    return MagicMock(spec=PodmanProxyManager)
+
+
+@pytest.fixture
+def runner() -> MagicMock:
+    return make_runner()
+
+
+@pytest.fixture
+def resources(
+    runner: MagicMock,
+    networks: MagicMock,
+    volumes: MagicMock,
+    proxy: MagicMock,
+) -> SessionResources:
+    return SessionResources(runner, networks, volumes, proxy)
+
+
+def _removed_volumes(volumes: MagicMock) -> list[str]:
+    """Every volume name passed to either removal method."""
+    return [
+        call.args[0]
+        for call in (
+            *volumes.remove_volume.call_args_list,
+            *volumes.remove_volume_verified.call_args_list,
+        )
+    ]
+
+
+class TestTeardownForRebuild:
+    """Upgrade's teardown: removes the container, keeps every byte of state."""
+
+    def test_removes_container_proxy_network_and_ca_volume(
+        self,
+        resources: SessionResources,
+        runner: MagicMock,
+        networks: MagicMock,
+        volumes: MagicMock,
+    ) -> None:
+        resources.teardown_for_rebuild(SESSION)
+
+        runner.remove_container.assert_any_call(container_name(SESSION), force=True)
+        runner.remove_container.assert_any_call(
+            proxy_container_name(SESSION), force=True
+        )
+        networks.remove_network.assert_called_once_with(network_name(SESSION))
+        volumes.remove_volume.assert_any_call(ca_volume_name(SESSION), force=True)
+
+    def test_never_removes_the_workspace_volume(
+        self, resources: SessionResources, volumes: MagicMock
+    ) -> None:
+        """The user's data. Losing this is the worst outcome in the codebase."""
+        resources.teardown_for_rebuild(SESSION)
+
+        assert volume_name(SESSION) not in _removed_volumes(volumes)
+        volumes.remove_volume_verified.assert_not_called()
+
+    def test_never_removes_the_proxy_auth_volume(
+        self, resources: SessionResources, volumes: MagicMock
+    ) -> None:
+        """Live proxy OAuth state -- removing it makes the user log in again."""
+        resources.teardown_for_rebuild(SESSION)
+
+        assert auth_volume_name(SESSION) not in _removed_volumes(volumes)
+
+    def test_never_clears_credential_secrets(
+        self, resources: SessionResources, proxy: MagicMock, runner: MagicMock
+    ) -> None:
+        resources.teardown_for_rebuild(SESSION)
+
+        proxy.remove_credential_secrets.assert_not_called()
+        runner.remove_secret.assert_not_called()
+
+    def test_every_removal_is_tolerant(
+        self, resources: SessionResources, runner: MagicMock, volumes: MagicMock
+    ) -> None:
+        """Re-running after a partial teardown must converge, not fail.
+
+        This is what makes an interrupted upgrade resumable.
+        """
+        resources.teardown_for_rebuild(SESSION)
+
+        assert all(
+            call.kwargs.get("force") is True
+            for call in runner.remove_container.call_args_list
+        )
+        assert all(
+            call.kwargs.get("force") is True
+            for call in volumes.remove_volume.call_args_list
+        )
+
+
+class TestCleanupAll:
+    """The delete path: this one is *meant* to destroy the session's data."""
+
+    def test_removes_every_volume_and_secret(
+        self,
+        resources: SessionResources,
+        runner: MagicMock,
+        networks: MagicMock,
+        volumes: MagicMock,
+        proxy: MagicMock,
+    ) -> None:
+        volumes.volume_exists.return_value = True
+
+        resources.cleanup_all(SESSION, volume_name(SESSION))
+
+        networks.remove_network.assert_called_once_with(network_name(SESSION))
+        removed = _removed_volumes(volumes)
+        assert ca_volume_name(SESSION) in removed
+        assert auth_volume_name(SESSION) in removed
+        assert volume_name(SESSION) in removed
+        proxy.remove_credential_secrets.assert_called_once_with(SESSION)
+        runner.remove_secret.assert_called_once()
+
+    def test_workspace_volume_removal_is_verified(
+        self, resources: SessionResources, volumes: MagicMock
+    ) -> None:
+        """Unlike the rebuild teardown, a delete must confirm the data is gone."""
+        resources.cleanup_all(SESSION, volume_name(SESSION))
+
+        volumes.remove_volume_verified.assert_called_once_with(volume_name(SESSION))
+
+    def test_skips_proxy_volumes_that_do_not_exist(
+        self, resources: SessionResources, volumes: MagicMock
+    ) -> None:
+        volumes.volume_exists.return_value = False
+
+        resources.cleanup_all(SESSION, volume_name(SESSION))
+
+        assert ca_volume_name(SESSION) not in _removed_volumes(volumes)
+
+
+class TestRollbackCreate:
+    """Create's rollback: undoes a half-built session without eating a reused one."""
+
+    def _config(self, *, proxy_image: str | None = "proxy:latest") -> SessionConfig:
+        return SessionConfig(
+            name=SESSION,
+            workspace=Path("/workspace"),
+            image="paude:latest",
+            proxy_image=proxy_image,
+        )
+
+    def test_reused_volume_survives(
+        self, resources: SessionResources, volumes: MagicMock
+    ) -> None:
+        """An upgrade rebuild reuses the workspace volume; a failed container
+        recreate must not take the user's data with it."""
+        resources.rollback_create(
+            self._config(), SESSION, volume_name(SESSION), volume_reused=True
+        )
+
+        volumes.remove_volume.assert_not_called()
+
+    def test_fresh_volume_is_removed(
+        self, resources: SessionResources, volumes: MagicMock
+    ) -> None:
+        resources.rollback_create(
+            self._config(), SESSION, volume_name(SESSION), volume_reused=False
+        )
+
+        volumes.remove_volume.assert_called_once_with(volume_name(SESSION), force=True)
+
+    def test_proxyless_session_leaves_the_network_alone(
+        self, resources: SessionResources, runner: MagicMock, networks: MagicMock
+    ) -> None:
+        resources.rollback_create(
+            self._config(proxy_image=None),
+            SESSION,
+            volume_name(SESSION),
+            volume_reused=False,
+        )
+
+        runner.remove_container.assert_not_called()
+        networks.remove_network.assert_not_called()
+
+
+class TestReads:
+    """One container fetch, and the probes that do not need one."""
+
+    def test_labels_reads_the_whole_spec_in_one_fetch(
+        self, resources: SessionResources, runner: MagicMock
+    ) -> None:
+        runner.list_containers.return_value = [
+            {
+                "Id": "abc",
+                "Labels": {PAUDE_LABEL_SESSION: SESSION, PAUDE_LABEL_AGENT: "codex"},
+            }
+        ]
+
+        view = resources.labels(SESSION)
+
+        assert view is not None
+        assert view.spec.agent == "codex"
+        assert runner.list_containers.call_count == 1
+
+    def test_labels_is_none_for_a_session_with_no_container(
+        self, resources: SessionResources, runner: MagicMock
+    ) -> None:
+        runner.list_containers.return_value = []
+
+        assert resources.labels(SESSION) is None
+
+    def test_probes_address_the_agent_container(
+        self, resources: SessionResources, runner: MagicMock
+    ) -> None:
+        runner.container_exists.return_value = True
+        runner.container_running.return_value = False
+        runner.get_container_image.return_value = "paude:latest"
+
+        assert resources.exists(SESSION) is True
+        assert resources.running(SESSION) is False
+        assert resources.image(SESSION) == "paude:latest"
+        for probe in (
+            runner.container_exists,
+            runner.container_running,
+            runner.get_container_image,
+        ):
+            probe.assert_called_once_with(container_name(SESSION))
+
+
+class TestMigrateLegacyState:
+    """Salvage is skipped when there is nothing left to salvage."""
+
+    def test_skipped_when_the_old_container_is_gone(
+        self, resources: SessionResources, runner: MagicMock
+    ) -> None:
+        """The resume path: its state was already copied into the volume."""
+        runner.container_exists.return_value = False
+
+        resources.migrate_legacy_state(SESSION, MagicMock())
+
+        runner.start_container.assert_not_called()
+        runner.exec_in_container.assert_not_called()

--- a/tests/test_subprocess_utils.py
+++ b/tests/test_subprocess_utils.py
@@ -8,28 +8,28 @@ import threading
 import pytest
 
 from paude.subprocess_utils import drain_pipe, raise_on_nonzero, reap
-from tests.fakes import FakePopen
+from tests.fakes import FakePopen, as_popen
 
 
 class TestReap:
     def test_already_exited_no_grace(self) -> None:
         proc = FakePopen(returncode=0)
-        assert reap(proc) == 0
+        assert reap(as_popen(proc)) == 0
         assert proc.killed is False
 
     def test_still_running_no_grace_gets_killed(self) -> None:
         proc = FakePopen(pending_waits=1, returncode=-9)
-        assert reap(proc) == -9
+        assert reap(as_popen(proc)) == -9
         assert proc.killed is True
 
     def test_exits_within_grace_not_killed(self) -> None:
         proc = FakePopen(returncode=0)
-        assert reap(proc, grace=5.0) == 0
+        assert reap(as_popen(proc), grace=5.0) == 0
         assert proc.killed is False
 
     def test_exceeds_grace_gets_killed(self) -> None:
         proc = FakePopen(pending_waits=1, returncode=-9)
-        assert reap(proc, grace=5.0) == -9
+        assert reap(as_popen(proc), grace=5.0) == -9
         assert proc.killed is True
 
     def test_joins_drain_threads(self) -> None:
@@ -37,7 +37,7 @@ class TestReap:
         joined = threading.Event()
         thread = threading.Thread(target=joined.set)
         thread.start()
-        reap(proc, thread)
+        reap(as_popen(proc), thread)
         assert joined.is_set()
 
 

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -496,7 +496,7 @@ class TestSshTransport:
     )
     @patch("paude.transport.ssh.subprocess.run")
     def test_machine_failure_raises(
-        self, mock_run: MagicMock, run_kwargs: dict
+        self, mock_run: MagicMock, run_kwargs: dict[str, object]
     ) -> None:
         mock_run.configure_mock(**run_kwargs)
         transport = SshTransport("user@host")

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -421,6 +421,48 @@ class TestResolveBaseFromView:
         assert view.spec.gpu is None
 
 
+class TestResolveBaseFromManifest:
+    """Rebuilding a session's config from a persisted upgrade manifest."""
+
+    def test_a_null_credential_providers_entry_resolves_to_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """The manifest is JSON on disk, and load applies no per-field checks.
+
+        Only agent_providers is normalised on the way in, so a manifest holding
+        ``"credential_providers": null`` -- hand-edited, or written by
+        something other than paude -- constructs fine and reaches here intact.
+        Without the fallback, resolving it raises TypeError and aborts the
+        resumed upgrade instead of degrading to the empty set.
+        """
+        from paude import upgrade_state
+        from paude.cli.upgrade import _resolve_base_from_manifest
+
+        path = tmp_path / "upgrades.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "upgrades": {
+                        "sess": {
+                            "name": "sess",
+                            "to_version": "0.20.0",
+                            "created_at": "2026-01-01T00:00:00+00:00",
+                            "workspace": "/home/user/project",
+                            "agent": "claude",
+                            "credential_providers": None,
+                        }
+                    }
+                }
+            )
+        )
+        manifest = upgrade_state.load("sess", path=path)
+        assert manifest is not None
+
+        state = _resolve_base_from_manifest(manifest)
+
+        assert state.spec.credential_providers == []
+
+
 class TestUpgradePodman:
     """Tests for _upgrade_podman internal function."""
 

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import json
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from typer.testing import CliRunner
 
-from paude.backends import SessionConfig
+from paude.backends import PodmanBackend, SessionConfig
 from paude.backends.base import Session
 from paude.backends.labels import (
     PAUDE_LABEL_AGENT,
@@ -28,7 +29,10 @@ from paude.backends.labels import (
 from paude.backends.session_env import encode_path
 from paude.cli import app
 from paude.cli.upgrade import UpgradeOverrides
+from paude.container.network import NetworkManager
+from paude.container.volume import VolumeManager
 from paude.registry import RegistryEntry, SessionRegistry
+from tests.fakes import FakeTransport, make_backend, make_engine, make_runner
 
 _NO_OVERRIDES = UpgradeOverrides()
 
@@ -312,6 +316,67 @@ class TestUpgradeCommand:
         assert expected in result.output
 
 
+@dataclass
+class _Upgrade:
+    """A backend built from the shared factory, plus the doubles behind it.
+
+    Replaces the ``MagicMock(spec=PodmanBackend)`` plus four private-attribute
+    assignments this file used to need for every ``_upgrade_podman`` test.
+    Those mirrored cli/upgrade.py reaching into the backend's collaborators
+    (KNOWN_ISSUES TEST-004); now that it goes through ``backend.resources``,
+    a real backend works and assertions land on the doubles the test injected
+    rather than on attributes read back out of the system under test.
+    """
+
+    backend: PodmanBackend
+    runner: MagicMock
+    volumes: MagicMock
+    networks: MagicMock
+    create_session: MagicMock
+    start: MagicMock
+
+    @property
+    def config(self) -> SessionConfig:
+        """The SessionConfig the rebuild handed to create_session."""
+        created: SessionConfig = self.create_session.call_args[0][0]
+        return created
+
+
+def _upgrade_backend(
+    labels: dict[str, str] | None = None,
+    *,
+    container_exists: bool = False,
+    remote: bool = False,
+) -> _Upgrade:
+    """Build a backend whose every collaborator is observable and inert."""
+    from paude.transport.ssh import SshTransport
+
+    transport = SshTransport("user@host") if remote else FakeTransport()
+    runner = make_runner(
+        make_engine(transport=transport, is_remote=remote),
+        container_exists=container_exists,
+        list_containers=[{"Labels": labels}] if labels is not None else [],
+    )
+    volumes = MagicMock(spec=VolumeManager)
+    networks = MagicMock(spec=NetworkManager)
+    backend = make_backend(runner, network_manager=networks, volume_manager=volumes)
+    create_session = MagicMock(return_value=_upgraded_session())
+    start = MagicMock()
+    backend.create_session = create_session  # type: ignore[method-assign]
+    backend.start_session_no_attach = start  # type: ignore[method-assign]
+    return _Upgrade(backend, runner, volumes, networks, create_session, start)
+
+
+def _upgraded_session(name: str = "test-session") -> Session:
+    return Session(
+        name=name,
+        status="stopped",
+        workspace=Path("/home/user/project"),
+        created_at="2026-01-01T00:00:00+00:00",
+        backend_type="podman",
+    )
+
+
 class TestUpgradePodman:
     """Tests for _upgrade_podman internal function."""
 
@@ -345,10 +410,8 @@ class TestUpgradePodman:
     @patch("paude.cli.helpers._prepare_session_create")
     @patch("paude.container.ImageManager")
     @patch("paude.config.detector.detect_config", return_value=None)
-    @patch("paude.backends.podman.helpers.find_container_by_session_name")
     def test_upgrade_podman_preserves_volume(
         self,
-        mock_find_container: MagicMock,
         mock_detect_config: MagicMock,
         mock_image_manager_class: MagicMock,
         mock_prepare: MagicMock,
@@ -356,7 +419,6 @@ class TestUpgradePodman:
     ) -> None:
         """After upgrade, old container is removed but volume is NOT removed."""
         labels = self._make_container_labels()
-        mock_find_container.return_value = {"Labels": labels}
 
         mock_image_manager = MagicMock()
         mock_image_manager.ensure_default_image.return_value = "paude:latest"
@@ -364,32 +426,25 @@ class TestUpgradePodman:
 
         mock_prepare.return_value = ([], [], {}, True)
 
-        from paude.backends.podman.backend import PodmanBackend
-
-        backend = MagicMock(spec=PodmanBackend)
-        backend._runner = MagicMock()
-        backend._runner.container_exists.return_value = False
-        backend._network_manager = MagicMock()
-        backend._volume_manager = MagicMock()
-        backend._engine = MagicMock()
+        up = _upgrade_backend(labels)
 
         from paude.cli.upgrade import _upgrade_podman
 
-        _upgrade_podman("test-session", backend, rebuild=False, overrides=_NO_OVERRIDES)
+        _upgrade_podman(
+            "test-session", up.backend, rebuild=False, overrides=_NO_OVERRIDES
+        )
 
         # Old container and proxy container removed
-        backend._runner.remove_container.assert_any_call(
-            "paude-test-session", force=True
-        )
-        backend._runner.remove_container.assert_any_call(
+        up.runner.remove_container.assert_any_call("paude-test-session", force=True)
+        up.runner.remove_container.assert_any_call(
             "paude-proxy-test-session", force=True
         )
         # create_session called with reuse_volume=True
-        backend.create_session.assert_called_once()
-        config = backend.create_session.call_args[0][0]
+        up.create_session.assert_called_once()
+        config = up.config
         assert config.reuse_volume is True
         # start_session_no_attach called
-        backend.start_session_no_attach.assert_called_once_with("test-session")
+        up.start.assert_called_once_with("test-session")
 
     @patch("paude.transport.config_sync.remap_mounts")
     @patch("paude.transport.config_sync.sync_configs_to_remote")
@@ -397,10 +452,8 @@ class TestUpgradePodman:
     @patch("paude.cli.helpers._prepare_session_create")
     @patch("paude.container.ImageManager")
     @patch("paude.config.detector.detect_config", return_value=None)
-    @patch("paude.backends.podman.helpers.find_container_by_session_name")
     def test_upgrade_remaps_remote_config_mounts(
         self,
-        mock_find_container: MagicMock,
         mock_detect_config: MagicMock,
         mock_image_manager_class: MagicMock,
         mock_prepare: MagicMock,
@@ -411,9 +464,6 @@ class TestUpgradePodman:
         """A --host upgrade transfers config to the remote host and remaps the
         bind-mount sources, so podman on the remote isn't handed a local (e.g.
         Mac) path that doesn't exist there ("statfs ...: no such file")."""
-        from paude.transport.ssh import SshTransport
-
-        mock_find_container.return_value = {"Labels": self._make_container_labels()}
 
         mock_image_manager = MagicMock()
         mock_image_manager.ensure_default_image.return_value = "paude:latest"
@@ -431,35 +481,26 @@ class TestUpgradePodman:
         )
         mock_remap.return_value = remote_mounts
 
-        from paude.backends.podman.backend import PodmanBackend
-
-        backend = MagicMock(spec=PodmanBackend)
-        backend._runner = MagicMock()
-        backend._runner.container_exists.return_value = False
-        backend._network_manager = MagicMock()
-        backend._volume_manager = MagicMock()
-        backend._engine = MagicMock()
-        backend._engine.is_remote = True
-        backend._engine.transport = MagicMock(spec=SshTransport)
+        up = _upgrade_backend(self._make_container_labels(), remote=True)
 
         from paude.cli.upgrade import _upgrade_podman
 
-        _upgrade_podman("test-session", backend, rebuild=False, overrides=_NO_OVERRIDES)
+        _upgrade_podman(
+            "test-session", up.backend, rebuild=False, overrides=_NO_OVERRIDES
+        )
 
         mock_sync.assert_called_once()
         mock_remap.assert_called_once()
         # The recreated session uses the remapped (remote) mount sources.
-        session_config = backend.create_session.call_args[0][0]
+        session_config = up.config
         assert session_config.mounts == remote_mounts
 
     @patch("paude.mounts.build_mounts", return_value=[])
     @patch("paude.cli.helpers._prepare_session_create")
     @patch("paude.container.ImageManager")
     @patch("paude.config.detector.detect_config", return_value=None)
-    @patch("paude.backends.podman.helpers.find_container_by_session_name")
     def test_upgrade_podman_reads_labels(
         self,
-        mock_find_container: MagicMock,
         mock_detect_config: MagicMock,
         mock_image_manager_class: MagicMock,
         mock_prepare: MagicMock,
@@ -473,7 +514,6 @@ class TestUpgradePodman:
             domains=".googleapis.com,.pypi.org",
             proxy_image="proxy:latest",
         )
-        mock_find_container.return_value = {"Labels": labels}
 
         mock_image_manager = MagicMock()
         mock_image_manager.ensure_custom_image.return_value = "paude:custom"
@@ -487,20 +527,15 @@ class TestUpgradePodman:
             False,
         )
 
-        from paude.backends.podman.backend import PodmanBackend
-
-        backend = MagicMock(spec=PodmanBackend)
-        backend._runner = MagicMock()
-        backend._runner.container_exists.return_value = False
-        backend._network_manager = MagicMock()
-        backend._volume_manager = MagicMock()
-        backend._engine = MagicMock()
+        up = _upgrade_backend(labels)
 
         from paude.cli.upgrade import _upgrade_podman
 
-        _upgrade_podman("test-session", backend, rebuild=False, overrides=_NO_OVERRIDES)
+        _upgrade_podman(
+            "test-session", up.backend, rebuild=False, overrides=_NO_OVERRIDES
+        )
 
-        config = backend.create_session.call_args[0][0]
+        config = up.config
         assert config.agent == "gemini"
         assert config.gpu == "all"
         assert config.yolo is True
@@ -510,10 +545,8 @@ class TestUpgradePodman:
     @patch("paude.cli.helpers._prepare_session_create")
     @patch("paude.container.ImageManager")
     @patch("paude.config.detector.detect_config", return_value=None)
-    @patch("paude.backends.podman.helpers.find_container_by_session_name")
     def test_upgrade_podman_rebuilds_image(
         self,
-        mock_find_container: MagicMock,
         mock_detect_config: MagicMock,
         mock_image_manager_class: MagicMock,
         mock_prepare: MagicMock,
@@ -521,7 +554,6 @@ class TestUpgradePodman:
     ) -> None:
         """Image is rebuilt using ImageManager."""
         labels = self._make_container_labels()
-        mock_find_container.return_value = {"Labels": labels}
 
         mock_image_manager = MagicMock()
         mock_image_manager.ensure_default_image.return_value = "paude:latest"
@@ -529,18 +561,13 @@ class TestUpgradePodman:
 
         mock_prepare.return_value = ([], [], {}, True)
 
-        from paude.backends.podman.backend import PodmanBackend
-
-        backend = MagicMock(spec=PodmanBackend)
-        backend._runner = MagicMock()
-        backend._runner.container_exists.return_value = False
-        backend._network_manager = MagicMock()
-        backend._volume_manager = MagicMock()
-        backend._engine = MagicMock()
+        up = _upgrade_backend(labels)
 
         from paude.cli.upgrade import _upgrade_podman
 
-        _upgrade_podman("test-session", backend, rebuild=False, overrides=_NO_OVERRIDES)
+        _upgrade_podman(
+            "test-session", up.backend, rebuild=False, overrides=_NO_OVERRIDES
+        )
 
         mock_image_manager.ensure_default_image.assert_called_once_with(
             force_rebuild=True
@@ -550,10 +577,8 @@ class TestUpgradePodman:
     @patch("paude.cli.helpers._prepare_session_create")
     @patch("paude.container.ImageManager")
     @patch("paude.config.detector.detect_config", return_value=None)
-    @patch("paude.backends.podman.helpers.find_container_by_session_name")
     def test_upgrade_podman_removes_proxy(
         self,
-        mock_find_container: MagicMock,
         mock_detect_config: MagicMock,
         mock_image_manager_class: MagicMock,
         mock_prepare: MagicMock,
@@ -564,7 +589,6 @@ class TestUpgradePodman:
             domains=".googleapis.com",
             proxy_image="proxy:latest",
         )
-        mock_find_container.return_value = {"Labels": labels}
 
         mock_image_manager = MagicMock()
         mock_image_manager.ensure_default_image.return_value = "paude:latest"
@@ -573,35 +597,27 @@ class TestUpgradePodman:
 
         mock_prepare.return_value = ([".googleapis.com"], [], {}, False)
 
-        from paude.backends.podman.backend import PodmanBackend
-
-        backend = MagicMock(spec=PodmanBackend)
-        backend._runner = MagicMock()
-        backend._network_manager = MagicMock()
-        backend._volume_manager = MagicMock()
-        backend._engine = MagicMock()
+        up = _upgrade_backend(labels)
 
         from paude.cli.upgrade import _upgrade_podman
 
-        _upgrade_podman("test-session", backend, rebuild=False, overrides=_NO_OVERRIDES)
+        _upgrade_podman(
+            "test-session", up.backend, rebuild=False, overrides=_NO_OVERRIDES
+        )
 
         # Proxy container removed
-        backend._runner.remove_container.assert_any_call(
+        up.runner.remove_container.assert_any_call(
             "paude-proxy-test-session", force=True
         )
         # Network removed
-        backend._network_manager.remove_network.assert_called_once_with(
-            "paude-net-test-session"
-        )
+        up.networks.remove_network.assert_called_once_with("paude-net-test-session")
 
     @patch("paude.mounts.build_mounts", return_value=[])
     @patch("paude.cli.helpers._prepare_session_create")
     @patch("paude.container.ImageManager")
     @patch("paude.config.detector.detect_config", return_value=None)
-    @patch("paude.backends.podman.helpers.find_container_by_session_name")
     def test_upgrade_podman_build_failure_is_retryable(
         self,
-        mock_find_container: MagicMock,
         mock_detect_config: MagicMock,
         mock_image_manager_class: MagicMock,
         mock_prepare: MagicMock,
@@ -613,33 +629,24 @@ class TestUpgradePodman:
         from paude import upgrade_state
         from paude.cli.upgrade import _upgrade_podman
 
-        mock_find_container.return_value = {"Labels": self._make_container_labels()}
-
         mock_image_manager = MagicMock()
         mock_image_manager.ensure_default_image.side_effect = RuntimeError("boom")
         mock_image_manager_class.return_value = mock_image_manager
 
         mock_prepare.return_value = ([], [], {}, True)
 
-        from paude.backends.podman.backend import PodmanBackend
-
-        backend = MagicMock(spec=PodmanBackend)
-        backend._runner = MagicMock()
-        backend._runner.container_exists.return_value = False
-        backend._network_manager = MagicMock()
-        backend._volume_manager = MagicMock()
-        backend._engine = MagicMock()
+        up = _upgrade_backend(self._make_container_labels())
 
         # A plain error (typer.Exit is not a RuntimeError), so this asserts the
         # failure is routed to session_upgrade's "data is safe / retry" handler.
         with pytest.raises(RuntimeError):
             _upgrade_podman(
-                "test-session", backend, rebuild=False, overrides=_NO_OVERRIDES
+                "test-session", up.backend, rebuild=False, overrides=_NO_OVERRIDES
             )
 
         # The manifest (written before the build) survives, so a re-run resumes.
         assert upgrade_state.load("test-session") is not None
-        backend.create_session.assert_not_called()
+        up.create_session.assert_not_called()
 
 
 class TestUpgradeResume:
@@ -669,10 +676,8 @@ class TestUpgradeResume:
     @patch("paude.cli.helpers._prepare_session_create")
     @patch("paude.container.ImageManager")
     @patch("paude.config.detector.detect_config", return_value=None)
-    @patch("paude.backends.podman.helpers.find_container_by_session_name")
     def test_manifest_written_before_teardown(
         self,
-        mock_find_container: MagicMock,
         mock_detect_config: MagicMock,
         mock_image_manager_class: MagicMock,
         mock_prepare: MagicMock,
@@ -683,30 +688,19 @@ class TestUpgradeResume:
         from paude import upgrade_state
         from paude.cli.upgrade import _upgrade_podman
 
-        mock_find_container.return_value = {
-            "Labels": self._labels(gpu="all", yolo=True)
-        }
-
         mock_image_manager = MagicMock()
         mock_image_manager.ensure_default_image.return_value = "paude:latest"
         mock_image_manager.ensure_proxy_image.return_value = "proxy:rebuilt"
         mock_image_manager_class.return_value = mock_image_manager
         mock_prepare.return_value = ([], [], {}, True)
 
-        from paude.backends.podman.backend import PodmanBackend
-
-        backend = MagicMock(spec=PodmanBackend)
-        backend._runner = MagicMock()
-        backend._runner.container_exists.return_value = False
+        up = _upgrade_backend(self._labels(gpu="all", yolo=True))
         # Interrupt exactly at the first destructive removal.
-        backend._runner.remove_container.side_effect = KeyboardInterrupt
-        backend._network_manager = MagicMock()
-        backend._volume_manager = MagicMock()
-        backend._engine = MagicMock()
+        up.runner.remove_container.side_effect = KeyboardInterrupt
 
         with pytest.raises(KeyboardInterrupt):
             _upgrade_podman(
-                "test-session", backend, rebuild=False, overrides=_NO_OVERRIDES
+                "test-session", up.backend, rebuild=False, overrides=_NO_OVERRIDES
             )
 
         # Config was captured durably before teardown was attempted.
@@ -716,16 +710,14 @@ class TestUpgradeResume:
         assert manifest.gpu == "all"
         assert manifest.yolo is True
         # The replacement was never created (we were interrupted first).
-        backend.create_session.assert_not_called()
+        up.create_session.assert_not_called()
 
     @patch("paude.mounts.build_mounts", return_value=[])
     @patch("paude.cli.helpers._prepare_session_create")
     @patch("paude.container.ImageManager")
     @patch("paude.config.detector.detect_config", return_value=None)
-    @patch("paude.backends.podman.helpers.find_container_by_session_name")
     def test_resume_uses_manifest_when_container_gone(
         self,
-        mock_find_container: MagicMock,
         mock_detect_config: MagicMock,
         mock_image_manager_class: MagicMock,
         mock_prepare: MagicMock,
@@ -749,7 +741,6 @@ class TestUpgradeResume:
                 allowed_domains=[".googleapis.com"],
             )
         )
-        mock_find_container.return_value = None  # container already removed
 
         mock_image_manager = MagicMock()
         mock_image_manager.ensure_default_image.return_value = "paude:latest"
@@ -757,25 +748,20 @@ class TestUpgradeResume:
         mock_image_manager_class.return_value = mock_image_manager
         mock_prepare.return_value = ([".googleapis.com"], [], {}, False)
 
-        from paude.backends.podman.backend import PodmanBackend
+        up = _upgrade_backend()  # container already removed
 
-        backend = MagicMock(spec=PodmanBackend)
-        backend._runner = MagicMock()
-        backend._runner.container_exists.return_value = False
-        backend._network_manager = MagicMock()
-        backend._volume_manager = MagicMock()
-        backend._engine = MagicMock()
+        _upgrade_podman(
+            "test-session", up.backend, rebuild=False, overrides=_NO_OVERRIDES
+        )
 
-        _upgrade_podman("test-session", backend, rebuild=False, overrides=_NO_OVERRIDES)
-
-        config = backend.create_session.call_args[0][0]
+        config = up.config
         assert config.agent == "gemini"
         assert config.gpu == "all"
         assert config.yolo is True
         assert config.reuse_volume is True
         # Config came from the manifest, never from the (gone) container labels.
-        mock_find_container.assert_not_called()
-        backend.start_session_no_attach.assert_called_once_with("test-session")
+        up.runner.list_containers.assert_not_called()
+        up.start.assert_called_once_with("test-session")
 
     @patch("paude.cli.upgrade._upgrade_podman")
     @patch("paude.cli.upgrade.find_session_backend")
@@ -1370,10 +1356,8 @@ class TestUpgradePodmanWithOverrides:
     @patch("paude.cli.helpers._prepare_session_create")
     @patch("paude.container.ImageManager")
     @patch("paude.config.detector.detect_config", return_value=None)
-    @patch("paude.backends.podman.helpers.find_container_by_session_name")
     def test_upgrade_adds_otel_endpoint(
         self,
-        mock_find_container: MagicMock,
         mock_detect_config: MagicMock,
         mock_image_manager_class: MagicMock,
         mock_prepare: MagicMock,
@@ -1383,7 +1367,6 @@ class TestUpgradePodmanWithOverrides:
         labels = self._make_container_labels(
             domains=".googleapis.com",
         )
-        mock_find_container.return_value = {"Labels": labels}
 
         mock_image_manager = MagicMock()
         mock_image_manager.ensure_default_image.return_value = "paude:latest"
@@ -1392,20 +1375,14 @@ class TestUpgradePodmanWithOverrides:
 
         mock_prepare.return_value = ([".googleapis.com"], [], {}, False)
 
-        from paude.backends.podman.backend import PodmanBackend
-
-        backend = MagicMock(spec=PodmanBackend)
-        backend._runner = MagicMock()
-        backend._network_manager = MagicMock()
-        backend._volume_manager = MagicMock()
-        backend._engine = MagicMock()
+        up = _upgrade_backend(labels)
 
         from paude.cli.upgrade import _upgrade_podman
 
         overrides = UpgradeOverrides(otel_endpoint="http://collector:4318")
-        _upgrade_podman("test-session", backend, rebuild=False, overrides=overrides)
+        _upgrade_podman("test-session", up.backend, rebuild=False, overrides=overrides)
 
-        config = backend.create_session.call_args[0][0]
+        config = up.config
         assert config.otel_endpoint == "http://collector:4318"
         assert config.otel_ports == [4318]
 
@@ -1413,10 +1390,8 @@ class TestUpgradePodmanWithOverrides:
     @patch("paude.cli.helpers._prepare_session_create")
     @patch("paude.container.ImageManager")
     @patch("paude.config.detector.detect_config", return_value=None)
-    @patch("paude.backends.podman.helpers.find_container_by_session_name")
     def test_upgrade_clears_otel_endpoint(
         self,
-        mock_find_container: MagicMock,
         mock_detect_config: MagicMock,
         mock_image_manager_class: MagicMock,
         mock_prepare: MagicMock,
@@ -1427,7 +1402,6 @@ class TestUpgradePodmanWithOverrides:
             domains=".googleapis.com",
             otel_endpoint="http://old-collector:4318",
         )
-        mock_find_container.return_value = {"Labels": labels}
 
         mock_image_manager = MagicMock()
         mock_image_manager.ensure_default_image.return_value = "paude:latest"
@@ -1436,20 +1410,14 @@ class TestUpgradePodmanWithOverrides:
 
         mock_prepare.return_value = ([".googleapis.com"], [], {}, False)
 
-        from paude.backends.podman.backend import PodmanBackend
-
-        backend = MagicMock(spec=PodmanBackend)
-        backend._runner = MagicMock()
-        backend._network_manager = MagicMock()
-        backend._volume_manager = MagicMock()
-        backend._engine = MagicMock()
+        up = _upgrade_backend(labels)
 
         from paude.cli.upgrade import _upgrade_podman
 
         overrides = UpgradeOverrides(otel_endpoint="")
-        _upgrade_podman("test-session", backend, rebuild=False, overrides=overrides)
+        _upgrade_podman("test-session", up.backend, rebuild=False, overrides=overrides)
 
-        config = backend.create_session.call_args[0][0]
+        config = up.config
         assert config.otel_endpoint is None
         assert config.otel_ports == []
 
@@ -1457,10 +1425,8 @@ class TestUpgradePodmanWithOverrides:
     @patch("paude.cli.helpers._prepare_session_create")
     @patch("paude.container.ImageManager")
     @patch("paude.config.detector.detect_config", return_value=None)
-    @patch("paude.backends.podman.helpers.find_container_by_session_name")
     def test_upgrade_preserves_existing_otel(
         self,
-        mock_find_container: MagicMock,
         mock_detect_config: MagicMock,
         mock_image_manager_class: MagicMock,
         mock_prepare: MagicMock,
@@ -1471,7 +1437,6 @@ class TestUpgradePodmanWithOverrides:
             domains=".googleapis.com",
             otel_endpoint="http://existing:4318",
         )
-        mock_find_container.return_value = {"Labels": labels}
 
         mock_image_manager = MagicMock()
         mock_image_manager.ensure_default_image.return_value = "paude:latest"
@@ -1480,65 +1445,49 @@ class TestUpgradePodmanWithOverrides:
 
         mock_prepare.return_value = ([".googleapis.com"], [], {}, False)
 
-        from paude.backends.podman.backend import PodmanBackend
-
-        backend = MagicMock(spec=PodmanBackend)
-        backend._runner = MagicMock()
-        backend._network_manager = MagicMock()
-        backend._volume_manager = MagicMock()
-        backend._engine = MagicMock()
+        up = _upgrade_backend(labels)
 
         from paude.cli.upgrade import _upgrade_podman
 
-        _upgrade_podman("test-session", backend, rebuild=False, overrides=_NO_OVERRIDES)
+        _upgrade_podman(
+            "test-session", up.backend, rebuild=False, overrides=_NO_OVERRIDES
+        )
 
-        config = backend.create_session.call_args[0][0]
+        config = up.config
         assert config.otel_endpoint == "http://existing:4318"
         assert config.otel_ports == [4318]
 
     @patch("paude.mounts.build_mounts", return_value=[])
     @patch("paude.container.ImageManager")
     @patch("paude.config.detector.detect_config", return_value=None)
-    @patch("paude.backends.podman.helpers.find_container_by_session_name")
     def test_upgrade_overrides_gpu(
         self,
-        mock_find_container: MagicMock,
         mock_detect_config: MagicMock,
         mock_image_manager_class: MagicMock,
         mock_build_mounts: MagicMock,
     ) -> None:
         """Upgrade with --gpu overrides label value."""
         labels = self._make_container_labels()
-        mock_find_container.return_value = {"Labels": labels}
 
         mock_image_manager = MagicMock()
         mock_image_manager.ensure_default_image.return_value = "paude:latest"
         mock_image_manager_class.return_value = mock_image_manager
 
-        from paude.backends.podman.backend import PodmanBackend
-
-        backend = MagicMock(spec=PodmanBackend)
-        backend._runner = MagicMock()
-        backend._runner.container_exists.return_value = False
-        backend._network_manager = MagicMock()
-        backend._volume_manager = MagicMock()
-        backend._engine = MagicMock()
+        up = _upgrade_backend(labels)
 
         from paude.cli.upgrade import _upgrade_podman
 
         overrides = UpgradeOverrides(gpu="all")
-        _upgrade_podman("test-session", backend, rebuild=False, overrides=overrides)
+        _upgrade_podman("test-session", up.backend, rebuild=False, overrides=overrides)
 
-        config = backend.create_session.call_args[0][0]
+        config = up.config
         assert config.gpu == "all"
 
     @patch("paude.mounts.build_mounts", return_value=[])
     @patch("paude.container.ImageManager")
     @patch("paude.config.detector.detect_config", return_value=None)
-    @patch("paude.backends.podman.helpers.find_container_by_session_name")
     def test_upgrade_disables_gpu(
         self,
-        mock_find_container: MagicMock,
         mock_detect_config: MagicMock,
         mock_image_manager_class: MagicMock,
         mock_build_mounts: MagicMock,
@@ -1548,27 +1497,19 @@ class TestUpgradePodmanWithOverrides:
 
         labels = self._make_container_labels()
         labels[PAUDE_LABEL_GPU] = "all"  # Had GPU before
-        mock_find_container.return_value = {"Labels": labels}
 
         mock_image_manager = MagicMock()
         mock_image_manager.ensure_default_image.return_value = "paude:latest"
         mock_image_manager_class.return_value = mock_image_manager
 
-        from paude.backends.podman.backend import PodmanBackend
-
-        backend = MagicMock(spec=PodmanBackend)
-        backend._runner = MagicMock()
-        backend._runner.container_exists.return_value = False
-        backend._network_manager = MagicMock()
-        backend._volume_manager = MagicMock()
-        backend._engine = MagicMock()
+        up = _upgrade_backend(labels)
 
         from paude.cli.upgrade import _upgrade_podman
 
         overrides = UpgradeOverrides(gpu="")
-        _upgrade_podman("test-session", backend, rebuild=False, overrides=overrides)
+        _upgrade_podman("test-session", up.backend, rebuild=False, overrides=overrides)
 
-        config = backend.create_session.call_args[0][0]
+        config = up.config
         assert config.gpu is None
 
 
@@ -1614,7 +1555,6 @@ class TestUpgradePodmanAddAgent:
         self, labels: dict[str, str], overrides: UpgradeOverrides
     ) -> SessionConfig:
         """Run _upgrade_podman with all I/O mocked; return the created config."""
-        from paude.backends.podman.backend import PodmanBackend
         from paude.cli.upgrade import _upgrade_podman
 
         with (
@@ -1635,15 +1575,12 @@ class TestUpgradePodmanAddAgent:
             mock_image_manager.ensure_proxy_image.return_value = "proxy:latest"
             mock_image_manager_class.return_value = mock_image_manager
 
-            backend = MagicMock(spec=PodmanBackend)
-            backend._runner = MagicMock()
-            backend._runner.container_exists.return_value = False
-            backend._network_manager = MagicMock()
-            backend._volume_manager = MagicMock()
-            backend._engine = MagicMock()
+            up = _upgrade_backend(labels)
 
-            _upgrade_podman("test-session", backend, rebuild=False, overrides=overrides)
-            config: SessionConfig = backend.create_session.call_args[0][0]
+            _upgrade_podman(
+                "test-session", up.backend, rebuild=False, overrides=overrides
+            )
+            config: SessionConfig = up.config
             return config
 
     def test_add_agent_merges_composition_preserves_primary(self) -> None:

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1616,7 +1616,7 @@ class TestUpgradePodmanAddAgent:
         ``providers`` seeds the credential-provider label (used to model a
         provider that is provisioned for the session but not mapped to any agent).
         """
-        from paude.backends.podman.helpers import (
+        from paude.backends.labels import (
             encode_agent_providers,
             encode_providers,
         )

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -647,6 +647,48 @@ class TestUpgradePodman:
         # The manifest (written before the build) survives, so a re-run resumes.
         assert upgrade_state.load("test-session") is not None
         up.create_session.assert_not_called()
+        # And nothing was torn down: the images are built first precisely so a
+        # build failure leaves the old session intact.
+        up.runner.remove_container.assert_not_called()
+        up.volumes.remove_volume.assert_not_called()
+        up.networks.remove_network.assert_not_called()
+
+    @patch("paude.mounts.build_mounts", return_value=[])
+    @patch("paude.cli.helpers._prepare_session_create")
+    @patch("paude.container.ImageManager")
+    @patch("paude.config.detector.detect_config", return_value=None)
+    def test_proxy_build_failure_is_also_non_destructive(
+        self,
+        mock_detect_config: MagicMock,
+        mock_image_manager_class: MagicMock,
+        mock_prepare: MagicMock,
+        mock_build_mounts: MagicMock,
+    ) -> None:
+        """The proxy build is the last step before teardown, so it matters most.
+
+        Both images are built before anything is removed; a failure on the
+        second one must be as harmless as a failure on the first.
+        """
+        from paude import upgrade_state
+        from paude.cli.upgrade import _upgrade_podman
+
+        mock_image_manager = MagicMock()
+        mock_image_manager.ensure_default_image.return_value = "paude:latest"
+        mock_image_manager.ensure_proxy_image.side_effect = RuntimeError("no proxy")
+        mock_image_manager_class.return_value = mock_image_manager
+        mock_prepare.return_value = ([], [], {}, True)
+
+        up = _upgrade_backend(self._make_container_labels())
+
+        with pytest.raises(RuntimeError, match="building the proxy image failed"):
+            _upgrade_podman(
+                "test-session", up.backend, rebuild=False, overrides=_NO_OVERRIDES
+            )
+
+        assert upgrade_state.load("test-session") is not None
+        up.runner.remove_container.assert_not_called()
+        up.volumes.remove_volume.assert_not_called()
+        up.create_session.assert_not_called()
 
 
 class TestUpgradeResume:

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -341,31 +341,6 @@ class TestUpgradePodman:
             labels[PAUDE_LABEL_PROXY_IMAGE] = proxy_image
         return labels
 
-    def test_reused_volume_survives_container_creation_rollback(self) -> None:
-        from paude.backends import SessionConfig
-        from paude.backends.podman.backend import PodmanBackend
-
-        backend = MagicMock(spec=PodmanBackend)
-        backend._runner = MagicMock()
-        backend._network_manager = MagicMock()
-        backend._volume_manager = MagicMock()
-        config = SessionConfig(
-            name="test-session",
-            workspace=Path("/workspace"),
-            image="paude:latest",
-            reuse_volume=True,
-        )
-
-        PodmanBackend._rollback_session_resources(
-            backend,
-            config,
-            "test-session",
-            "paude-test-session-workspace",
-            volume_reused=True,
-        )
-
-        backend._volume_manager.remove_volume.assert_not_called()
-
     @patch("paude.mounts.build_mounts", return_value=[])
     @patch("paude.cli.helpers._prepare_session_create")
     @patch("paude.container.ImageManager")

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from typer.testing import CliRunner
 
+from paude.backends import SessionConfig
 from paude.backends.base import Session
 from paude.backends.labels import (
     PAUDE_LABEL_AGENT,
@@ -75,7 +76,7 @@ class TestUpgradeCommand:
         from paude.backends.podman.backend import PodmanBackend
 
         mock_backend = MagicMock()
-        mock_backend.__class__ = PodmanBackend
+        mock_backend.__class__ = PodmanBackend  # type: ignore[assignment]
         mock_backend.get_session.return_value = _make_session(
             "test-session", version=__version__
         )
@@ -102,7 +103,7 @@ class TestUpgradeCommand:
         # Make backend appear as PodmanBackend
         from paude.backends.podman.backend import PodmanBackend
 
-        mock_backend.__class__ = PodmanBackend
+        mock_backend.__class__ = PodmanBackend  # type: ignore[assignment]
         mock_find.return_value = ("podman", mock_backend)
 
         result = runner.invoke(app, ["upgrade", "test-session", "--rebuild"])
@@ -122,7 +123,7 @@ class TestUpgradeCommand:
         )
         from paude.backends.podman.backend import PodmanBackend
 
-        mock_backend.__class__ = PodmanBackend
+        mock_backend.__class__ = PodmanBackend  # type: ignore[assignment]
         mock_find.return_value = ("podman", mock_backend)
 
         result = runner.invoke(app, ["upgrade", "test-session"])
@@ -141,7 +142,7 @@ class TestUpgradeCommand:
         )
         from paude.backends.podman.backend import PodmanBackend
 
-        mock_backend.__class__ = PodmanBackend
+        mock_backend.__class__ = PodmanBackend  # type: ignore[assignment]
         mock_find.return_value = ("podman", mock_backend)
 
         result = runner.invoke(
@@ -172,7 +173,7 @@ class TestUpgradeCommand:
         backend.get_session.return_value = _make_session(
             "test-session", version="0.1.0"
         )
-        backend.__class__ = PodmanBackend
+        backend.__class__ = PodmanBackend  # type: ignore[assignment]
         mock_find.return_value = ("podman", backend)
         return backend
 
@@ -277,7 +278,7 @@ class TestUpgradeCommand:
         )
         from paude.backends.podman.backend import PodmanBackend
 
-        mock_backend.__class__ = PodmanBackend
+        mock_backend.__class__ = PodmanBackend  # type: ignore[assignment]
         mock_find.return_value = ("podman", mock_backend)
 
         result = runner.invoke(
@@ -820,7 +821,7 @@ class TestUpgradeResume:
             )
         )
         mock_backend = MagicMock()
-        mock_backend.__class__ = PodmanBackend
+        mock_backend.__class__ = PodmanBackend  # type: ignore[assignment]
         mock_backend.get_session.return_value = _make_session(
             "test-session", version="0.1.0"
         )
@@ -851,7 +852,7 @@ class TestUpgradeResume:
             )
         )
         mock_backend = MagicMock()
-        mock_backend.__class__ = PodmanBackend
+        mock_backend.__class__ = PodmanBackend  # type: ignore[assignment]
         mock_backend.get_session.return_value = _make_session(
             "test-session", status="running", version=__version__
         )
@@ -891,7 +892,7 @@ class TestUpgradeResume:
             )
         )
         mock_backend = MagicMock()
-        mock_backend.__class__ = PodmanBackend
+        mock_backend.__class__ = PodmanBackend  # type: ignore[assignment]
         mock_backend.get_session.return_value = _make_session(
             "test-session", status="stopped", version=__version__
         )
@@ -926,7 +927,7 @@ class TestUpgradeResume:
             )
         )
         mock_backend = MagicMock()
-        mock_backend.__class__ = PodmanBackend
+        mock_backend.__class__ = PodmanBackend  # type: ignore[assignment]
         mock_backend.get_session.return_value = _make_session(
             "test-session", status="degraded", version=__version__
         )
@@ -970,7 +971,7 @@ class TestUpgradeResume:
             )
         )
         mock_backend = MagicMock()
-        mock_backend.__class__ = PodmanBackend
+        mock_backend.__class__ = PodmanBackend  # type: ignore[assignment]
         mock_backend.get_session.return_value = _make_session(
             "test-session", status="running", version=__version__
         )
@@ -1069,7 +1070,7 @@ class TestUpgradeResume:
             )
         )
         mock_backend = MagicMock()
-        mock_backend.__class__ = PodmanBackend
+        mock_backend.__class__ = PodmanBackend  # type: ignore[assignment]
         mock_backend.get_session.return_value = None  # container gone
         mock_find.return_value = ("podman", mock_backend)
 
@@ -1102,7 +1103,7 @@ class TestUpgradeResume:
         mock_upgrade_podman.side_effect = KeyboardInterrupt
 
         mock_backend = MagicMock()
-        mock_backend.__class__ = PodmanBackend
+        mock_backend.__class__ = PodmanBackend  # type: ignore[assignment]
         mock_backend.get_session.return_value = _make_session(
             "test-session", version="0.1.0"
         )
@@ -1140,7 +1141,7 @@ class TestUpgradeResume:
         )
 
         mock_backend = MagicMock()
-        mock_backend.__class__ = PodmanBackend
+        mock_backend.__class__ = PodmanBackend  # type: ignore[assignment]
         mock_backend.get_session.return_value = _make_session(
             "test-session", version="0.1.0"
         )
@@ -1171,7 +1172,7 @@ class TestUpgradeResume:
         )
 
         mock_backend = MagicMock()
-        mock_backend.__class__ = PodmanBackend
+        mock_backend.__class__ = PodmanBackend  # type: ignore[assignment]
         mock_backend.get_session.return_value = _make_session(
             "test-session", version="0.1.0"
         )
@@ -1634,7 +1635,9 @@ class TestUpgradePodmanAddAgent:
             labels[PAUDE_LABEL_PROVIDERS] = encode_providers(providers)
         return labels
 
-    def _run(self, labels: dict[str, str], overrides: UpgradeOverrides) -> object:
+    def _run(
+        self, labels: dict[str, str], overrides: UpgradeOverrides
+    ) -> SessionConfig:
         """Run _upgrade_podman with all I/O mocked; return the created config."""
         from paude.backends.podman.backend import PodmanBackend
         from paude.cli.upgrade import _upgrade_podman
@@ -1665,7 +1668,8 @@ class TestUpgradePodmanAddAgent:
             backend._engine = MagicMock()
 
             _upgrade_podman("test-session", backend, rebuild=False, overrides=overrides)
-            return backend.create_session.call_args[0][0]
+            config: SessionConfig = backend.create_session.call_args[0][0]
+            return config
 
     def test_add_agent_merges_composition_preserves_primary(self) -> None:
         """--add-agent codex appends codex, keeping claude primary."""

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -377,6 +377,50 @@ def _upgraded_session(name: str = "test-session") -> Session:
     )
 
 
+class TestResolveBaseFromView:
+    """Reading a session's config off its labels, before any override."""
+
+    def test_legacy_session_without_a_providers_label_derives_them(self) -> None:
+        """The spec carries the raw label; upgrade needs the derived set.
+
+        A session created before the providers label existed has none, and
+        rebuilding it with an empty credential set would provision nothing.
+        The derivation also dedupes, which the raw agent-provider projection
+        does not -- a gascity session maps two of its three agents to vertex.
+        """
+        from paude.backends.labels import LabeledSession, spec_from_labels
+        from paude.cli.upgrade import _resolve_base_from_view
+
+        view = LabeledSession(
+            spec=spec_from_labels({PAUDE_LABEL_AGENT: "gascity"}),
+            workspace=Path("/home/user/project"),
+            created_at="2026-01-01T00:00:00+00:00",
+            version=None,
+        )
+
+        state = _resolve_base_from_view(view)
+
+        assert view.spec.credential_providers == []
+        assert state.spec.credential_providers == ["vertex", "google"]
+
+    def test_the_views_spec_is_copied_not_aliased(self) -> None:
+        """LabeledSession is frozen; _apply_overrides mutates what it is given."""
+        from paude.backends.labels import LabeledSession, spec_from_labels
+        from paude.cli.upgrade import _resolve_base_from_view
+
+        view = LabeledSession(
+            spec=spec_from_labels({PAUDE_LABEL_AGENT: "claude"}),
+            workspace=Path("/w"),
+            created_at="",
+            version=None,
+        )
+
+        state = _resolve_base_from_view(view)
+        state.spec.gpu = "all"
+
+        assert view.spec.gpu is None
+
+
 class TestUpgradePodman:
     """Tests for _upgrade_podman internal function."""
 

--- a/tests/test_upgrade_state.py
+++ b/tests/test_upgrade_state.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import json
-from dataclasses import MISSING, fields
 from pathlib import Path
 
 from paude import upgrade_state
 from paude.backends.labels import SessionSpec
 from paude.upgrade_state import UpgradeManifest
+from tests.fakes import assert_carries_every_spec_field
 
 
 def _manifest(name: str = "test-session") -> UpgradeManifest:
@@ -203,12 +203,4 @@ class TestManifestCarriesTheWholeSpec:
 
         manifest = _manifest_from_state("s", state, "0.21.0", "2026-08-25T00:00:00Z")
 
-        for spec_field in fields(SessionSpec):
-            default = (
-                spec_field.default_factory()
-                if spec_field.default_factory is not MISSING
-                else spec_field.default
-            )
-            assert getattr(manifest, spec_field.name) != default, (
-                f"_manifest_from_state does not carry SessionSpec.{spec_field.name}"
-            )
+        assert_carries_every_spec_field(manifest, "_manifest_from_state")

--- a/tests/test_upgrade_state.py
+++ b/tests/test_upgrade_state.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import json
+from dataclasses import MISSING, fields
 from pathlib import Path
 
 from paude import upgrade_state
+from paude.backends.labels import SessionSpec
 from paude.upgrade_state import UpgradeManifest
 
 
@@ -91,3 +94,119 @@ class TestUpgradeState:
         path = tmp_path / "upgrades.json"
         path.write_text('{"upgrades": {"test-session": {"unexpected": "field"}}}')
         assert upgrade_state.load("test-session", path=path) is None
+
+
+class TestManifestSchema:
+    """Guards on the on-disk schema, which in-flight upgrades depend on."""
+
+    # A manifest exactly as paude 0.20.2 wrote it, before UpgradeManifest
+    # inherited SessionSpec: flat, and in the field order of that release.
+    LEGACY_JSON = """
+    {"upgrades": {"test-session": {
+        "name": "test-session",
+        "to_version": "0.20.2",
+        "created_at": "2026-08-01T09:00:00+00:00",
+        "workspace": "/home/user/project",
+        "agent": "claude",
+        "provider": "anthropic",
+        "agent_providers": [["claude", "anthropic"], ["codex", "openai"]],
+        "credential_providers": ["anthropic", "openai"],
+        "gpu": "all",
+        "yolo": true,
+        "otel_endpoint": "http://collector:4318",
+        "allowed_domains": [".googleapis.com"],
+        "proxy_image": "proxy:latest"
+    }}}
+    """
+
+    def test_a_manifest_from_an_earlier_release_still_loads(
+        self, tmp_path: Path
+    ) -> None:
+        """An upgrade interrupted before this change must still be resumable."""
+        path = tmp_path / "upgrades.json"
+        path.write_text(self.LEGACY_JSON)
+
+        loaded = upgrade_state.load("test-session", path=path)
+
+        assert loaded == UpgradeManifest(
+            name="test-session",
+            to_version="0.20.2",
+            created_at="2026-08-01T09:00:00+00:00",
+            workspace="/home/user/project",
+            agent="claude",
+            provider="anthropic",
+            agent_providers=[("claude", "anthropic"), ("codex", "openai")],
+            credential_providers=["anthropic", "openai"],
+            gpu="all",
+            yolo=True,
+            otel_endpoint="http://collector:4318",
+            allowed_domains=[".googleapis.com"],
+            proxy_image="proxy:latest",
+        )
+
+    def test_saved_json_stays_flat(self, tmp_path: Path) -> None:
+        """Nesting the spec would strand every manifest an earlier paude wrote."""
+        path = tmp_path / "upgrades.json"
+        upgrade_state.save(_manifest(), path=path)
+
+        entry = json.loads(path.read_text())["upgrades"]["test-session"]
+
+        assert "spec" not in entry
+        assert not any(isinstance(value, dict) for value in entry.values())
+        assert set(entry) == {
+            "name",
+            "to_version",
+            "created_at",
+            "workspace",
+            "agent",
+            "provider",
+            "agent_providers",
+            "credential_providers",
+            "gpu",
+            "yolo",
+            "otel_endpoint",
+            "allowed_domains",
+            "proxy_image",
+        }
+
+
+class TestManifestCarriesTheWholeSpec:
+    """A new SessionSpec field must reach the manifest, not just the dataclass.
+
+    Inheriting the spec dedupes the *schema*; it does not dedupe the *copying*.
+    ``_manifest_from_state`` assigns the spec fields explicitly (which is what
+    makes them mypy-checkable), so a tenth label added to ``SessionSpec`` would
+    silently persist as its default until someone updated that function too.
+    This fails instead.
+    """
+
+    def test_every_spec_field_reaches_the_manifest(self) -> None:
+        from paude.agents import get_agents
+        from paude.cli.upgrade import _manifest_from_state, _ResolvedUpgrade
+
+        state = _ResolvedUpgrade(
+            agent_name="codex",
+            provider_name="openai",
+            composition=get_agents(
+                ["codex"], providers={"codex": "openai"}, include_bundled=False
+            ),
+            credential_providers=["openai"],
+            workspace=Path("/home/user/project"),
+            gpu="all",
+            yolo=True,
+            otel_endpoint="http://collector:4318",
+            allowed_domains=[".pypi.org"],
+            proxy_image_label="proxy:latest",
+        )
+
+        manifest = _manifest_from_state("s", state, "0.21.0", "2026-08-25T00:00:00Z")
+
+        for spec_field in fields(SessionSpec):
+            default = (
+                spec_field.default_factory()
+                if spec_field.default_factory is not MISSING
+                else spec_field.default
+            )
+            assert getattr(manifest, spec_field.name) != default, (
+                f"_manifest_from_state does not carry SessionSpec.{spec_field.name}"
+            )

--- a/tests/test_upgrade_state.py
+++ b/tests/test_upgrade_state.py
@@ -181,22 +181,24 @@ class TestManifestCarriesTheWholeSpec:
     """
 
     def test_every_spec_field_reaches_the_manifest(self) -> None:
-        from paude.agents import get_agents
-        from paude.cli.upgrade import _manifest_from_state, _ResolvedUpgrade
+        from paude.backends.podman.helpers import composition_for_spec
+        from paude.cli.upgrade import ResolvedSession, _manifest_from_state
 
-        state = _ResolvedUpgrade(
-            agent_name="codex",
-            provider_name="openai",
-            composition=get_agents(
-                ["codex"], providers={"codex": "openai"}, include_bundled=False
-            ),
+        spec = SessionSpec(
+            agent="codex",
+            provider="openai",
+            agent_providers=[("codex", "openai")],
             credential_providers=["openai"],
-            workspace=Path("/home/user/project"),
             gpu="all",
             yolo=True,
             otel_endpoint="http://collector:4318",
             allowed_domains=[".pypi.org"],
-            proxy_image_label="proxy:latest",
+            proxy_image="proxy:latest",
+        )
+        state = ResolvedSession(
+            spec=spec,
+            composition=composition_for_spec(spec),
+            workspace=Path("/home/user/project"),
         )
 
         manifest = _manifest_from_state("s", state, "0.21.0", "2026-08-25T00:00:00Z")

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from paude.config.models import PaudeConfig
-from paude.config.resolver import resolve_create_options
+from paude.config.resolver import ResolvedCreateOptions, resolve_create_options
 from paude.config.user_config import UserDefaults, load_user_defaults
 
 
@@ -90,8 +91,8 @@ class TestLoadUserDefaults:
 class TestResolveCreateOptions:
     """Tests for resolve_create_options."""
 
-    def _resolve(self, **kwargs):
-        defaults = {
+    def _resolve(self, **kwargs: Any) -> ResolvedCreateOptions:
+        defaults: dict[str, Any] = {
             "cli_backend": None,
             "cli_agent": None,
             "cli_yolo": None,
@@ -198,8 +199,8 @@ class TestResolveCreateOptions:
 class TestResolveAgentsAndProviders:
     """Tests for list-valued agents/providers resolution."""
 
-    def _resolve(self, **kwargs):
-        defaults = {
+    def _resolve(self, **kwargs: Any) -> ResolvedCreateOptions:
+        defaults: dict[str, Any] = {
             "cli_backend": None,
             "cli_agent": None,
             "cli_yolo": None,

--- a/tests/test_volume_archive.py
+++ b/tests/test_volume_archive.py
@@ -30,10 +30,11 @@ def _failing_stream(data: bytes = b"partial") -> Iterator[io.BytesIO]:
     raise RuntimeError("archive command failed")
 
 
-def _helper_name_from(call_args) -> str:
+def _helper_name_from(call_args: object) -> str:
     """Extract the helper container name from a ``run ... --name NAME ...`` call."""
-    args = list(call_args.args)
-    return args[args.index("--name") + 1]
+    args = list(call_args.args)  # type: ignore[attr-defined]
+    name: str = args[args.index("--name") + 1]
+    return name
 
 
 class TestExportVolume:


### PR DESCRIPTION
  Two passes that turned out to be the same job: the test suite couldn't
  cover the create/upgrade/backup paths without shared doubles, and the
  paths themselves duplicated too much to be worth covering as they were.

  ## Test infrastructure

  - Shared container/transport doubles in `tests/fakes.py`; backend and
    backup suites migrated onto the factory.
  - Unit-test poll sleeps are instant (`_POLL_SLEEP_MODULES`), and the
    integration guard matches on directory rather than substring.
  - `mypy src tests` in the Makefile and pre-commit, with a `tests.*`
    override so ~1900 test signatures don't need annotating first
    (KNOWN_ISSUES TEST-003).

  ## Session rebuild

  - Container labels get a typed `SessionSpec` and one codec; both
    manifests inherit it, so `asdict()` stays flat and in-flight upgrades
    survive the change.
  - A session's labels are read once, into a spec, instead of re-fetched
    per field.
  - New `SessionResources` collaborator on the podman backend owns
    rollback, cleanup, and rebuild teardown, replacing three inline
    variants.
  - New `cli/session_rebuild.py` holds the steps create and upgrade share;
    both now build their session through it.
  - Upgrade and backup moved onto the backend's public seam.

  Behaviour is unchanged throughout — each collapsed branch was checked
  against the code it replaced.

  ## Also

  - Container-state migration moved below the CLI layer
    (`podman/legacy_state.py`).
  - Fixed: a manifest with a null `credential_providers` no longer aborts
    a resumed upgrade with a `TypeError`.
  - KNOWN_ISSUES gained eleven entries the consolidation uncovered but
    didn't fix — notably CREATE-001 (a failed `create_session` performs no
    rollback), PERF-001, and UPGRADE-002/003/004.

  `make test` (1996 passed), `make lint`, `make typecheck` all clean.