### PR TITLE
Support destination-scoped allowed endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,10 @@ paude allowed-domains SESSION --add 192.168.7.31
 paude allowed-endpoints SESSION --add 192.168.7.31:8000
 ```
 
+Both rules must match. If an endpoint host is not covered by the session's
+allowed domains, Paude keeps the exact endpoint rule but warns that it will
+remain blocked and shows the `allowed-domains` command needed to enable it.
+
 This grants port 8000 only to that host. `allowed-endpoints` also supports
 `--remove` and `--replace`; domain and endpoint updates preserve the other
 policy list and use the same rollback-safe swap. IPv6 authorities must be

--- a/README.md
+++ b/README.md
@@ -275,6 +275,19 @@ restores the old proxy and policy instead of leaving the session without an
 authenticated route. Committed domains survive proxy recovery and are used by
 subsequent backups and upgrades.
 
+For a nonstandard port, authorize the host and add an exact destination
+exception:
+
+```bash
+paude allowed-domains SESSION --add 192.168.7.31
+paude allowed-endpoints SESSION --add 192.168.7.31:8000
+```
+
+This grants port 8000 only to that host. `allowed-endpoints` also supports
+`--remove` and `--replace`; domain and endpoint updates preserve the other
+policy list and use the same rollback-safe swap. IPv6 authorities must be
+bracketed, for example `[2001:db8::1]:4317`.
+
 To deliberately replace credentials whose fresh values are available in the
 current environment, add `--refresh-credentials` to a domain mutation. Fresh
 values replace matching bindings while unrelated credentials remain attached:

--- a/containers/proxy/Dockerfile
+++ b/containers/proxy/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage — compile paude-proxy from source
 FROM golang:1.23 AS builder
 WORKDIR /app
-ARG PAUDE_PROXY_VERSION=185a6b9bce3533aa916a4277c6bd282e8a9c7c4d
+ARG PAUDE_PROXY_VERSION=598d2d89cbc6a9002db71de9d31d20d70fefb1cc
 RUN git init . && \
     git fetch --depth 1 https://github.com/bbrowning/paude-proxy.git ${PAUDE_PROXY_VERSION} && \
     git checkout FETCH_HEAD && \

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -51,6 +51,7 @@ Then edit it to set the values you want. Any field set to `null` or omitted uses
     "platform": "linux/amd64",
     "gpu": "all",
     "allowed-domains": ["default", "golang"],
+    "allowed-endpoints": ["api.example.com:8443"],
     "otel-endpoint": null
   }
 }
@@ -68,12 +69,13 @@ Projects can declare defaults in their `paude.json` so that anyone cloning the r
   "packages": ["make"],
   "create": {
     "allowed-domains": ["default", "golang"],
+    "allowed-endpoints": ["api.example.com:8443"],
     "agent": "claude"
   }
 }
 ```
 
-Only `allowed-domains`, `agent`, `provider`, `agents`, `providers`,
+Only `allowed-domains`, `allowed-endpoints`, `agent`, `provider`, `agents`, `providers`,
 `agent-providers`, and `otel-endpoint` are supported as project-level create
 hints.
 
@@ -103,6 +105,9 @@ Gas City does not implicitly install child CLIs.
 Domains from user defaults and project config are **merged** (union). For example, if your user defaults specify `["default", "golang"]` and the project config specifies `["nodejs"]`, the resolved list is `["default", "golang", "nodejs"]`.
 
 However, if you pass `--allowed-domains` on the CLI, it **overrides** entirely — no merging with user/project config occurs. The one exception is provider-required domains, which are always forced onto the allowlist regardless of what you pass — see [Network Domains](#network-domains).
+
+`allowed-endpoints` uses the same merge/override rule. Entries are exact
+`host:port` authorities; the host must independently match `allowed-domains`.
 
 ### Port Forwarding
 
@@ -135,6 +140,7 @@ paude create --dry-run
 | `git` | yes | — | `--git` | `false` |
 | `platform` | yes | — | `--platform` | (none) |
 | `allowed-domains` | yes | yes | `--allowed-domains` | `["default"]` |
+| `allowed-endpoints` | yes | yes | `--allowed-endpoints` | `[]` |
 | `gpu` | yes | — | `--gpu` / `--no-gpu` | (none) |
 | `provider` | yes | yes | `--provider` | (none) |
 | `agents` | yes | yes | `--agents` | `["claude"]` |
@@ -221,6 +227,24 @@ Opt-in OpenClaw plugin aliases, for skill packages that talk to external service
 
 **Special values**: `all` (unrestricted), `default` (vertexai + python + github + agent-specific). Any other alias name listed above, or a raw domain, can also be passed directly. Specifying domains without `default` replaces the allowlist entirely.
 
+## Destination-Scoped Port Exceptions
+
+Default proxy ports and telemetry ports remain global. To allow a nonstandard
+port for only one destination, configure both layers:
+
+```bash
+paude create \
+  --allowed-domains 192.168.7.31 \
+  --allowed-endpoints 192.168.7.31:8000
+```
+
+Endpoint hosts are case-insensitive and ignore one trailing dot. IP addresses
+are canonicalized, bracketed IPv6 is supported, and container service names may
+contain underscores. Schemes, paths, userinfo, wildcard/suffix/regex hosts,
+missing or invalid ports, invalid IPs, IPv6 zones, and unbracketed IPv6 are
+rejected before a proxy is changed. `paude allowed-endpoints NAME` lists rules
+and supports mutually exclusive `--add`, `--remove`, and `--replace` updates.
+
 ## Diagnosing Blocked Domains
 
 When a tool or package install fails due to network filtering, check what the proxy blocked:
@@ -264,6 +288,11 @@ paude allowed-domains my-session --remove registry.npmjs.org
 # Replace the entire allowlist
 paude allowed-domains my-session --replace default,pypi
 ```
+
+Blocked nonstandard destinations retain their port in this report. Follow both
+suggested commands: allow the host with `allowed-domains`, then allow the exact
+authority with `allowed-endpoints`; granting `host:8000` never grants port 8000
+to another host.
 
 ## GitHub CLI Access
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -52,6 +52,10 @@ The `--yolo` flag enables autonomous execution (no confirmation prompts). This i
 
 **Do not combine `--yolo` with `--allowed-domains all`** unless you fully trust the task.
 
+`--allowed-endpoints HOST:PORT` is narrower than a global port exception: the
+proxy requires both an allowed-domain host match and the exact endpoint match.
+Endpoint rules never authorize a host on their own or grant that port elsewhere.
+
 ## Workspace Protection
 
 The agent operates on its own copy of your code, not your host files. **Your protection is git itself.** Push important work to a remote before running in autonomous mode:

--- a/docs/SESSIONS.md
+++ b/docs/SESSIONS.md
@@ -21,7 +21,7 @@ paude
 | `stop` | Stops the container, preserves the volume |
 | `connect` | Attaches to running session |
 | `cp` | Copies files between local machine and session |
-| `upgrade` | Pulls current bases, rebuilds with the latest stable agent tooling, and recreates the session while preserving workspace and agent state; can also add agents (`--add-agent`, `--agents`) and reconfigure options (`--otel-endpoint`, `--allowed-domains`, `--gpu`/`--no-gpu`, `--yolo`/`--no-yolo`, `--provider`) |
+| `upgrade` | Pulls current bases, rebuilds with the latest stable agent tooling, and recreates the session while preserving workspace and agent state; can also add agents (`--add-agent`, `--agents`) and reconfigure options (`--otel-endpoint`, `--allowed-domains`, `--allowed-endpoints`, `--gpu`/`--no-gpu`, `--yolo`/`--no-yolo`, `--provider`) |
 | `remote` | Manages git remotes for code sync |
 | `delete` | Removes all resources including volume |
 | `backup` | Snapshots a stopped session (volume + config) to a portable bundle |
@@ -32,6 +32,7 @@ paude
 | `reset` | Resets session workspace and clears conversation history |
 | `config` | Manages user defaults (`config show`, `config path`, `config init`) |
 | `allowed-domains` | Views or modifies allowed egress domains for a session |
+| `allowed-endpoints` | Views or modifies exact destination port exceptions |
 | `blocked-domains` | Shows domains blocked by the proxy for a session |
 
 ## Examples
@@ -172,7 +173,8 @@ paude backup my-project -o /tmp/my-project.paude
 A backup is a `<name>-<timestamp>.paude/` directory (mode `0700`) with two files:
 
 - `manifest.json` — the session's identity and configuration (agent/providers,
-  allowed domains, yolo, gpu, otel, workspace path, backend/engine, and SSH
+  allowed domains and endpoints, yolo, gpu, otel, workspace path,
+  backend/engine, and SSH
   details for remote sessions).
 - `pvc.tar.gz` — the session's `/pvc` data volume: the workspace plus all agent
   state, history, and skills.

--- a/src/paude/backends/base.py
+++ b/src/paude/backends/base.py
@@ -64,6 +64,7 @@ class SessionConfig:
         args: Arguments to pass to Claude.
         workdir: Working directory inside container.
         allowed_domains: List of domains to allow. Empty list means unrestricted.
+        allowed_endpoints: Exact host:port exceptions for nonstandard ports.
         yolo: Enable YOLO mode.
         network: Podman network name for proxy setup.
         ports: Ports to expose as (host_port, container_port) tuples.
@@ -77,6 +78,7 @@ class SessionConfig:
     args: list[str] = field(default_factory=list)
     workdir: str | None = None
     allowed_domains: list[str] = field(default_factory=list)
+    allowed_endpoints: list[str] = field(default_factory=list)
     yolo: bool = False
     network: str | None = None
     proxy_image: str | None = None
@@ -222,6 +224,10 @@ class Backend(Protocol):
         """
         ...
 
+    def get_allowed_endpoints(self, name: str) -> list[str] | None:
+        """Get exact destination-scoped port exceptions for a session."""
+        ...
+
     def get_proxy_blocked_log(self, name: str) -> str | None:
         """Get raw blocked-domain log from the proxy container.
 
@@ -250,6 +256,10 @@ class Backend(Protocol):
             refresh_credentials: Replace bindings for credentials currently
                 supplied by the host while preserving all other bindings.
         """
+        ...
+
+    def update_allowed_endpoints(self, name: str, endpoints: list[str]) -> None:
+        """Replace exact destination-scoped port exceptions for a session."""
         ...
 
     def start_agent_headless(self, name: str) -> None:

--- a/src/paude/backends/labels.py
+++ b/src/paude/backends/labels.py
@@ -27,6 +27,7 @@ PAUDE_LABEL_WORKSPACE = "paude.io/workspace"
 PAUDE_LABEL_CREATED = "paude.io/created-at"
 PAUDE_LABEL_AGENT = "paude.io/agent"
 PAUDE_LABEL_DOMAINS = "paude.io/allowed-domains"
+PAUDE_LABEL_ENDPOINTS = "paude.io/allowed-endpoints"
 PAUDE_LABEL_PROXY_IMAGE = "paude.io/proxy-image"
 PAUDE_LABEL_VERSION = "paude.io/version"
 PAUDE_LABEL_GPU = "paude.io/gpu"
@@ -43,7 +44,7 @@ class SessionSpec:
     """The session configuration both durable manifests serialize.
 
     The field set is not a design principle, it is a schema constraint: these
-    are exactly the nine fields ``UpgradeManifest`` and ``BackupManifest``
+    are exactly the fields ``UpgradeManifest`` and ``BackupManifest``
     already wrote to disk, kept verbatim so existing ``upgrades.json`` files
     and backup bundles stay readable. Adding a field here changes both
     schemas; that, not a rule about "declared configuration", is the test to
@@ -67,6 +68,7 @@ class SessionSpec:
     yolo: bool = False
     otel_endpoint: str | None = None
     allowed_domains: list[str] | None = None
+    allowed_endpoints: list[str] = field(default_factory=list)
     proxy_image: str | None = None
 
 
@@ -154,6 +156,11 @@ def parse_domains_label(raw: str | None) -> list[str] | None:
     return raw.split(",") if raw else []
 
 
+def parse_endpoints_label(raw: str | None) -> list[str]:
+    """Parse the endpoint label, defaulting legacy sessions to no exceptions."""
+    return raw.split(",") if raw else []
+
+
 def normalize_agent_providers(value: object) -> list[tuple[str, str]]:
     """Coerce a JSON-decoded agent/provider list back into tuples.
 
@@ -218,6 +225,7 @@ def spec_from_labels(labels: Mapping[str, str]) -> SessionSpec:
         yolo=labels.get(PAUDE_LABEL_YOLO) == "1",
         otel_endpoint=labels.get(PAUDE_LABEL_OTEL_ENDPOINT) or None,
         allowed_domains=parse_domains_label(labels.get(PAUDE_LABEL_DOMAINS)),
+        allowed_endpoints=parse_endpoints_label(labels.get(PAUDE_LABEL_ENDPOINTS)),
         proxy_image=labels.get(PAUDE_LABEL_PROXY_IMAGE) or None,
     )
 

--- a/src/paude/backends/podman/backend.py
+++ b/src/paude/backends/podman/backend.py
@@ -144,6 +144,13 @@ class PodmanBackend:
             raise
 
         print(f"Session '{name}' created (stopped).", file=sys.stderr)
+        from paude.endpoints import warn_for_uncovered_allowed_endpoints
+
+        warn_for_uncovered_allowed_endpoints(
+            config.allowed_endpoints,
+            config.allowed_domains,
+            session_name=name,
+        )
         return Session(
             name=name,
             status="stopped",

--- a/src/paude/backends/podman/backend.py
+++ b/src/paude/backends/podman/backend.py
@@ -408,6 +408,11 @@ class PodmanBackend:
         require_session(self._runner, name)
         return self._proxy.get_allowed_domains(name)
 
+    def get_allowed_endpoints(self, name: str) -> list[str] | None:
+        """Get current allowed endpoints for a session."""
+        require_session(self._runner, name)
+        return self._proxy.get_allowed_endpoints(name)
+
     def get_proxy_blocked_log(self, name: str) -> str | None:
         """Get raw blocked-domain log from the proxy container."""
         require_session(self._runner, name)
@@ -440,6 +445,31 @@ class PodmanBackend:
             name,
             domains,
             credentials=refresh,
+            credential_targets=proxy_credential_targets(composition),
+            required_credentials=required_proxy_credential_targets(
+                composition, providers
+            ),
+        )
+
+    def update_allowed_endpoints(self, name: str, endpoints: list[str]) -> None:
+        """Update destination-scoped port exceptions for a session."""
+        from paude.endpoints import normalize_allowed_endpoints
+
+        endpoints = normalize_allowed_endpoints(endpoints)
+        require_session(self._runner, name)
+        composition = get_session_composition(self._runner, name)
+        from paude.backends.podman.helpers import get_session_credential_providers
+        from paude.backends.proxy_config import (
+            ProxyCredentials,
+            proxy_credential_targets,
+            required_proxy_credential_targets,
+        )
+
+        providers = get_session_credential_providers(self._runner, name)
+        self._proxy.update_endpoints(
+            name,
+            endpoints,
+            credentials=ProxyCredentials(chatgpt_oauth_mode="chatgpt" in providers),
             credential_targets=proxy_credential_targets(composition),
             required_credentials=required_proxy_credential_targets(
                 composition, providers

--- a/src/paude/backends/podman/proxy.py
+++ b/src/paude/backends/podman/proxy.py
@@ -619,3 +619,10 @@ class PodmanProxyManager:
             proxy_image=proxy_image,
             operation_label="endpoints",
         )
+        from paude.endpoints import warn_for_uncovered_allowed_endpoints
+
+        warn_for_uncovered_allowed_endpoints(
+            endpoints,
+            domains,
+            session_name=session_name,
+        )

--- a/src/paude/backends/podman/proxy.py
+++ b/src/paude/backends/podman/proxy.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping
 
 from paude.backends.labels import (
     PAUDE_LABEL_DOMAINS,
+    PAUDE_LABEL_ENDPOINTS,
     PAUDE_LABEL_OTEL_PORTS,
     PAUDE_LABEL_PROXY_IMAGE,
 )
@@ -100,6 +101,13 @@ class PodmanProxyManager:
         self._ca_cert = CACertDistributor(runner)
         self._credentials = ProxyCredentialManager(runner)
         self._state = ProxyStateStore(runner)
+        self._endpoint_state = ProxyStateStore(
+            runner,
+            path="/data/auth/allowed-endpoints.json",
+            schema="allowed-endpoints.v1",
+            field="endpoints",
+            description="allowed-endpoint",
+        )
 
     def _create_credential_secrets(
         self,
@@ -126,11 +134,11 @@ class PodmanProxyManager:
 
     def get_config_from_labels(
         self, session_name: str
-    ) -> tuple[str, list[str], list[int]] | None:
+    ) -> tuple[str, list[str], list[str], list[int]] | None:
         """Read proxy configuration from the main container's labels.
 
         Returns:
-            Tuple of (proxy_image, domains, otel_ports) or None.
+            Tuple of (proxy_image, domains, endpoints, otel_ports) or None.
         """
         container = find_container_by_session_name(self._runner, session_name)
         if container is None:
@@ -151,10 +159,17 @@ class PodmanProxyManager:
         if durable_domains is not None:
             domains = durable_domains
 
+        endpoints = [
+            item for item in labels.get(PAUDE_LABEL_ENDPOINTS, "").split(",") if item
+        ]
+        durable_endpoints = self.read_endpoint_state(session_name, proxy_image)
+        if durable_endpoints is not None:
+            endpoints = durable_endpoints
+
         otel_ports_str = labels.get(PAUDE_LABEL_OTEL_PORTS, "")
         otel_ports = [int(p) for p in otel_ports_str.split(",") if p]
 
-        return (proxy_image, domains, otel_ports)
+        return (proxy_image, domains, endpoints, otel_ports)
 
     def read_domain_state(
         self, session_name: str, proxy_image: str | None
@@ -163,6 +178,14 @@ class PodmanProxyManager:
         if not proxy_image:
             return None
         return self._state.read(auth_volume_name(session_name), proxy_image)
+
+    def read_endpoint_state(
+        self, session_name: str, proxy_image: str | None
+    ) -> list[str] | None:
+        """Read the committed endpoint override for a session, if one exists."""
+        if not proxy_image:
+            return None
+        return self._endpoint_state.read(auth_volume_name(session_name), proxy_image)
 
     def start_if_needed(
         self,
@@ -185,7 +208,7 @@ class PodmanProxyManager:
             return
 
         # Recreate the missing proxy
-        proxy_image, domains, otel_ports = proxy_config
+        proxy_image, domains, endpoints, otel_ports = proxy_config
         nname = network_name(session_name)
         ca_vol = ca_volume_name(session_name)
         auth_vol = auth_volume_name(session_name)
@@ -217,6 +240,7 @@ class PodmanProxyManager:
             network=nname,
             dns=dns,
             allowed_domains=domains,
+            allowed_endpoints=endpoints,
             ip=proxy_ip,
             otel_ports=otel_ports,
             ca_volume=ca_vol,
@@ -319,6 +343,7 @@ class PodmanProxyManager:
         allowed_domains: list[str] | None,
         otel_ports: list[int] | None = None,
         credentials: ProxyCredentials | Mapping[str, str] | None = None,
+        allowed_endpoints: list[str] | None = None,
     ) -> tuple[str, str | None]:
         """Create a proxy container for a session.
 
@@ -371,6 +396,7 @@ class PodmanProxyManager:
                 network=nname,
                 dns=dns,
                 allowed_domains=allowed_domains,
+                allowed_endpoints=allowed_endpoints,
                 ip=proxy_ip,
                 otel_ports=otel_ports,
                 ca_volume=ca_vol,
@@ -402,6 +428,14 @@ class PodmanProxyManager:
 
         return [d for d in domains_str.split(",") if d]
 
+    def get_allowed_endpoints(self, session_name: str) -> list[str] | None:
+        """Get current destination-scoped port exceptions for a session."""
+        pname = proxy_container_name(session_name)
+        if not self._runner.container_exists(pname):
+            return None
+        endpoints = self._runner.get_container_env(pname, "ALLOWED_ENDPOINTS")
+        return [item for item in (endpoints or "").split(",") if item]
+
     def get_blocked_log(self, session_name: str) -> str | None:
         """Get raw blocked-domain log from the proxy container."""
         pname = proxy_container_name(session_name)
@@ -429,6 +463,7 @@ class PodmanProxyManager:
         credentials: ProxyCredentials | Mapping[str, str] | None = None,
         credential_targets: set[str] | None = None,
         required_credentials: set[str] | None = None,
+        allowed_endpoints: list[str] | None = None,
     ) -> None:
         """Update domains using preserved credentials and a rollback-safe swap."""
         pname = proxy_container_name(session_name)
@@ -444,7 +479,12 @@ class PodmanProxyManager:
 
         # Preserve OTEL ports from labels across proxy recreate
         proxy_config = self.get_config_from_labels(session_name)
-        _, _, otel_ports = proxy_config if proxy_config else ("", [], [])
+        _, _, configured_endpoints, otel_ports = (
+            proxy_config if proxy_config else ("", [], [], [])
+        )
+        endpoints = (
+            configured_endpoints if allowed_endpoints is None else allowed_endpoints
+        )
 
         nname = network_name(session_name)
         ca_vol = ca_volume_name(session_name)
@@ -465,6 +505,14 @@ class PodmanProxyManager:
         elif not isinstance(credentials, ProxyCredentials):
             credentials = ProxyCredentials(environment=dict(credentials))
         previous_domains = self._state.read(auth_vol, proxy_image)
+        commit_endpoint_state = allowed_endpoints is not None or bool(
+            configured_endpoints
+        )
+        previous_endpoints = (
+            self._endpoint_state.read(auth_vol, proxy_image)
+            if commit_endpoint_state
+            else None
+        )
         prepared = self._credentials.prepare_update(
             session_name,
             pname,
@@ -486,6 +534,7 @@ class PodmanProxyManager:
                 network=nname,
                 dns=dns,
                 allowed_domains=domains,
+                allowed_endpoints=endpoints,
                 ip=proxy_ip,
                 otel_ports=otel_ports,
                 ca_volume=ca_vol,
@@ -496,6 +545,8 @@ class PodmanProxyManager:
                 auth_volume=auth_vol,
             )
             self._state.write(auth_vol, proxy_image, domains)
+            if commit_endpoint_state:
+                self._endpoint_state.write(auth_vol, proxy_image, endpoints)
             swap.commit()
         except Exception as primary:
             rollback_failures: list[str] = []
@@ -504,6 +555,15 @@ class PodmanProxyManager:
                     self._state.restore(auth_vol, proxy_image, previous_domains)
                 except Exception as exc:
                     rollback_failures.append(f"state restore failed: {exc}")
+                if commit_endpoint_state:
+                    try:
+                        self._endpoint_state.restore(
+                            auth_vol, proxy_image, previous_endpoints
+                        )
+                    except Exception as exc:
+                        rollback_failures.append(
+                            f"endpoint state restore failed: {exc}"
+                        )
                 try:
                     swap.rollback()
                 except Exception as exc:
@@ -520,3 +580,28 @@ class PodmanProxyManager:
         # Verify CA cert survived the recreate (same named volume = same cert).
         # If the cert is missing or changed, redistribute to the agent.
         self._redistribute_ca_if_needed(session_name)
+
+    def update_endpoints(
+        self,
+        session_name: str,
+        endpoints: list[str],
+        *,
+        credentials: ProxyCredentials | None = None,
+        credential_targets: set[str] | None = None,
+        required_credentials: set[str] | None = None,
+    ) -> None:
+        """Update endpoints while preserving domains via the transactional swap."""
+        domains = self.get_allowed_domains(session_name)
+        if domains is None:
+            raise ValueError(
+                f"Session '{session_name}' has no proxy (unrestricted network). "
+                "Cannot update endpoints."
+            )
+        self.update_domains(
+            session_name,
+            domains,
+            credentials=credentials,
+            credential_targets=credential_targets,
+            required_credentials=required_credentials,
+            allowed_endpoints=endpoints,
+        )

--- a/src/paude/backends/podman/proxy.py
+++ b/src/paude/backends/podman/proxy.py
@@ -155,14 +155,15 @@ class PodmanProxyManager:
             return None
 
         domains = [d for d in domains_str.split(",") if d]
-        durable_domains = self.read_domain_state(session_name, proxy_image)
+        durable_domains, durable_endpoints = self.read_policy_state(
+            session_name, proxy_image
+        )
         if durable_domains is not None:
             domains = durable_domains
 
         endpoints = [
             item for item in labels.get(PAUDE_LABEL_ENDPOINTS, "").split(",") if item
         ]
-        durable_endpoints = self.read_endpoint_state(session_name, proxy_image)
         if durable_endpoints is not None:
             endpoints = durable_endpoints
 
@@ -171,21 +172,17 @@ class PodmanProxyManager:
 
         return (proxy_image, domains, endpoints, otel_ports)
 
-    def read_domain_state(
+    def read_policy_state(
         self, session_name: str, proxy_image: str | None
-    ) -> list[str] | None:
-        """Read the committed domain override for a session, if one exists."""
+    ) -> tuple[list[str] | None, list[str] | None]:
+        """Read committed domain and endpoint overrides in one helper."""
         if not proxy_image:
-            return None
-        return self._state.read(auth_volume_name(session_name), proxy_image)
-
-    def read_endpoint_state(
-        self, session_name: str, proxy_image: str | None
-    ) -> list[str] | None:
-        """Read the committed endpoint override for a session, if one exists."""
-        if not proxy_image:
-            return None
-        return self._endpoint_state.read(auth_volume_name(session_name), proxy_image)
+            return None, None
+        return self._state.read_pair(
+            self._endpoint_state,
+            auth_volume_name(session_name),
+            proxy_image,
+        )
 
     def start_if_needed(
         self,
@@ -479,6 +476,7 @@ class PodmanProxyManager:
         required_credentials: set[str] | None = None,
         allowed_endpoints: list[str] | None = None,
         proxy_image: str | None = None,
+        operation_label: str = "domains",
     ) -> None:
         """Update domains using preserved credentials and a rollback-safe swap."""
         pname = proxy_container_name(session_name)
@@ -520,14 +518,11 @@ class PodmanProxyManager:
             credentials = ProxyCredentials()
         elif not isinstance(credentials, ProxyCredentials):
             credentials = ProxyCredentials(environment=dict(credentials))
-        previous_domains = self._state.read(auth_vol, proxy_image)
         commit_endpoint_state = allowed_endpoints is not None or bool(
             configured_endpoints
         )
-        previous_endpoints = (
-            self._endpoint_state.read(auth_vol, proxy_image)
-            if commit_endpoint_state
-            else None
+        previous_domains, previous_endpoints = self._state.read_pair(
+            self._endpoint_state, auth_vol, proxy_image
         )
         prepared = self._credentials.prepare_update(
             session_name,
@@ -539,7 +534,7 @@ class PodmanProxyManager:
         credential_env = self._credential_env(prepared.credentials)
 
         print(
-            f"Updating proxy domains for session '{session_name}'...",
+            f"Updating proxy {operation_label} for session '{session_name}'...",
             file=sys.stderr,
         )
         swap = None
@@ -622,4 +617,5 @@ class PodmanProxyManager:
             required_credentials=required_credentials,
             allowed_endpoints=endpoints,
             proxy_image=proxy_image,
+            operation_label="endpoints",
         )

--- a/src/paude/backends/podman/proxy.py
+++ b/src/paude/backends/podman/proxy.py
@@ -436,6 +436,20 @@ class PodmanProxyManager:
         endpoints = self._runner.get_container_env(pname, "ALLOWED_ENDPOINTS")
         return [item for item in (endpoints or "").split(",") if item]
 
+    def _endpoint_update_proxy_image(self, session_name: str) -> str:
+        """Return the configured image after verifying endpoint capability."""
+        container = find_container_by_session_name(self._runner, session_name)
+        labels = container.get("Labels", {}) or {} if container else {}
+        if PAUDE_LABEL_ENDPOINTS not in labels:
+            raise ValueError(
+                f"Session '{session_name}' predates allowed-endpoints support. "
+                f"Run 'paude upgrade {session_name}' before changing endpoints."
+            )
+        proxy_image = labels.get(PAUDE_LABEL_PROXY_IMAGE, "")
+        if not proxy_image:
+            raise ValueError(f"Cannot inspect proxy configuration for: {session_name}")
+        return str(proxy_image)
+
     def get_blocked_log(self, session_name: str) -> str | None:
         """Get raw blocked-domain log from the proxy container."""
         pname = proxy_container_name(session_name)
@@ -464,6 +478,7 @@ class PodmanProxyManager:
         credential_targets: set[str] | None = None,
         required_credentials: set[str] | None = None,
         allowed_endpoints: list[str] | None = None,
+        proxy_image: str | None = None,
     ) -> None:
         """Update domains using preserved credentials and a rollback-safe swap."""
         pname = proxy_container_name(session_name)
@@ -473,9 +488,10 @@ class PodmanProxyManager:
                 "Cannot update domains."
             )
 
-        proxy_image = self._runner.get_container_image(pname)
-        if not proxy_image:
+        running_proxy_image = self._runner.get_container_image(pname)
+        if not running_proxy_image:
             raise ValueError(f"Cannot inspect proxy container: {pname}")
+        proxy_image = proxy_image or running_proxy_image
 
         # Preserve OTEL ports from labels across proxy recreate
         proxy_config = self.get_config_from_labels(session_name)
@@ -591,6 +607,7 @@ class PodmanProxyManager:
         required_credentials: set[str] | None = None,
     ) -> None:
         """Update endpoints while preserving domains via the transactional swap."""
+        proxy_image = self._endpoint_update_proxy_image(session_name)
         domains = self.get_allowed_domains(session_name)
         if domains is None:
             raise ValueError(
@@ -604,4 +621,5 @@ class PodmanProxyManager:
             credential_targets=credential_targets,
             required_credentials=required_credentials,
             allowed_endpoints=endpoints,
+            proxy_image=proxy_image,
         )

--- a/src/paude/backends/podman/proxy_state.py
+++ b/src/paude/backends/podman/proxy_state.py
@@ -6,8 +6,8 @@ import json
 
 from paude.container.runner import ContainerRunner
 
-_STATE_PATH = "/data/auth/allowed-domains.json"
-_STATE_SCHEMA = "allowed-domains.v1"
+_DOMAIN_STATE_PATH = "/data/auth/allowed-domains.json"
+_DOMAIN_STATE_SCHEMA = "allowed-domains.v1"
 _MISSING_EXIT = 3
 
 
@@ -18,8 +18,20 @@ class ProxyStateError(RuntimeError):
 class ProxyStateStore:
     """Read and atomically write non-secret proxy state through the engine."""
 
-    def __init__(self, runner: ContainerRunner) -> None:
+    def __init__(
+        self,
+        runner: ContainerRunner,
+        *,
+        path: str = _DOMAIN_STATE_PATH,
+        schema: str = _DOMAIN_STATE_SCHEMA,
+        field: str = "domains",
+        description: str = "allowed-domain",
+    ) -> None:
         self._runner = runner
+        self._path = path
+        self._schema = schema
+        self._field = field
+        self._description = description
 
     def read(self, volume: str, image: str) -> list[str] | None:
         """Return committed domains, or ``None`` for a legacy absent record."""
@@ -32,38 +44,40 @@ class ProxyStateStore:
             "sh",
             image,
             "-c",
-            f"test -e {_STATE_PATH} || exit {_MISSING_EXIT}; cat {_STATE_PATH}",
+            f"test -e {self._path} || exit {_MISSING_EXIT}; cat {self._path}",
             check=False,
         )
         if result.returncode == _MISSING_EXIT:
             return None
         if result.returncode != 0:
             raise ProxyStateError(
-                "Could not read durable allowed-domain state: "
+                f"Could not read durable {self._description} state: "
                 f"{result.stderr.strip() or 'container helper failed'}"
             )
         try:
             record = json.loads(result.stdout)
         except (json.JSONDecodeError, TypeError) as exc:
-            raise ProxyStateError("Durable allowed-domain state is corrupt.") from exc
+            raise ProxyStateError(
+                f"Durable {self._description} state is corrupt."
+            ) from exc
         if (
             not isinstance(record, dict)
-            or record.get("schema") != _STATE_SCHEMA
-            or not isinstance(record.get("domains"), list)
-            or not all(isinstance(item, str) for item in record["domains"])
+            or record.get("schema") != self._schema
+            or not isinstance(record.get(self._field), list)
+            or not all(isinstance(item, str) for item in record[self._field])
         ):
-            raise ProxyStateError("Durable allowed-domain state is corrupt.")
-        return list(record["domains"])
+            raise ProxyStateError(f"Durable {self._description} state is corrupt.")
+        return list(record[self._field])
 
-    def write(self, volume: str, image: str, domains: list[str]) -> None:
-        """Atomically commit a versioned allowed-domain record."""
+    def write(self, volume: str, image: str, values: list[str]) -> None:
+        """Atomically commit a versioned proxy policy record."""
         payload = json.dumps(
-            {"schema": _STATE_SCHEMA, "domains": domains}, separators=(",", ":")
+            {"schema": self._schema, self._field: values}, separators=(",", ":")
         )
         script = (
             "umask 077; "
-            f"tmp={_STATE_PATH}.tmp.$$; "
-            f'cat > "$tmp" && mv -f "$tmp" {_STATE_PATH}'
+            f"tmp={self._path}.tmp.$$; "
+            f'cat > "$tmp" && mv -f "$tmp" {self._path}'
         )
         result = self._runner.engine.run(
             "run",
@@ -81,7 +95,7 @@ class ProxyStateStore:
         )
         if result.returncode != 0:
             raise ProxyStateError(
-                "Could not commit durable allowed-domain state: "
+                f"Could not commit durable {self._description} state: "
                 f"{result.stderr.strip() or 'container helper failed'}"
             )
 
@@ -104,11 +118,11 @@ class ProxyStateStore:
             "sh",
             image,
             "-c",
-            f"rm -f {_STATE_PATH}",
+            f"rm -f {self._path}",
             check=False,
         )
         if result.returncode != 0:
             raise ProxyStateError(
-                "Could not restore durable allowed-domain state: "
+                f"Could not restore durable {self._description} state: "
                 f"{result.stderr.strip() or 'container helper failed'}"
             )

--- a/src/paude/backends/podman/proxy_state.py
+++ b/src/paude/backends/podman/proxy_state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 
 from paude.container.runner import ContainerRunner
 
@@ -54,8 +55,64 @@ class ProxyStateStore:
                 f"Could not read durable {self._description} state: "
                 f"{result.stderr.strip() or 'container helper failed'}"
             )
+        return self._decode(result.stdout)
+
+    def read_pair(
+        self,
+        other: ProxyStateStore,
+        volume: str,
+        image: str,
+    ) -> tuple[list[str] | None, list[str] | None]:
+        """Read two adjacent policy records with one helper container."""
+        stores = (self, other)
+        script = "; ".join(store._framed_read_command() for store in stores)
+        result = self._runner.engine.run(
+            "run",
+            "--rm",
+            "-v",
+            f"{volume}:/data/auth:ro",
+            "--entrypoint",
+            "sh",
+            image,
+            "-c",
+            script,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise ProxyStateError(
+                "Could not read durable proxy policy state: "
+                f"{result.stderr.strip() or 'container helper failed'}"
+            )
+        if not isinstance(result.stdout, str):
+            raise ProxyStateError("Durable proxy policy state is corrupt.")
+        frames = result.stdout.split("\0")
+        if len(frames) != 5 or frames[-1]:
+            raise ProxyStateError("Durable proxy policy state is corrupt.")
+        return (
+            self._decode_frame(frames[0], frames[1]),
+            other._decode_frame(frames[2], frames[3]),
+        )
+
+    def _framed_read_command(self) -> str:
+        """Build a shell fragment that frames presence and arbitrary JSON."""
+        path = shlex.quote(self._path)
+        return (
+            f"if test -e {path}; then printf '1\\0'; cat {path} || exit $?; "
+            "printf '\\0'; else printf '0\\0\\0'; fi"
+        )
+
+    def _decode_frame(self, marker: str, payload: str) -> list[str] | None:
+        """Decode one framed record while preserving legacy absence."""
+        if marker == "0" and not payload:
+            return None
+        if marker != "1":
+            raise ProxyStateError("Durable proxy policy state is corrupt.")
+        return self._decode(payload)
+
+    def _decode(self, payload: str) -> list[str]:
+        """Validate and decode this store's versioned JSON record."""
         try:
-            record = json.loads(result.stdout)
+            record = json.loads(payload)
         except (json.JSONDecodeError, TypeError) as exc:
             raise ProxyStateError(
                 f"Durable {self._description} state is corrupt."

--- a/src/paude/backends/podman/resources.py
+++ b/src/paude/backends/podman/resources.py
@@ -92,8 +92,7 @@ class SessionResources:
         if container is None:
             return None
         view = read_labels(container.get("Labels", {}) or {})
-        domains = self._proxy.read_domain_state(name, view.spec.proxy_image)
-        endpoints = self._proxy.read_endpoint_state(name, view.spec.proxy_image)
+        domains, endpoints = self._proxy.read_policy_state(name, view.spec.proxy_image)
         if domains is None and endpoints is None:
             return view
         return replace(

--- a/src/paude/backends/podman/resources.py
+++ b/src/paude/backends/podman/resources.py
@@ -93,9 +93,21 @@ class SessionResources:
             return None
         view = read_labels(container.get("Labels", {}) or {})
         domains = self._proxy.read_domain_state(name, view.spec.proxy_image)
-        if domains is None:
+        endpoints = self._proxy.read_endpoint_state(name, view.spec.proxy_image)
+        if domains is None and endpoints is None:
             return view
-        return replace(view, spec=replace(view.spec, allowed_domains=domains))
+        return replace(
+            view,
+            spec=replace(
+                view.spec,
+                allowed_domains=(
+                    view.spec.allowed_domains if domains is None else domains
+                ),
+                allowed_endpoints=(
+                    view.spec.allowed_endpoints if endpoints is None else endpoints
+                ),
+            ),
+        )
 
     # -- rebuild ----------------------------------------------------------
 

--- a/src/paude/backends/podman/session_setup.py
+++ b/src/paude/backends/podman/session_setup.py
@@ -18,6 +18,7 @@ from paude.backends.labels import (
     PAUDE_LABEL_AGENT_PROVIDERS,
     PAUDE_LABEL_CREATED,
     PAUDE_LABEL_DOMAINS,
+    PAUDE_LABEL_ENDPOINTS,
     PAUDE_LABEL_GPU,
     PAUDE_LABEL_OTEL_ENDPOINT,
     PAUDE_LABEL_OTEL_PORTS,
@@ -299,6 +300,7 @@ class SessionSetup:
         if config.yolo:
             labels[PAUDE_LABEL_YOLO] = "1"
         labels[PAUDE_LABEL_DOMAINS] = ",".join(config.allowed_domains)
+        labels[PAUDE_LABEL_ENDPOINTS] = ",".join(config.allowed_endpoints)
         if config.proxy_image:
             labels[PAUDE_LABEL_PROXY_IMAGE] = config.proxy_image
         if config.otel_ports:
@@ -326,6 +328,7 @@ class SessionSetup:
             session_name,
             config.proxy_image or "",
             config.allowed_domains,
+            allowed_endpoints=config.allowed_endpoints,
             otel_ports=config.otel_ports,
             credentials=proxy_creds,
         )

--- a/src/paude/cli/__init__.py
+++ b/src/paude/cli/__init__.py
@@ -16,6 +16,7 @@ import paude.cli.backup as _backup  # noqa: F401
 import paude.cli.commands as _commands  # noqa: F401
 import paude.cli.create as _create  # noqa: F401
 import paude.cli.domains as _domains  # noqa: F401
+import paude.cli.endpoints as _endpoints  # noqa: F401
 import paude.cli.remote as _remote  # noqa: F401
 import paude.cli.status as _status  # noqa: F401
 import paude.cli.upgrade as _upgrade  # noqa: F401

--- a/src/paude/cli/backup.py
+++ b/src/paude/cli/backup.py
@@ -131,6 +131,7 @@ def _build_manifest(
         yolo=view.spec.yolo,
         otel_endpoint=view.spec.otel_endpoint,
         allowed_domains=view.spec.allowed_domains,
+        allowed_endpoints=list(view.spec.allowed_endpoints),
         proxy_image=view.spec.proxy_image,
         image=image,
         backend_type=backend_type,

--- a/src/paude/cli/config_cmd.py
+++ b/src/paude/cli/config_cmd.py
@@ -44,6 +44,7 @@ def config_show() -> None:
             cli_platform=None,
             cli_gpu=None,
             cli_allowed_domains=None,
+            cli_allowed_endpoints=None,
             project_config=project_config,
             user_defaults=user_defaults,
         )
@@ -92,6 +93,13 @@ def config_show() -> None:
     else:
         typer.echo('  allowed-domains: ["default"]  (built-in)')
 
+    if resolved.allowed_endpoints:
+        typer.echo("  allowed-endpoints:")
+        for endpoints, source in resolved.allowed_endpoints_provenance:
+            typer.echo(f"    {', '.join(endpoints)}  ({source})")
+    else:
+        typer.echo("  allowed-endpoints: []  (built-in)")
+
 
 @config_app.command("path")
 def config_path() -> None:
@@ -121,6 +129,7 @@ def config_init() -> None:
             "platform": None,
             "gpu": None,
             "allowed-domains": [],
+            "allowed-endpoints": [],
             "otel-endpoint": None,
         }
     }

--- a/src/paude/cli/create.py
+++ b/src/paude/cli/create.py
@@ -50,6 +50,16 @@ def session_create(
             ),
         ),
     ] = None,
+    allowed_endpoints: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--allowed-endpoints",
+            help=(
+                "Exact host:port exceptions for nonstandard proxy ports. "
+                "Can be repeated; each host must also be allowed by domains."
+            ),
+        ),
+    ] = None,
     rebuild: Annotated[
         bool,
         typer.Option(
@@ -237,6 +247,7 @@ def session_create(
             cli_platform=platform,
             cli_gpu=cli_gpu,
             cli_allowed_domains=allowed_domains,
+            cli_allowed_endpoints=allowed_endpoints,
             cli_otel_endpoint=otel_endpoint,
             project_config=config,
             user_defaults=user_defaults,
@@ -270,6 +281,13 @@ def session_create(
     r_allowed_domains: list[str] | None = (
         resolved.allowed_domains if resolved.allowed_domains else None
     )
+    from paude.endpoints import normalize_allowed_endpoints
+
+    try:
+        r_allowed_endpoints = normalize_allowed_endpoints(resolved.allowed_endpoints)
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1) from None
 
     # Validate agent name and provider combination
     try:
@@ -297,6 +315,7 @@ def session_create(
         show_dry_run(
             flags={
                 "allowed_domains": expanded,
+                "allowed_endpoints": r_allowed_endpoints,
                 "rebuild": rebuild,
                 "verbose": verbose,
                 "claude_args": parsed_args,
@@ -361,6 +380,7 @@ def session_create(
         config=config,
         env=env,
         expanded_domains=expanded_domains,
+        allowed_endpoints=r_allowed_endpoints,
         parsed_args=parsed_args,
         yolo=r_yolo,
         git=r_git,

--- a/src/paude/cli/create.py
+++ b/src/paude/cli/create.py
@@ -299,6 +299,7 @@ def session_create(
     # Handle dry-run mode
     if dry_run:
         from paude.dry_run import show_dry_run
+        from paude.endpoints import warn_for_uncovered_allowed_endpoints
 
         parsed_args = _parse_agent_args(claude_args)
         expanded, _parsed, _env, _unrestricted = _prepare_session_create(
@@ -312,6 +313,7 @@ def session_create(
             composition=composition,
             credential_providers=resolved.providers,
         )
+        warn_for_uncovered_allowed_endpoints(r_allowed_endpoints, expanded)
         show_dry_run(
             flags={
                 "allowed_domains": expanded,

--- a/src/paude/cli/create_podman.py
+++ b/src/paude/cli/create_podman.py
@@ -39,6 +39,7 @@ def create_podman_session(
     config: PaudeConfig | None,
     env: dict[str, str],
     expanded_domains: list[str],
+    allowed_endpoints: list[str] | None = None,
     parsed_args: list[str],
     yolo: bool,
     git: bool,
@@ -69,6 +70,7 @@ def create_podman_session(
         gpu=gpu,
         yolo=yolo,
         otel_endpoint=otel_endpoint,
+        allowed_endpoints=allowed_endpoints or [],
     )
 
     try:
@@ -134,6 +136,7 @@ def _resolve_composition_and_spec(
     gpu: str | None,
     yolo: bool,
     otel_endpoint: str | None,
+    allowed_endpoints: list[str] | None = None,
 ) -> tuple[AgentComposition, SessionSpec]:
     """Resolve the requested agents and gather the session's declared config.
 
@@ -157,6 +160,7 @@ def _resolve_composition_and_spec(
         gpu=gpu,
         yolo=yolo,
         otel_endpoint=otel_endpoint,
+        allowed_endpoints=allowed_endpoints or [],
     )
     return composition, spec
 

--- a/src/paude/cli/domains.py
+++ b/src/paude/cli/domains.py
@@ -346,5 +346,13 @@ def blocked_domains_cmd(
         f"{len(entries)} unique domain(s) blocked ({total_requests} total requests)."
     )
     typer.echo("")
-    typer.echo("Tip: To allow a domain, run:")
-    typer.echo(f"  paude allowed-domains {name} --add <domain>")
+    endpoint_blocked = any(
+        entry.port is not None and entry.port not in (80, 443) for entry in entries
+    )
+    if endpoint_blocked:
+        typer.echo("Tip: A nonstandard port needs both host and endpoint access:")
+        typer.echo(f"  paude allowed-domains {name} --add <host>")
+        typer.echo(f"  paude allowed-endpoints {name} --add <host:port>")
+    else:
+        typer.echo("Tip: To allow a domain, run:")
+        typer.echo(f"  paude allowed-domains {name} --add <domain>")

--- a/src/paude/cli/endpoints.py
+++ b/src/paude/cli/endpoints.py
@@ -1,0 +1,102 @@
+"""Runtime management for destination-scoped proxy endpoint exceptions."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+import typer
+
+from paude.backends import SessionNotFoundError
+from paude.backends.base import Backend
+from paude.cli.app import BackendType, app
+from paude.cli.helpers import _get_backend_instance, find_session_backend
+from paude.endpoints import normalize_allowed_endpoints
+
+
+def _resolve_backend(name: str, backend: BackendType | None) -> Backend:
+    """Resolve the explicitly selected or session-owning backend."""
+    if backend is not None:
+        return _get_backend_instance(backend)
+    result = find_session_backend(name)
+    if result is None:
+        typer.echo(f"Session '{name}' not found.", err=True)
+        raise typer.Exit(1)
+    return result[1]
+
+
+def _updated_endpoints(
+    current: list[str],
+    *,
+    add: list[str] | None,
+    remove: list[str] | None,
+    replace: list[str] | None,
+) -> tuple[list[str], str]:
+    """Apply one requested list operation and return its result and verb."""
+    if add:
+        additions = normalize_allowed_endpoints(add)
+        return list(dict.fromkeys([*current, *additions])), "Added"
+    if remove:
+        removal = set(normalize_allowed_endpoints(remove))
+        return [item for item in current if item not in removal], "Removed"
+    if replace:
+        return normalize_allowed_endpoints(replace), "Replaced"
+    return current, "Listed"
+
+
+@app.command("allowed-endpoints")
+def allowed_endpoints_cmd(
+    name: Annotated[str, typer.Argument(help="Session name.")],
+    add: Annotated[
+        list[str] | None,
+        typer.Option("--add", help="Add exact host:port exceptions."),
+    ] = None,
+    remove: Annotated[
+        list[str] | None,
+        typer.Option("--remove", help="Remove exact host:port exceptions."),
+    ] = None,
+    replace: Annotated[
+        list[str] | None,
+        typer.Option("--replace", help="Replace the entire endpoint list."),
+    ] = None,
+    backend: Annotated[
+        BackendType | None,
+        typer.Option(
+            "--backend",
+            help="Container backend (auto-detected from session if omitted).",
+        ),
+    ] = None,
+) -> None:
+    """Manage exact destination-scoped nonstandard-port exceptions."""
+    if sum(option is not None for option in (add, remove, replace)) > 1:
+        typer.echo(
+            "Error: Only one of --add, --remove, --replace can be specified.",
+            err=True,
+        )
+        raise typer.Exit(1)
+
+    backend_obj = _resolve_backend(name, backend)
+    try:
+        current = backend_obj.get_allowed_endpoints(name)
+        if current is None:
+            raise ValueError(
+                "Session was created without a proxy. Recreate it to enable "
+                "endpoint filtering."
+            )
+        updated, verb = _updated_endpoints(
+            current, add=add, remove=remove, replace=replace
+        )
+        if verb == "Listed":
+            typer.echo(f"Allowed endpoints for session '{name}':")
+            output = "  (none)" if not current else "\n".join(f"  {e}" for e in current)
+            typer.echo(output)
+            return
+        backend_obj.update_allowed_endpoints(name, updated)
+        typer.echo(
+            f"{verb} allowed endpoints for session '{name}' ({len(updated)} total)."
+        )
+    except (SessionNotFoundError, ValueError, NotImplementedError) as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1) from None
+    except Exception as e:
+        typer.echo(f"Error managing endpoints: {e}", err=True)
+        raise typer.Exit(1) from None

--- a/src/paude/cli/help.py
+++ b/src/paude/cli/help.py
@@ -157,6 +157,8 @@ _SECTIONS: tuple[HelpSection, ...] = (
             " restored if the candidate cannot start or commit. Use"
             " --refresh-credentials only when fresh replacement values are present"
             " in the current environment; unrelated bindings remain attached."
+            " Endpoint hosts outside allowed-domains remain blocked and produce an"
+            " actionable warning."
         ),
     ),
     HelpSection(

--- a/src/paude/cli/help.py
+++ b/src/paude/cli/help.py
@@ -143,12 +143,17 @@ _SECTIONS: tuple[HelpSection, ...] = (
                 "paude allowed-domains NAME --add .example.com --refresh-credentials",
                 "Update domains and refresh supplied credentials",
             ),
+            (
+                "paude allowed-endpoints NAME --add api.example.com:8443",
+                "Allow one exact host and nonstandard port",
+            ),
             ("paude blocked-domains NAME", "Show blocked domains"),
             ("paude blocked-domains NAME --raw", "Show raw proxy log"),
         ),
         text=(
-            "Domain-only updates preserve the proxy's current credential bindings"
-            " and durable policy. Replacement is fail-closed: the old proxy is"
+            "Domain and endpoint updates preserve the other policy list and the"
+            " proxy's current credential bindings. Replacement is fail-closed:"
+            " the old proxy is"
             " restored if the candidate cannot start or commit. Use"
             " --refresh-credentials only when fresh replacement values are present"
             " in the current environment; unrelated bindings remain attached."
@@ -168,6 +173,11 @@ _SECTIONS: tuple[HelpSection, ...] = (
             (
                 "paude create --allowed-domains .example.com",
                 "Allow ONLY custom domain (replaces defaults)",
+            ),
+            (
+                "paude create --allowed-domains api.example.com"
+                " --allowed-endpoints api.example.com:8443",
+                "Allow one destination on a nonstandard port",
             ),
             ("paude create -a '-p \"prompt\"'", "Create session with initial prompt"),
             ("paude create --dry-run", "Verify configuration without creating"),
@@ -211,7 +221,8 @@ _SECTIONS: tuple[HelpSection, ...] = (
             "User defaults: ~/.config/paude/defaults.json"
             " (backend, yolo, git, domains, etc.)\n"
             'Project hints: paude.json "create" section'
-            " (allowed-domains, agent, provider, agents, providers, agent-providers)"
+            " (allowed-domains, allowed-endpoints, agent, provider, agents,"
+            " providers, agent-providers)"
         ),
     ),
     HelpSection(

--- a/src/paude/cli/session_rebuild.py
+++ b/src/paude/cli/session_rebuild.py
@@ -180,6 +180,7 @@ def session_config_from_spec(
         # records what was declared (or None for a session predating the
         # always-on proxy), the container needs what that expands to.
         allowed_domains=expanded_domains,
+        allowed_endpoints=list(spec.allowed_endpoints),
         yolo=spec.yolo,
         proxy_image=images.proxy,
         agent=spec.agent,

--- a/src/paude/cli/upgrade.py
+++ b/src/paude/cli/upgrade.py
@@ -35,6 +35,7 @@ class UpgradeOverrides:
 
     otel_endpoint: str | None = None
     allowed_domains: list[str] | None = None
+    allowed_endpoints: list[str] | None = None
     gpu: str | None = None  # "" means explicitly disabled
     yolo: bool | None = None
     provider: str | None = None
@@ -48,6 +49,7 @@ class UpgradeOverrides:
         return (
             self.otel_endpoint is not None
             or self.allowed_domains is not None
+            or self.allowed_endpoints is not None
             or self.gpu is not None
             or self.yolo is not None
             or self.provider is not None
@@ -105,6 +107,13 @@ def session_upgrade(
         typer.Option(
             "--allowed-domains",
             help="Override allowed domains for network filtering.",
+        ),
+    ] = None,
+    allowed_endpoints: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--allowed-endpoints",
+            help="Override exact host:port exceptions for nonstandard proxy ports.",
         ),
     ] = None,
     gpu: Annotated[
@@ -229,9 +238,22 @@ def session_upgrade(
         )
         raise typer.Exit(1)
 
+    from paude.endpoints import normalize_allowed_endpoints
+
+    try:
+        normalized_endpoints = (
+            normalize_allowed_endpoints(allowed_endpoints)
+            if allowed_endpoints is not None
+            else None
+        )
+    except ValueError as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1) from None
+
     overrides = UpgradeOverrides(
         otel_endpoint=otel_endpoint,
         allowed_domains=allowed_domains,
+        allowed_endpoints=normalized_endpoints,
         gpu=cli_gpu,
         yolo=cli_yolo,
         provider=provider,
@@ -426,6 +448,7 @@ def _resolve_base_from_manifest(manifest: UpgradeManifest) -> ResolvedSession:
         yolo=manifest.yolo,
         otel_endpoint=manifest.otel_endpoint,
         allowed_domains=manifest.allowed_domains,
+        allowed_endpoints=list(manifest.allowed_endpoints),
         proxy_image=manifest.proxy_image,
     )
     return ResolvedSession(
@@ -553,6 +576,8 @@ def _apply_overrides(state: ResolvedSession, overrides: UpgradeOverrides) -> Non
         state.spec.otel_endpoint = overrides.otel_endpoint or None
     if overrides.allowed_domains is not None:
         state.spec.allowed_domains = overrides.allowed_domains
+    if overrides.allowed_endpoints is not None:
+        state.spec.allowed_endpoints = overrides.allowed_endpoints
 
 
 def _manifest_from_state(
@@ -577,6 +602,7 @@ def _manifest_from_state(
         yolo=state.spec.yolo,
         otel_endpoint=state.spec.otel_endpoint,
         allowed_domains=state.spec.allowed_domains,
+        allowed_endpoints=list(state.spec.allowed_endpoints),
         proxy_image=state.spec.proxy_image,
     )
 

--- a/src/paude/config/models.py
+++ b/src/paude/config/models.py
@@ -36,6 +36,7 @@ class PaudeConfig:
 
     # Create hints (from paude.json "create" section)
     create_allowed_domains: list[str] = field(default_factory=list)
+    create_allowed_endpoints: list[str] = field(default_factory=list)
     create_agent: str | None = None
     create_provider: str | None = None
     create_agents: list[str] = field(default_factory=list)

--- a/src/paude/config/parser.py
+++ b/src/paude/config/parser.py
@@ -122,6 +122,7 @@ def _parse_paude_json(config_file: Path, data: dict[str, Any]) -> PaudeConfig:
         packages=packages,
         setup_command=setup_command,
         create_allowed_domains=create_hints.allowed_domains,
+        create_allowed_endpoints=create_hints.allowed_endpoints,
         create_agent=create_hints.agent,
         create_provider=create_hints.provider,
         create_agents=create_hints.agents,
@@ -133,6 +134,7 @@ def _parse_paude_json(config_file: Path, data: dict[str, Any]) -> PaudeConfig:
 
 _KNOWN_CREATE_KEYS = {
     "allowed-domains",
+    "allowed-endpoints",
     "agent",
     "provider",
     "agents",
@@ -147,6 +149,7 @@ class CreateHints:
     """Parsed create hints from a project config 'create' section."""
 
     allowed_domains: list[str] = field(default_factory=list)
+    allowed_endpoints: list[str] = field(default_factory=list)
     agent: str | None = None
     provider: str | None = None
     agents: list[str] = field(default_factory=list)
@@ -170,6 +173,7 @@ def _parse_create_section(create_data: dict[str, Any]) -> CreateHints:
     _warn_unknown_keys(create_data, _KNOWN_CREATE_KEYS, "create section")
 
     allowed_domains = _string_list(create_data.get("allowed-domains", []))
+    allowed_endpoints = _string_list(create_data.get("allowed-endpoints", []))
     agents = _string_list(create_data.get("agents", []))
     providers = _string_list(create_data.get("providers", []))
     raw_agent_providers = create_data.get("agent-providers", {})
@@ -197,6 +201,7 @@ def _parse_create_section(create_data: dict[str, Any]) -> CreateHints:
 
     return CreateHints(
         allowed_domains=allowed_domains,
+        allowed_endpoints=allowed_endpoints,
         agent=agent,
         provider=provider,
         agents=agents,

--- a/src/paude/config/resolver.py
+++ b/src/paude/config/resolver.py
@@ -77,6 +77,10 @@ class ResolvedCreateOptions:
     allowed_domains_provenance: list[tuple[list[str], Source]] = field(
         default_factory=list
     )
+    allowed_endpoints: list[str] = field(default_factory=list)
+    allowed_endpoints_provenance: list[tuple[list[str], Source]] = field(
+        default_factory=list
+    )
 
 
 def resolve_create_options(
@@ -92,6 +96,7 @@ def resolve_create_options(
     cli_platform: str | None,
     cli_gpu: str | None,
     cli_allowed_domains: list[str] | None,
+    cli_allowed_endpoints: list[str] | None = None,
     cli_otel_endpoint: str | None = None,
     project_config: PaudeConfig | None,
     user_defaults: UserDefaults,
@@ -187,6 +192,12 @@ def resolve_create_options(
     _resolve_domains(
         result=result,
         cli_allowed_domains=cli_allowed_domains,
+        project_config=project_config,
+        user_defaults=user_defaults,
+    )
+    _resolve_endpoints(
+        result=result,
+        cli_allowed_endpoints=cli_allowed_endpoints,
         project_config=project_config,
         user_defaults=user_defaults,
     )
@@ -465,3 +476,25 @@ def _resolve_domains(
 
     result.allowed_domains = merged
     result.allowed_domains_provenance = provenance
+
+
+def _resolve_endpoints(
+    *,
+    result: ResolvedCreateOptions,
+    cli_allowed_endpoints: list[str] | None,
+    project_config: PaudeConfig | None,
+    user_defaults: UserDefaults,
+) -> None:
+    """Resolve endpoint exceptions with domain-equivalent precedence."""
+    if cli_allowed_endpoints is not None:
+        result.allowed_endpoints = _dedupe(cli_allowed_endpoints)
+        result.allowed_endpoints_provenance = [(cli_allowed_endpoints, "cli")]
+        return
+
+    user = user_defaults.allowed_endpoints
+    project = project_config.create_allowed_endpoints if project_config else []
+    result.allowed_endpoints = _dedupe([*user, *project])
+    if user:
+        result.allowed_endpoints_provenance.append((list(user), "user defaults"))
+    if project:
+        result.allowed_endpoints_provenance.append((list(project), "paude.json"))

--- a/src/paude/config/user_config.py
+++ b/src/paude/config/user_config.py
@@ -29,6 +29,7 @@ class UserDefaults:
     platform: str | None = None
     gpu: str | None = None
     allowed_domains: list[str] = field(default_factory=list)
+    allowed_endpoints: list[str] = field(default_factory=list)
     otel_endpoint: str | None = None
 
 
@@ -45,6 +46,7 @@ _KNOWN_KEYS = {
     "platform",
     "gpu",
     "allowed-domains",
+    "allowed-endpoints",
     "otel-endpoint",
 }
 
@@ -127,6 +129,7 @@ def _parse_defaults(data: dict[str, Any], path: Path) -> UserDefaults:
         platform=data.get("platform"),
         gpu=data.get("gpu"),
         allowed_domains=_string_list(data.get("allowed-domains", [])),
+        allowed_endpoints=_string_list(data.get("allowed-endpoints", [])),
         otel_endpoint=data.get("otel-endpoint"),
     )
 

--- a/src/paude/container/proxy_runner.py
+++ b/src/paude/container/proxy_runner.py
@@ -125,6 +125,7 @@ class ProxyRunner:
         dns: str | None,
         allowed_domains: list[str] | None,
         otel_ports: list[int] | None = None,
+        allowed_endpoints: list[str] | None = None,
         credentials: Mapping[str, str] | None = None,
         allowed_clients: str | None = None,
         credential_env: Mapping[str, str] | None = None,
@@ -136,6 +137,8 @@ class ProxyRunner:
             args.extend(["-e", f"PROXY_DNS={dns}"])
         if allowed_domains:
             args.extend(["-e", f"ALLOWED_DOMAINS={','.join(allowed_domains)}"])
+        if allowed_endpoints:
+            args.extend(["-e", f"ALLOWED_ENDPOINTS={','.join(allowed_endpoints)}"])
         if otel_ports:
             args.extend(
                 ["-e", f"ALLOWED_OTEL_PORTS={','.join(str(p) for p in otel_ports)}"]
@@ -188,6 +191,7 @@ class ProxyRunner:
         allowed_domains: list[str] | None = None,
         ip: str | None = None,
         otel_ports: list[int] | None = None,
+        allowed_endpoints: list[str] | None = None,
         ca_volume: str | None = None,
         credentials: Mapping[str, str] | None = None,
         allowed_clients: str | None = None,
@@ -209,6 +213,7 @@ class ProxyRunner:
             dns,
             allowed_domains,
             otel_ports,
+            allowed_endpoints,
             credentials,
             allowed_clients,
             credential_env,
@@ -279,6 +284,7 @@ class ProxyRunner:
         allowed_domains: list[str] | None = None,
         ip: str | None = None,
         otel_ports: list[int] | None = None,
+        allowed_endpoints: list[str] | None = None,
         ca_volume: str | None = None,
         credentials: Mapping[str, str] | None = None,
         allowed_clients: str | None = None,
@@ -300,6 +306,7 @@ class ProxyRunner:
             network=network,
             dns=dns,
             allowed_domains=allowed_domains,
+            allowed_endpoints=allowed_endpoints,
             ip=ip,
             otel_ports=otel_ports,
             ca_volume=ca_volume,
@@ -322,6 +329,7 @@ class ProxyRunner:
         allowed_domains: list[str] | None = None,
         ip: str | None = None,
         otel_ports: list[int] | None = None,
+        allowed_endpoints: list[str] | None = None,
         ca_volume: str | None = None,
         credentials: Mapping[str, str] | None = None,
         allowed_clients: str | None = None,
@@ -362,6 +370,7 @@ class ProxyRunner:
                 network=network,
                 dns=dns,
                 allowed_domains=allowed_domains,
+                allowed_endpoints=allowed_endpoints,
                 ip=ip,
                 otel_ports=otel_ports,
                 ca_volume=ca_volume,

--- a/src/paude/domains.py
+++ b/src/paude/domains.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import ipaddress
+import re
+
 # Domain aliases for common use cases
 DOMAIN_ALIASES: dict[str, list[str]] = {
     "vertexai": [
@@ -171,6 +174,48 @@ def expand_domains(
                 seen.add(domain)
 
     return expanded
+
+
+def host_matches_allowed_domains(host: str, domains: list[str]) -> bool:
+    """Return whether ``host`` is covered by an allowed-domain entry.
+
+    The comparison mirrors the proxy's exact, suffix, and regex forms. Domain
+    aliases are expanded for callers that have not already resolved them, and
+    an empty expanded list means unrestricted access.
+    """
+    expanded = expand_domains(domains)
+    if not expanded:
+        return True
+
+    canonical_host = _canonical_match_host(host)
+    return any(_domain_matches_host(canonical_host, domain) for domain in expanded)
+
+
+def _domain_matches_host(host: str, domain: str) -> bool:
+    """Match one proxy allowed-domain entry without enforcing policy."""
+    if domain.startswith("~"):
+        try:
+            return re.search(domain[1:], host) is not None
+        except re.error:
+            # This check is advisory. Avoid a false warning when the proxy's
+            # regex dialect accepts syntax that Python's does not.
+            return True
+    if domain.startswith("."):
+        suffix = _canonical_match_host(domain[1:])
+        return host == suffix or host.endswith(f".{suffix}")
+    return host == _canonical_match_host(domain)
+
+
+def _canonical_match_host(host: str) -> str:
+    """Canonicalize a host for advisory policy comparisons."""
+    host = host.lower().removesuffix(".")
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        return host
+    if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped:
+        return str(address.ipv4_mapped)
+    return address.compressed
 
 
 def is_unrestricted(domains: list[str]) -> bool:

--- a/src/paude/dry_run.py
+++ b/src/paude/dry_run.py
@@ -118,6 +118,10 @@ def _show_resolved_flags(
     else:
         typer.echo(f"  allowed-domains: {domains_display}  (built-in)")
 
+    endpoints = flags.get("allowed_endpoints", [])
+    typer.echo(f"  allowed-endpoints: {', '.join(endpoints) or '(none)'}")
+    _show_provenance_groups(resolved.allowed_endpoints_provenance)
+
     typer.echo(f"  rebuild: {flags.get('rebuild', False)}")
 
     if resolved.gpu.value:
@@ -184,6 +188,8 @@ def _show_legacy_flags(flags: dict[str, Any]) -> None:
     allowed_domains = flags.get("allowed_domains", [])
     domains_display = format_domains_for_display(allowed_domains)
     typer.echo(f"  --allowed-domains: {domains_display}")
+    endpoints = flags.get("allowed_endpoints", [])
+    typer.echo(f"  --allowed-endpoints: {', '.join(endpoints) or '(none)'}")
 
     typer.echo(f"  --rebuild: {flags.get('rebuild', False)}")
 

--- a/src/paude/endpoints.py
+++ b/src/paude/endpoints.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import ipaddress
 import re
+import sys
+
+from paude.domains import host_matches_allowed_domains
 
 _HOST_LABEL = re.compile(r"^[a-z0-9_](?:[a-z0-9_-]{0,61}[a-z0-9_])?$")
 
@@ -29,6 +32,37 @@ def normalize_allowed_endpoints(values: list[str] | None) -> list[str]:
                 normalized.append(endpoint)
                 seen.add(endpoint)
     return normalized
+
+
+def warn_for_uncovered_allowed_endpoints(
+    endpoints: list[str] | None,
+    allowed_domains: list[str],
+    *,
+    session_name: str | None = None,
+) -> None:
+    """Warn about endpoint rules whose hosts remain domain-blocked."""
+    for endpoint in normalize_allowed_endpoints(endpoints):
+        host = _authority_host(endpoint)
+        if host_matches_allowed_domains(host, allowed_domains):
+            continue
+        if session_name:
+            action = (
+                f"Run 'paude allowed-domains {session_name} --add {host}' to enable it."
+            )
+        else:
+            action = f"Add '--allowed-domains {host}' to enable it."
+        print(
+            f"Warning: allowed endpoint '{endpoint}' will remain blocked because "
+            f"host '{host}' is not allowed by allowed-domains. {action}",
+            file=sys.stderr,
+        )
+
+
+def _authority_host(authority: str) -> str:
+    """Extract the canonical host from a normalized authority."""
+    if authority.startswith("["):
+        return authority[1 : authority.index("]")]
+    return authority.rsplit(":", 1)[0]
 
 
 def _canonical_authority(authority: str) -> str:

--- a/src/paude/endpoints.py
+++ b/src/paude/endpoints.py
@@ -1,0 +1,101 @@
+"""Validation and canonicalization for destination-scoped proxy endpoints."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+
+_HOST_LABEL = re.compile(r"^[a-z0-9_](?:[a-z0-9_-]{0,61}[a-z0-9_])?$")
+
+
+def normalize_allowed_endpoints(values: list[str] | None) -> list[str]:
+    """Return canonical, de-duplicated exact ``host:port`` authorities.
+
+    Values may be repeated or comma-separated. Invalid entries raise a
+    user-facing ``ValueError`` before a proxy container is changed.
+    """
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in values or []:
+        for raw in value.split(","):
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                endpoint = _canonical_authority(raw)
+            except ValueError as exc:
+                raise ValueError(f"Invalid allowed endpoint {raw!r}: {exc}") from None
+            if endpoint not in seen:
+                normalized.append(endpoint)
+                seen.add(endpoint)
+    return normalized
+
+
+def _canonical_authority(authority: str) -> str:
+    """Canonicalize one exact authority using the proxy's accepted grammar."""
+    if any(char in authority for char in "/?#@") or "://" in authority:
+        raise ValueError(
+            "must be host:port without a scheme, path, query, fragment, or userinfo"
+        )
+
+    if authority.startswith("["):
+        close = authority.find("]")
+        if close < 0 or close + 1 >= len(authority) or authority[close + 1] != ":":
+            raise ValueError("must be an exact host:port authority")
+        host = authority[1:close]
+        port_text = authority[close + 2 :]
+        try:
+            address = ipaddress.ip_address(host)
+        except ValueError:
+            raise ValueError("brackets are only valid around IPv6 addresses") from None
+        if not isinstance(address, ipaddress.IPv6Address):
+            raise ValueError("brackets are only valid around IPv6 addresses")
+    else:
+        if authority.count(":") != 1:
+            if authority.count(":") > 1:
+                raise ValueError("IPv6 addresses must be bracketed")
+            raise ValueError("must be an exact host:port authority")
+        host, port_text = authority.rsplit(":", 1)
+
+    if not port_text:
+        raise ValueError("port is required")
+    if not port_text.isascii() or not port_text.isdigit():
+        raise ValueError(f"port {port_text!r} must be numeric")
+    port = int(port_text)
+    if not 1 <= port <= 65535:
+        raise ValueError(f"port {port_text!r} must be between 1 and 65535")
+
+    canonical_host = _canonical_host(host)
+    if ":" in canonical_host:
+        return f"[{canonical_host}]:{port}"
+    return f"{canonical_host}:{port}"
+
+
+def _canonical_host(host: str) -> str:
+    """Canonicalize an exact hostname or IP address."""
+    host = host.lower().removesuffix(".")
+    if not host:
+        raise ValueError("host is required")
+    if host.startswith((".", "~")) or "*" in host:
+        raise ValueError("host must be an exact hostname or IP address")
+    if "%" in host:
+        raise ValueError("IPv6 zones are not valid destination hosts")
+
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        address = None
+    if address is not None:
+        if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped:
+            return str(address.ipv4_mapped)
+        return address.compressed
+
+    if ":" in host:
+        raise ValueError("IPv6 addresses must be bracketed")
+    if all(char.isdigit() or char == "." for char in host):
+        raise ValueError("invalid IP address")
+    if len(host) > 253:
+        raise ValueError("hostname is too long")
+    if any(not _HOST_LABEL.fullmatch(label) for label in host.split(".")):
+        raise ValueError("invalid hostname")
+    return host

--- a/src/paude/proxy_log.py
+++ b/src/paude/proxy_log.py
@@ -13,6 +13,7 @@ class BlockedDomain:
     domain: str
     count: int
     last_seen: str
+    port: int | None = None
 
 
 def parse_blocked_log(raw_log: str) -> list[BlockedDomain]:
@@ -28,6 +29,7 @@ def parse_blocked_log(raw_log: str) -> list[BlockedDomain]:
     """
     counts: dict[str, int] = {}
     last_seen: dict[str, str] = {}
+    ports: dict[str, int | None] = {}
 
     for line in raw_log.splitlines():
         parts = line.split()
@@ -36,15 +38,20 @@ def parse_blocked_log(raw_log: str) -> list[BlockedDomain]:
 
         timestamp = f"{parts[0]} {parts[1]}"
         url = parts[5]
-        domain = _extract_domain(url)
+        host, port = _extract_destination(url)
+        domain = _display_destination(host, port)
         if not domain:
             continue
 
         counts[domain] = counts.get(domain, 0) + 1
         last_seen[domain] = timestamp
+        ports[domain] = port
 
     result = [
-        BlockedDomain(domain=d, count=counts[d], last_seen=last_seen[d]) for d in counts
+        BlockedDomain(
+            domain=d, count=counts[d], last_seen=last_seen[d], port=ports[d]
+        )
+        for d in counts
     ]
     result.sort(key=lambda b: b.count, reverse=True)
     return result
@@ -52,10 +59,30 @@ def parse_blocked_log(raw_log: str) -> list[BlockedDomain]:
 
 def _extract_domain(url: str) -> str | None:
     """Extract hostname from a URL or host:port string."""
+    return _extract_destination(url)[0]
+
+
+def _extract_destination(url: str) -> tuple[str | None, int | None]:
+    """Extract the host and explicit port from a proxy log destination."""
     if "://" in url:
         parsed = urlparse(url)
-        return parsed.hostname or None
+        try:
+            return parsed.hostname or None, parsed.port
+        except ValueError:
+            return parsed.hostname or None, None
 
-    # CONNECT-style: host:port
-    host = url.split(":")[0]
-    return host if host else None
+    parsed = urlparse(f"//{url}")
+    try:
+        return parsed.hostname or None, parsed.port
+    except ValueError:
+        return parsed.hostname or None, None
+
+
+def _display_destination(host: str | None, port: int | None) -> str | None:
+    """Retain nonstandard ports while keeping ordinary domain blocks compact."""
+    if not host:
+        return None
+    if port is None or port in (80, 443):
+        return host
+    bracketed = f"[{host}]" if ":" in host else host
+    return f"{bracketed}:{port}"

--- a/src/paude/proxy_log.py
+++ b/src/paude/proxy_log.py
@@ -48,18 +48,11 @@ def parse_blocked_log(raw_log: str) -> list[BlockedDomain]:
         ports[domain] = port
 
     result = [
-        BlockedDomain(
-            domain=d, count=counts[d], last_seen=last_seen[d], port=ports[d]
-        )
+        BlockedDomain(domain=d, count=counts[d], last_seen=last_seen[d], port=ports[d])
         for d in counts
     ]
     result.sort(key=lambda b: b.count, reverse=True)
     return result
-
-
-def _extract_domain(url: str) -> str | None:
-    """Extract hostname from a URL or host:port string."""
-    return _extract_destination(url)[0]
 
 
 def _extract_destination(url: str) -> tuple[str | None, int | None]:

--- a/tests/test_allow_domain.py
+++ b/tests/test_allow_domain.py
@@ -96,6 +96,12 @@ class TestPodmanUpdateAllowedDomains:
             if args[:3] == ("inspect", "-f", "{{.State.Running}}"):
                 return MagicMock(returncode=0, stdout="true\n", stderr="")
             if args and args[0] == "run" and any("test -e" in arg for arg in args):
+                if any("printf" in arg for arg in args):
+                    return MagicMock(
+                        returncode=0,
+                        stdout="\0".join(["0", "", "0", "", ""]),
+                        stderr="",
+                    )
                 return MagicMock(returncode=3, stdout="", stderr="")
             return MagicMock(returncode=0, stdout="", stderr="")
 

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -18,6 +18,7 @@ from paude.backends.labels import (
     PAUDE_LABEL_AGENT_PROVIDERS,
     PAUDE_LABEL_CREATED,
     PAUDE_LABEL_DOMAINS,
+    PAUDE_LABEL_ENDPOINTS,
     PAUDE_LABEL_GPU,
     PAUDE_LABEL_OTEL_ENDPOINT,
     PAUDE_LABEL_PROVIDER,
@@ -509,6 +510,7 @@ class TestBuildManifest:
                 PAUDE_LABEL_GPU: "all",
                 PAUDE_LABEL_YOLO: "1",
                 PAUDE_LABEL_DOMAINS: "a,b",
+                PAUDE_LABEL_ENDPOINTS: "api.example.com:8443",
                 PAUDE_LABEL_OTEL_ENDPOINT: "http://collector:4318",
                 PAUDE_LABEL_PROXY_IMAGE: "proxy:1",
             }
@@ -564,6 +566,7 @@ class TestBuildManifest:
                 PAUDE_LABEL_GPU: "all",
                 PAUDE_LABEL_YOLO: "1",
                 PAUDE_LABEL_DOMAINS: "a,b",
+                PAUDE_LABEL_ENDPOINTS: "api.example.com:8443",
                 PAUDE_LABEL_OTEL_ENDPOINT: "http://collector:4318",
                 PAUDE_LABEL_PROXY_IMAGE: "proxy:1",
             }

--- a/tests/test_backup_state.py
+++ b/tests/test_backup_state.py
@@ -25,6 +25,7 @@ def _manifest(name: str = "test-session") -> BackupManifest:
         yolo=True,
         otel_endpoint="http://collector:4318",
         allowed_domains=[".googleapis.com", ".pypi.org"],
+        allowed_endpoints=["api.example.com:8443"],
         proxy_image="proxy:latest",
         image="runtime:abc123",
         backend_type="podman",
@@ -119,6 +120,7 @@ class TestManifestSchema:
         assert loaded.name == "test-session"
         assert loaded.agent_providers == [("claude", "anthropic")]
         assert loaded.allowed_domains == [".pypi.org"]
+        assert loaded.allowed_endpoints == []
         assert loaded.image == "runtime:abc123"
         assert loaded.gpu is None
 
@@ -144,6 +146,7 @@ class TestManifestSchema:
             "yolo",
             "otel_endpoint",
             "allowed_domains",
+            "allowed_endpoints",
             "proxy_image",
             "image",
             "backend_type",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -260,6 +260,41 @@ def test_allowed_endpoints_create_values_are_normalized() -> None:
     assert "allowed-endpoints: api.example.com:8443" in result.output
 
 
+def test_allowed_endpoints_create_warns_for_uncovered_host() -> None:
+    result = runner.invoke(
+        app,
+        [
+            "create",
+            "--allowed-domains",
+            "other.example",
+            "--allowed-endpoints",
+            "api.example.com:8443",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "will remain blocked" in result.output
+    assert "--allowed-domains api.example.com" in result.output
+
+
+def test_allowed_endpoints_create_alias_avoids_false_warning() -> None:
+    result = runner.invoke(
+        app,
+        [
+            "create",
+            "--allowed-domains",
+            "python",
+            "--allowed-endpoints",
+            "files.pythonhosted.org:8443",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "will remain blocked" not in result.output
+
+
 def test_invalid_allowed_endpoint_fails_before_create() -> None:
     result = runner.invoke(
         app,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -243,6 +243,33 @@ def test_allowed_domains_multiple_values():
     assert "vertexai" in result.stdout or ".example.com" in result.stdout
 
 
+def test_allowed_endpoints_create_values_are_normalized() -> None:
+    result = runner.invoke(
+        app,
+        [
+            "create",
+            "--allowed-domains",
+            "api.example.com",
+            "--allowed-endpoints",
+            "API.EXAMPLE.COM.:08443",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "allowed-endpoints: api.example.com:8443" in result.output
+
+
+def test_invalid_allowed_endpoint_fails_before_create() -> None:
+    result = runner.invoke(
+        app,
+        ["create", "--allowed-endpoints", "https://api.example.com", "--dry-run"],
+    )
+
+    assert result.exit_code == 1
+    assert "Invalid allowed endpoint" in result.output
+
+
 def test_help_shows_dry_run_option():
     """--help shows --dry-run option."""
     result = runner.invoke(app, ["--help"])
@@ -1884,6 +1911,68 @@ class TestAllowedDomainsCLI:
         assert "--refresh-credentials" in strip_ansi(result.stdout)
 
 
+class TestAllowedEndpointsCLI:
+    """Tests for exact endpoint list management."""
+
+    @patch("paude.cli.endpoints._resolve_backend")
+    def test_add_normalizes_and_preserves_existing_rules(
+        self, mock_resolve: MagicMock
+    ) -> None:
+        backend = MagicMock()
+        backend.get_allowed_endpoints.return_value = ["old.example:8000"]
+        mock_resolve.return_value = backend
+
+        result = runner.invoke(
+            app,
+            [
+                "allowed-endpoints",
+                "my-session",
+                "--add",
+                "API.EXAMPLE.:08443",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        backend.update_allowed_endpoints.assert_called_once_with(
+            "my-session", ["old.example:8000", "api.example:8443"]
+        )
+
+    @patch("paude.cli.endpoints._resolve_backend")
+    def test_invalid_endpoint_does_not_mutate_proxy(
+        self, mock_resolve: MagicMock
+    ) -> None:
+        backend = MagicMock()
+        backend.get_allowed_endpoints.return_value = []
+        mock_resolve.return_value = backend
+
+        result = runner.invoke(
+            app,
+            ["allowed-endpoints", "my-session", "--add", "https://example.com"],
+        )
+
+        assert result.exit_code == 1
+        assert "Invalid allowed endpoint" in result.output
+        backend.update_allowed_endpoints.assert_not_called()
+
+    @patch("paude.cli.endpoints._resolve_backend")
+    def test_operations_are_mutually_exclusive(self, mock_resolve: MagicMock) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "allowed-endpoints",
+                "my-session",
+                "--add",
+                "a.example:8000",
+                "--remove",
+                "b.example:9000",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Only one of" in result.output
+        mock_resolve.assert_not_called()
+
+
 class TestBlockedDomainsCLI:
     """Tests for the blocked-domains CLI subcommand."""
 
@@ -1940,6 +2029,24 @@ class TestBlockedDomainsCLI:
         assert "other.com" in result.stdout
         assert "2 unique domain(s) blocked (3 total requests)" in result.stdout
         assert "paude allowed-domains my-session --add" in result.stdout
+
+    @patch("paude.cli.domains._resolve_backend_for_domains")
+    def test_nonstandard_port_suggests_endpoint_rule(
+        self, mock_resolve: MagicMock
+    ) -> None:
+        log = (
+            "08/Mar/2026:14:00:00 +0000 10.0.0.2 TCP_DENIED/403 "
+            "CONNECT api.example.com:8443 BLOCKED\n"
+        )
+        backend = MagicMock()
+        backend.get_proxy_blocked_log.return_value = log
+        mock_resolve.return_value = backend
+
+        result = runner.invoke(app, ["blocked-domains", "my-session"])
+
+        assert result.exit_code == 0
+        assert "api.example.com:8443" in result.output
+        assert "paude allowed-endpoints my-session --add <host:port>" in result.output
 
     @patch("paude.cli.domains._resolve_backend_for_domains")
     def test_session_not_found_error(self, mock_resolve: MagicMock) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,6 +59,18 @@ class TestDetectConfig:
 class TestParseConfig:
     """Tests for config parsing."""
 
+    def test_parses_allowed_endpoints_create_hint(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "paude.json"
+        config_file.write_text(
+            json.dumps(
+                {"create": {"allowed-endpoints": ["api.example.com:8443"]}}
+            )
+        )
+
+        assert parse_config(config_file).create_allowed_endpoints == [
+            "api.example.com:8443"
+        ]
+
     def test_rejects_devcontainer_file(self, tmp_path: Path):
         """parse_config accepts only paude.json."""
         config_file = tmp_path / ".devcontainer" / "devcontainer.json"

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1294,6 +1294,25 @@ class TestParseGatewayJson:
 class TestProxyRunnerFixedIp:
     """Tests for ProxyRunner with fixed IP."""
 
+    def test_create_session_proxy_passes_allowed_endpoints(self):
+        """Endpoint exceptions reach the proxy's plural environment variable."""
+        from paude.container.proxy_runner import ProxyRunner
+
+        mock_runner = MagicMock()
+        mock_runner.engine.supports_multi_network_create = True
+        mock_runner.engine.default_bridge_network = "podman"
+        mock_runner.engine.run.return_value = MagicMock(returncode=0)
+
+        ProxyRunner(mock_runner).create_session_proxy(
+            name="paude-proxy-test",
+            image="proxy:latest",
+            network="paude-net-test",
+            allowed_endpoints=["api.example.com:8443"],
+        )
+
+        args = mock_runner.engine.run.call_args_list[0].args
+        assert "ALLOWED_ENDPOINTS=api.example.com:8443" in args
+
     def test_create_session_proxy_embeds_ip_in_network_podman(self):
         """Podman: IP is embedded in --network spec, not as separate --ip."""
         from paude.container.proxy_runner import ProxyRunner

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from paude.endpoints import normalize_allowed_endpoints
@@ -48,8 +46,3 @@ def test_normalizes_and_deduplicates_exact_authorities() -> None:
 def test_rejects_non_exact_or_malformed_authorities(value: str) -> None:
     with pytest.raises(ValueError, match="Invalid allowed endpoint"):
         normalize_allowed_endpoints([value])
-
-
-def test_proxy_image_is_pinned_to_endpoint_capable_merge() -> None:
-    dockerfile = (Path(__file__).parents[1] / "containers/proxy/Dockerfile").read_text()
-    assert "598d2d89cbc6a9002db71de9d31d20d70fefb1cc" in dockerfile

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import pytest
 
-from paude.endpoints import normalize_allowed_endpoints
+from paude.domains import host_matches_allowed_domains
+from paude.endpoints import (
+    normalize_allowed_endpoints,
+    warn_for_uncovered_allowed_endpoints,
+)
 
 
 def test_normalizes_and_deduplicates_exact_authorities() -> None:
@@ -46,3 +50,34 @@ def test_normalizes_and_deduplicates_exact_authorities() -> None:
 def test_rejects_non_exact_or_malformed_authorities(value: str) -> None:
     with pytest.raises(ValueError, match="Invalid allowed endpoint"):
         normalize_allowed_endpoints([value])
+
+
+@pytest.mark.parametrize(
+    ("host", "domains"),
+    [
+        ("api.example.com", ["api.example.com"]),
+        ("api.example.com", [".example.com"]),
+        ("us-east5-aiplatform.googleapis.com", ["vertexai"]),
+        ("anything.example", []),
+        ("anything.example", ["all"]),
+    ],
+)
+def test_allowed_domain_forms_cover_endpoint_hosts(
+    host: str, domains: list[str]
+) -> None:
+    assert host_matches_allowed_domains(host, domains)
+
+
+def test_warns_for_each_endpoint_without_domain_coverage(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    warn_for_uncovered_allowed_endpoints(
+        ["api.example.com:8443", "other.example:9000"],
+        ["covered.example"],
+        session_name="demo",
+    )
+
+    stderr = capsys.readouterr().err
+    assert "allowed endpoint 'api.example.com:8443' will remain blocked" in stderr
+    assert "allowed endpoint 'other.example:9000' will remain blocked" in stderr
+    assert "paude allowed-domains demo --add api.example.com" in stderr

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,55 @@
+"""Tests for destination-scoped allowed endpoint validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from paude.endpoints import normalize_allowed_endpoints
+
+
+def test_normalizes_and_deduplicates_exact_authorities() -> None:
+    assert normalize_allowed_endpoints(
+        [
+            "Example.COM.:08000,[2001:0db8::1]:4317",
+            "[::ffff:192.0.2.1]:9000",
+            "example.com:8000",
+            "API_SERVICE:8443",
+        ]
+    ) == [
+        "example.com:8000",
+        "[2001:db8::1]:4317",
+        "192.0.2.1:9000",
+        "api_service:8443",
+    ]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "example.com",
+        "example.com:",
+        "example.com:0",
+        "example.com:65536",
+        "example.com:+80",
+        "http://example.com:8000",
+        "user@example.com:8000",
+        "example.com:8000/path",
+        ".example.com:8000",
+        "~example:8000",
+        "*.example.com:8000",
+        "[example.com]:8000",
+        "[fe80::1%eth0]:8000",
+        "2001:db8::1:8000",
+        "192.168.001.001:8000",
+    ],
+)
+def test_rejects_non_exact_or_malformed_authorities(value: str) -> None:
+    with pytest.raises(ValueError, match="Invalid allowed endpoint"):
+        normalize_allowed_endpoints([value])
+
+
+def test_proxy_image_is_pinned_to_endpoint_capable_merge() -> None:
+    dockerfile = (Path(__file__).parents[1] / "containers/proxy/Dockerfile").read_text()
+    assert "598d2d89cbc6a9002db71de9d31d20d70fefb1cc" in dockerfile

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -17,6 +17,7 @@ from paude.backends.labels import (
     PAUDE_LABEL_AGENT_PROVIDERS,
     PAUDE_LABEL_CREATED,
     PAUDE_LABEL_DOMAINS,
+    PAUDE_LABEL_ENDPOINTS,
     PAUDE_LABEL_GPU,
     PAUDE_LABEL_OTEL_ENDPOINT,
     PAUDE_LABEL_PROVIDER,
@@ -60,6 +61,7 @@ class TestSpecFromLabels:
                 PAUDE_LABEL_YOLO: "1",
                 PAUDE_LABEL_OTEL_ENDPOINT: "http://otel:4317",
                 PAUDE_LABEL_DOMAINS: "github.com,pypi.org",
+                PAUDE_LABEL_ENDPOINTS: "api.example.com:8443,10.0.0.1:8000",
                 PAUDE_LABEL_PROXY_IMAGE: "paude-proxy:1.2.3",
             }
         )
@@ -72,6 +74,7 @@ class TestSpecFromLabels:
             yolo=True,
             otel_endpoint="http://otel:4317",
             allowed_domains=["github.com", "pypi.org"],
+            allowed_endpoints=["api.example.com:8443", "10.0.0.1:8000"],
             proxy_image="paude-proxy:1.2.3",
         )
 

--- a/tests/test_podman_proxy.py
+++ b/tests/test_podman_proxy.py
@@ -319,7 +319,7 @@ class TestResolveProxyIpGuard:
         with patch.object(
             manager,
             "get_config_from_labels",
-            return_value=("proxy:latest", [".googleapis.com"], []),
+            return_value=("proxy:latest", [".googleapis.com"], [], []),
         ):
             with pytest.raises(ProxyStartError):
                 manager.start_if_needed(session_name="test-session")
@@ -1098,7 +1098,7 @@ class TestUpdateDomainTransaction:
         network.get_network_gateway.return_value = "10.89.0.1"
         manager = PodmanProxyManager(runner, network)
         manager.get_config_from_labels = MagicMock(  # type: ignore[method-assign]
-            return_value=("proxy:latest", [".old.example"], [])
+            return_value=("proxy:latest", [".old.example"], [], [])
         )
         prepared = PreparedProxyCredentials(credentials=ProxyCredentials())
         manager._credentials = MagicMock()
@@ -1132,7 +1132,7 @@ class TestUpdateDomainTransaction:
         network.get_network_gateway.return_value = "10.89.0.1"
         manager = PodmanProxyManager(runner, network)
         manager.get_config_from_labels = MagicMock(  # type: ignore[method-assign]
-            return_value=("proxy:latest", [".old.example"], [])
+            return_value=("proxy:latest", [".old.example"], [], [])
         )
         prepared = PreparedProxyCredentials(credentials=ProxyCredentials())
         manager._credentials = MagicMock()
@@ -1152,6 +1152,45 @@ class TestUpdateDomainTransaction:
         assert [call[0] for call in events.mock_calls] == ["write", "commit"]
         manager._credentials.commit_update.assert_called_once_with(prepared)
         swap.rollback.assert_not_called()
+
+    @patch("paude.backends.podman.proxy._get_host_dns", return_value=None)
+    def test_domain_update_preserves_and_commits_endpoint_policy(
+        self, mock_dns: MagicMock
+    ) -> None:
+        runner = _make_mock_runner()
+        runner.container_exists.return_value = True
+        runner.get_container_image.return_value = "proxy:latest"
+        network = MagicMock()
+        network.get_network_gateway.return_value = "10.89.0.1"
+        manager = PodmanProxyManager(runner, network)
+        manager.get_config_from_labels = MagicMock(  # type: ignore[method-assign]
+            return_value=(
+                "proxy:latest",
+                ["api.example.com"],
+                ["api.example.com:8443"],
+                [],
+            )
+        )
+        manager._credentials = MagicMock()
+        manager._credentials.prepare_update.return_value = PreparedProxyCredentials(
+            credentials=ProxyCredentials()
+        )
+        manager._credentials.credential_env.return_value = {}
+        manager._state = MagicMock()
+        manager._endpoint_state = MagicMock()
+        manager._proxy_runner = MagicMock()
+        manager._proxy_runner.swap_session_proxy.return_value = MagicMock()
+        manager._ca_cert = MagicMock()
+
+        manager.update_domains("test-session", ["new.example.com"])
+
+        swap_args = manager._proxy_runner.swap_session_proxy.call_args.kwargs
+        assert swap_args["allowed_endpoints"] == ["api.example.com:8443"]
+        manager._endpoint_state.write.assert_called_once_with(
+            "paude-auth-test-session",
+            "proxy:latest",
+            ["api.example.com:8443"],
+        )
 
 
 class TestSourceIpFiltering:
@@ -1259,7 +1298,7 @@ class TestSourceIpFiltering:
         with patch.object(
             manager,
             "get_config_from_labels",
-            return_value=("proxy:latest", [".googleapis.com"], []),
+            return_value=("proxy:latest", [".googleapis.com"], [], []),
         ):
             manager.start_if_needed(
                 session_name="test-session",

--- a/tests/test_podman_proxy.py
+++ b/tests/test_podman_proxy.py
@@ -1228,6 +1228,49 @@ class TestUpdateEndpointsCapability:
 
         manager._proxy_runner.swap_session_proxy.assert_not_called()
 
+    def test_warns_after_updating_uncovered_endpoint(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        manager = PodmanProxyManager(_make_mock_runner(), MagicMock())
+        manager._endpoint_update_proxy_image = MagicMock(  # type: ignore[method-assign]
+            return_value="proxy:endpoint-capable"
+        )
+        manager.get_allowed_domains = MagicMock(  # type: ignore[method-assign]
+            return_value=["other.example"]
+        )
+        manager.update_domains = MagicMock()  # type: ignore[method-assign]
+
+        manager.update_endpoints("test-session", ["api.example.com:8443"])
+
+        stderr = capsys.readouterr().err
+        assert "will remain blocked" in stderr
+        assert "paude allowed-domains test-session --add api.example.com" in stderr
+
+    @pytest.mark.parametrize(
+        "domains",
+        [
+            [".example.com"],
+            [r"~^api\.example\.com$"],
+        ],
+    )
+    def test_covered_endpoint_does_not_warn(
+        self,
+        domains: list[str],
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        manager = PodmanProxyManager(_make_mock_runner(), MagicMock())
+        manager._endpoint_update_proxy_image = MagicMock(  # type: ignore[method-assign]
+            return_value="proxy:endpoint-capable"
+        )
+        manager.get_allowed_domains = MagicMock(  # type: ignore[method-assign]
+            return_value=domains
+        )
+        manager.update_domains = MagicMock()  # type: ignore[method-assign]
+
+        manager.update_endpoints("test-session", ["api.example.com:8443"])
+
+        assert "will remain blocked" not in capsys.readouterr().err
+
     @patch("paude.backends.podman.proxy._get_host_dns", return_value=None)
     def test_uses_configured_endpoint_capable_image(
         self, mock_dns: MagicMock, capsys: pytest.CaptureFixture[str]

--- a/tests/test_podman_proxy.py
+++ b/tests/test_podman_proxy.py
@@ -7,6 +7,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from paude.backends.labels import (
+    PAUDE_LABEL_DOMAINS,
+    PAUDE_LABEL_ENDPOINTS,
+    PAUDE_LABEL_PROXY_IMAGE,
+    PAUDE_LABEL_SESSION,
+)
 from paude.backends.podman.proxy import (
     _PROXY_IP_POLL_ATTEMPTS,
     CA_CERT_CONTAINER_PATH,
@@ -1189,6 +1195,71 @@ class TestUpdateDomainTransaction:
         manager._endpoint_state.write.assert_called_once_with(
             "paude-auth-test-session",
             "proxy:latest",
+            ["api.example.com:8443"],
+        )
+
+
+class TestUpdateEndpointsCapability:
+    """Endpoint updates never silently reuse a pre-feature proxy image."""
+
+    def test_legacy_session_requires_upgrade(self) -> None:
+        runner = _make_mock_runner()
+        runner.list_containers.return_value = [
+            {
+                "Labels": {
+                    PAUDE_LABEL_SESSION: "test-session",
+                    PAUDE_LABEL_DOMAINS: "api.example.com",
+                    PAUDE_LABEL_PROXY_IMAGE: "proxy:legacy",
+                }
+            }
+        ]
+        manager = PodmanProxyManager(runner, MagicMock())
+        manager._proxy_runner = MagicMock()
+
+        with pytest.raises(ValueError, match="paude upgrade test-session"):
+            manager.update_endpoints("test-session", ["api.example.com:8443"])
+
+        manager._proxy_runner.swap_session_proxy.assert_not_called()
+
+    @patch("paude.backends.podman.proxy._get_host_dns", return_value=None)
+    def test_uses_configured_endpoint_capable_image(
+        self, mock_dns: MagicMock
+    ) -> None:
+        runner = _make_mock_runner()
+        runner.container_exists.return_value = True
+        runner.get_container_image.return_value = "proxy:legacy"
+        runner.get_container_env.return_value = "api.example.com"
+        runner.list_containers.return_value = [
+            {
+                "Labels": {
+                    PAUDE_LABEL_SESSION: "test-session",
+                    PAUDE_LABEL_DOMAINS: "api.example.com",
+                    PAUDE_LABEL_ENDPOINTS: "",
+                    PAUDE_LABEL_PROXY_IMAGE: "proxy:endpoint-capable",
+                }
+            }
+        ]
+        network = MagicMock()
+        network.get_network_gateway.return_value = "10.89.0.1"
+        manager = PodmanProxyManager(runner, network)
+        manager._credentials = MagicMock()
+        manager._credentials.prepare_update.return_value = PreparedProxyCredentials(
+            credentials=ProxyCredentials()
+        )
+        manager._credentials.credential_env.return_value = {}
+        manager._state = MagicMock()
+        manager._endpoint_state = MagicMock()
+        manager._proxy_runner = MagicMock()
+        manager._proxy_runner.swap_session_proxy.return_value = MagicMock()
+        manager._ca_cert = MagicMock()
+
+        manager.update_endpoints("test-session", ["api.example.com:8443"])
+
+        swap_args = manager._proxy_runner.swap_session_proxy.call_args.kwargs
+        assert swap_args["image"] == "proxy:endpoint-capable"
+        manager._endpoint_state.write.assert_called_once_with(
+            "paude-auth-test-session",
+            "proxy:endpoint-capable",
             ["api.example.com:8443"],
         )
 

--- a/tests/test_podman_proxy.py
+++ b/tests/test_podman_proxy.py
@@ -44,6 +44,12 @@ def _make_mock_runner(engine_binary: str = "podman") -> MagicMock:
         if args[:3] == ("inspect", "-f", "{{.State.Running}}"):
             return MagicMock(returncode=0, stdout="true\n", stderr="")
         if args and args[0] == "run" and any("test -e" in arg for arg in args):
+            if any("printf" in arg for arg in args):
+                return MagicMock(
+                    returncode=0,
+                    stdout="\0".join(["0", "", "0", "", ""]),
+                    stderr="",
+                )
             return MagicMock(returncode=3, stdout="", stderr="")
         return MagicMock(returncode=0, stdout="", stderr="")
 
@@ -1111,7 +1117,7 @@ class TestUpdateDomainTransaction:
         manager._credentials.prepare_update.return_value = prepared
         manager._credentials.credential_env.return_value = {}
         manager._state = MagicMock()
-        manager._state.read.return_value = [".old.example"]
+        manager._state.read_pair.return_value = ([".old.example"], None)
         manager._state.write.side_effect = RuntimeError("write failed")
         swap = MagicMock()
         manager._proxy_runner = MagicMock()
@@ -1145,7 +1151,7 @@ class TestUpdateDomainTransaction:
         manager._credentials.prepare_update.return_value = prepared
         manager._credentials.credential_env.return_value = {}
         manager._state = MagicMock()
-        manager._state.read.return_value = [".old.example"]
+        manager._state.read_pair.return_value = ([".old.example"], None)
         swap = MagicMock()
         manager._proxy_runner = MagicMock()
         manager._proxy_runner.swap_session_proxy.return_value = swap
@@ -1184,6 +1190,7 @@ class TestUpdateDomainTransaction:
         manager._credentials.credential_env.return_value = {}
         manager._state = MagicMock()
         manager._endpoint_state = MagicMock()
+        manager._state.read_pair.return_value = (["api.example.com"], None)
         manager._proxy_runner = MagicMock()
         manager._proxy_runner.swap_session_proxy.return_value = MagicMock()
         manager._ca_cert = MagicMock()
@@ -1223,7 +1230,7 @@ class TestUpdateEndpointsCapability:
 
     @patch("paude.backends.podman.proxy._get_host_dns", return_value=None)
     def test_uses_configured_endpoint_capable_image(
-        self, mock_dns: MagicMock
+        self, mock_dns: MagicMock, capsys: pytest.CaptureFixture[str]
     ) -> None:
         runner = _make_mock_runner()
         runner.container_exists.return_value = True
@@ -1249,6 +1256,7 @@ class TestUpdateEndpointsCapability:
         manager._credentials.credential_env.return_value = {}
         manager._state = MagicMock()
         manager._endpoint_state = MagicMock()
+        manager._state.read_pair.return_value = (["api.example.com"], None)
         manager._proxy_runner = MagicMock()
         manager._proxy_runner.swap_session_proxy.return_value = MagicMock()
         manager._ca_cert = MagicMock()
@@ -1257,6 +1265,10 @@ class TestUpdateEndpointsCapability:
 
         swap_args = manager._proxy_runner.swap_session_proxy.call_args.kwargs
         assert swap_args["image"] == "proxy:endpoint-capable"
+        assert (
+            "Updating proxy endpoints for session 'test-session'"
+            in capsys.readouterr().err
+        )
         manager._endpoint_state.write.assert_called_once_with(
             "paude-auth-test-session",
             "proxy:endpoint-capable",

--- a/tests/test_podman_session.py
+++ b/tests/test_podman_session.py
@@ -1536,11 +1536,8 @@ class TestProxyRecreation:
         mock_network = MagicMock()
 
         backend = make_backend(mock_runner, mock_network)
-        backend._proxy.read_domain_state = MagicMock(  # type: ignore[method-assign]
-            return_value=None
-        )
-        backend._proxy.read_endpoint_state = MagicMock(  # type: ignore[method-assign]
-            return_value=None
+        backend._proxy.read_policy_state = MagicMock(  # type: ignore[method-assign]
+            return_value=(None, None)
         )
         backend.start_session("my-session")
 
@@ -1615,11 +1612,8 @@ class TestProxyRecreation:
         mock_network = MagicMock()
 
         backend = make_backend(mock_runner, mock_network)
-        backend._proxy.read_domain_state = MagicMock(  # type: ignore[method-assign]
-            return_value=None
-        )
-        backend._proxy.read_endpoint_state = MagicMock(  # type: ignore[method-assign]
-            return_value=None
+        backend._proxy.read_policy_state = MagicMock(  # type: ignore[method-assign]
+            return_value=(None, None)
         )
         backend.connect_session("my-session")
 

--- a/tests/test_podman_session.py
+++ b/tests/test_podman_session.py
@@ -15,6 +15,7 @@ from paude.backends.labels import (
     PAUDE_LABEL_APP,
     PAUDE_LABEL_CREATED,
     PAUDE_LABEL_DOMAINS,
+    PAUDE_LABEL_ENDPOINTS,
     PAUDE_LABEL_PROVIDERS,
     PAUDE_LABEL_PROXY_IMAGE,
     PAUDE_LABEL_SESSION,
@@ -1059,6 +1060,7 @@ class TestPodmanBackendCreateSessionWithProxy:
             workspace=Path("/home/user/project"),
             image="paude:latest",
             allowed_domains=[".googleapis.com", ".pypi.org"],
+            allowed_endpoints=["api.example.com:8443"],
             proxy_image="proxy:latest",
         )
         session = backend.create_session(config)
@@ -1101,6 +1103,7 @@ class TestPodmanBackendCreateSessionWithProxy:
             workspace=Path("/home/user/project"),
             image="paude:latest",
             allowed_domains=[".googleapis.com", ".pypi.org"],
+            allowed_endpoints=["api.example.com:8443"],
             proxy_image="proxy:latest",
         )
         backend.create_session(config)
@@ -1109,6 +1112,7 @@ class TestPodmanBackendCreateSessionWithProxy:
         labels = call_kwargs["labels"]
         assert PAUDE_LABEL_DOMAINS in labels
         assert labels[PAUDE_LABEL_DOMAINS] == ".googleapis.com,.pypi.org"
+        assert labels[PAUDE_LABEL_ENDPOINTS] == "api.example.com:8443"
         assert labels[PAUDE_LABEL_PROXY_IMAGE] == "proxy:latest"
 
     @patch("paude.backends.podman.proxy.get_podman_machine_dns")
@@ -1535,6 +1539,9 @@ class TestProxyRecreation:
         backend._proxy.read_domain_state = MagicMock(  # type: ignore[method-assign]
             return_value=None
         )
+        backend._proxy.read_endpoint_state = MagicMock(  # type: ignore[method-assign]
+            return_value=None
+        )
         backend.start_session("my-session")
 
         # Proxy should be recreated via engine.run (create + start)
@@ -1609,6 +1616,9 @@ class TestProxyRecreation:
 
         backend = make_backend(mock_runner, mock_network)
         backend._proxy.read_domain_state = MagicMock(  # type: ignore[method-assign]
+            return_value=None
+        )
+        backend._proxy.read_endpoint_state = MagicMock(  # type: ignore[method-assign]
             return_value=None
         )
         backend.connect_session("my-session")

--- a/tests/test_proxy_log.py
+++ b/tests/test_proxy_log.py
@@ -75,7 +75,8 @@ class TestParseBlockedLog:
         log = "08/Mar/2026:14:00:00 +0000 10.0.0.2 TCP_DENIED/403 GET http://example.com:8080/path BLOCKED"
         result = parse_blocked_log(log)
         assert len(result) == 1
-        assert result[0].domain == "example.com"
+        assert result[0].domain == "example.com:8080"
+        assert result[0].port == 8080
 
     def test_connect_without_port(self) -> None:
         log = "08/Mar/2026:14:00:00 +0000 10.0.0.2 TCP_DENIED/403 CONNECT example.com BLOCKED"

--- a/tests/test_proxy_state.py
+++ b/tests/test_proxy_state.py
@@ -37,6 +37,58 @@ class TestProxyStateStore:
 
         assert ProxyStateStore(runner).read("auth", "proxy:latest") == []
 
+    def test_reads_domain_and_endpoint_records_in_one_helper(self) -> None:
+        domain_payload = json.dumps(
+            {"schema": "allowed-domains.v1", "domains": ["api.example.com"]}
+        )
+        endpoint_payload = json.dumps(
+            {
+                "schema": "allowed-endpoints.v1",
+                "endpoints": ["api.example.com:8443"],
+            }
+        )
+        runner = MagicMock(spec=ContainerRunner)
+        runner.engine.run.return_value = MagicMock(
+            returncode=0,
+            stdout="\0".join(["1", domain_payload, "1", endpoint_payload, ""]),
+            stderr="",
+        )
+        domains = ProxyStateStore(runner)
+        endpoints = ProxyStateStore(
+            runner,
+            path="/data/auth/allowed-endpoints.json",
+            schema="allowed-endpoints.v1",
+            field="endpoints",
+            description="allowed-endpoint",
+        )
+
+        assert domains.read_pair(endpoints, "auth", "proxy:latest") == (
+            ["api.example.com"],
+            ["api.example.com:8443"],
+        )
+        runner.engine.run.assert_called_once()
+
+    def test_paired_read_preserves_an_absent_legacy_record(self) -> None:
+        endpoint_payload = json.dumps(
+            {"schema": "allowed-endpoints.v1", "endpoints": []}
+        )
+        runner = MagicMock(spec=ContainerRunner)
+        runner.engine.run.return_value = MagicMock(
+            returncode=0,
+            stdout="\0".join(["0", "", "1", endpoint_payload, ""]),
+            stderr="",
+        )
+        domains = ProxyStateStore(runner)
+        endpoints = ProxyStateStore(
+            runner,
+            path="/data/auth/allowed-endpoints.json",
+            schema="allowed-endpoints.v1",
+            field="endpoints",
+            description="allowed-endpoint",
+        )
+
+        assert domains.read_pair(endpoints, "auth", "proxy:latest") == (None, [])
+
     @pytest.mark.parametrize(
         "result",
         [

--- a/tests/test_session_resources.py
+++ b/tests/test_session_resources.py
@@ -43,7 +43,9 @@ def networks() -> MagicMock:
 
 @pytest.fixture
 def proxy() -> MagicMock:
-    return MagicMock(spec=PodmanProxyManager)
+    proxy = MagicMock(spec=PodmanProxyManager)
+    proxy.read_policy_state.return_value = (None, None)
+    return proxy
 
 
 @pytest.fixture
@@ -257,13 +259,13 @@ class TestReads:
                 },
             }
         ]
-        proxy.read_domain_state.return_value = []
+        proxy.read_policy_state.return_value = ([], None)
 
         view = resources.labels(SESSION)
 
         assert view is not None
         assert view.spec.allowed_domains == []
-        proxy.read_domain_state.assert_called_once_with(SESSION, "proxy:latest")
+        proxy.read_policy_state.assert_called_once_with(SESSION, "proxy:latest")
 
     def test_labels_is_none_for_a_session_with_no_container(
         self, resources: SessionResources, runner: MagicMock

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -363,6 +363,9 @@ def _upgrade_backend(
     backend._proxy.read_domain_state = MagicMock(  # type: ignore[method-assign]
         return_value=None
     )
+    backend._proxy.read_endpoint_state = MagicMock(  # type: ignore[method-assign]
+        return_value=None
+    )
     create_session = MagicMock(return_value=_upgraded_session())
     start = MagicMock()
     backend.create_session = create_session  # type: ignore[method-assign]

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -360,11 +360,8 @@ def _upgrade_backend(
     volumes = MagicMock(spec=VolumeManager)
     networks = MagicMock(spec=NetworkManager)
     backend = make_backend(runner, network_manager=networks, volume_manager=volumes)
-    backend._proxy.read_domain_state = MagicMock(  # type: ignore[method-assign]
-        return_value=None
-    )
-    backend._proxy.read_endpoint_state = MagicMock(  # type: ignore[method-assign]
-        return_value=None
+    backend._proxy.read_policy_state = MagicMock(  # type: ignore[method-assign]
+        return_value=(None, None)
     )
     create_session = MagicMock(return_value=_upgraded_session())
     start = MagicMock()

--- a/tests/test_upgrade_state.py
+++ b/tests/test_upgrade_state.py
@@ -25,6 +25,7 @@ def _manifest(name: str = "test-session") -> UpgradeManifest:
         yolo=True,
         otel_endpoint="http://collector:4318",
         allowed_domains=[".googleapis.com", ".pypi.org"],
+        allowed_endpoints=["api.example.com:8443"],
         proxy_image="proxy:latest",
     )
 
@@ -166,6 +167,7 @@ class TestManifestSchema:
             "yolo",
             "otel_endpoint",
             "allowed_domains",
+            "allowed_endpoints",
             "proxy_image",
         }
 
@@ -193,6 +195,7 @@ class TestManifestCarriesTheWholeSpec:
             yolo=True,
             otel_endpoint="http://collector:4318",
             allowed_domains=[".pypi.org"],
+            allowed_endpoints=["api.example.com:8443"],
             proxy_image="proxy:latest",
         )
         state = ResolvedSession(

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -24,6 +24,19 @@ class TestLoadUserDefaults:
         assert result.yolo is None
         assert result.git is None
         assert result.allowed_domains == []
+        assert result.allowed_endpoints == []
+
+    def test_loads_allowed_endpoints(self, tmp_path: Path) -> None:
+        config = tmp_path / "defaults.json"
+        config.write_text(
+            json.dumps(
+                {"defaults": {"allowed-endpoints": ["api.example.com:8443"]}}
+            )
+        )
+
+        assert load_user_defaults(config).allowed_endpoints == [
+            "api.example.com:8443"
+        ]
 
     def test_warns_on_unknown_keys(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -100,6 +113,7 @@ class TestResolveCreateOptions:
             "cli_platform": None,
             "cli_gpu": None,
             "cli_allowed_domains": None,
+            "cli_allowed_endpoints": None,
             "project_config": None,
             "user_defaults": UserDefaults(),
         }
@@ -110,10 +124,30 @@ class TestResolveCreateOptions:
         """Returns built-in defaults when nothing is configured."""
         result = self._resolve()
         assert result.backend.value == "podman"
+        assert result.allowed_endpoints == []
         assert result.backend.source == "built-in"
         assert result.agent.value == "claude"
         assert result.yolo.value is False
         assert result.git.value is False
+
+    def test_endpoints_merge_and_cli_override(self) -> None:
+        user = UserDefaults(allowed_endpoints=["user.example:8000"])
+        project = PaudeConfig(
+            create_allowed_endpoints=["project.example:9000"]
+        )
+
+        merged = self._resolve(user_defaults=user, project_config=project)
+        assert merged.allowed_endpoints == [
+            "user.example:8000",
+            "project.example:9000",
+        ]
+
+        overridden = self._resolve(
+            user_defaults=user,
+            project_config=project,
+            cli_allowed_endpoints=["cli.example:7000"],
+        )
+        assert overridden.allowed_endpoints == ["cli.example:7000"]
 
     def test_project_overrides_user(self):
         """Project config overrides user defaults for agent."""


### PR DESCRIPTION
Adds exact host:port endpoint rules for approved nonstandard ports, allowing use cases such as 192.168.7.31:8000 without broadly opening that port.

The feature includes CLI/config/runtime management, persistence across session lifecycle operations, diagnostics, documentation, and proxy integration pinned to paude-proxy commit 598d2d89. Endpoint rules remain subject to ALLOWED_DOMAINS; they do not bypass host authorization.