### PR TITLE
Require Podman 4 networking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     name: Podman Integration Tests
     needs: [detect-changes, lint, unit-tests]
     if: always() && !failure() && !cancelled() && (needs.detect-changes.outputs.code == 'true' || needs.detect-changes.outputs.containers == 'true')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
 
@@ -84,6 +84,12 @@ jobs:
         run: |
           podman version
           podman info
+          podman_version="$(podman version --format '{{.Client.Version}}')"
+          podman_major="${podman_version%%.*}"
+          if ! [[ "$podman_major" =~ ^[0-9]+$ ]] || (( podman_major < 4 )); then
+            echo "Podman 4.0+ is required; found ${podman_version:-unknown}" >&2
+            exit 1
+          fi
 
       - name: Build test images
         run: make build

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -151,22 +151,27 @@ This predates the `--add-agent` work (the `--providers` validation branch was al
 ### REFACTOR-009: Proxy IP is inspected back from an auto-allocated subnet instead of being chosen deterministically
 
 **Status**: Open
-**Priority**: Low (bounded retry makes it reliable today; deterministic subnet is the deeper fix)
+**Priority**: Low (deterministic subnet allocation would remove inspect coupling)
 **Discovered**: 2026-08-14 during a `/simplify` review of the proxy-IP race fix
 
 `PodmanProxyManager.create_proxy` (`src/paude/backends/podman/proxy.py`) lets
 Podman auto-allocate the session network's subnet (`create_internal_network`
 with no `--subnet`), then discovers the gateway/proxy IP by running `podman
 network inspect` (`_get_proxy_ip` → `NetworkManager.get_network_gateway`) and
-deriving `gateway + 1`. The inspect can race the create — on a `--disable-dns`
-network run under CI load, `network inspect` occasionally returns before the
-subnet/IPAM is populated, so the proxy IP comes back `None`. The current fix is
-a bounded retry poll in `_get_proxy_ip` (5 attempts, 0.25s apart) plus a
-Podman-gated hard error when the IP still can't be determined.
+deriving `gateway + 1`. A bounded retry poll in `_get_proxy_ip` (5 attempts,
+0.25s apart) covers transient inspect results, and a Podman-gated hard error
+prevents an unreachable proxy when the IP still cannot be determined.
 
-The retry is a reasonable, low-risk interim measure, but it is a workaround for
-a design that could be deterministic: passing an explicit `--subnet` at network
-create time makes the gateway/proxy IP known *without inspecting at all*,
+The 2026-09-04 Podman CI failure was not this race: the runner had downgraded to
+unsupported Podman 3.4.4, whose CNI inspect output uses a different schema.
+Podman 3.x also cannot safely express Paude's repeated `--network` flags and
+per-network static IPs. An explicit subnet or a CNI parser branch would not fix
+that incompatibility, so Paude now requires Podman 4.0+ and fails before
+creating proxy resources on older or indeterminate versions.
+
+The remaining inspect dependency could be removed by passing an explicit
+`--subnet` at network creation time. That makes the gateway/proxy IP known
+*without inspecting at all*,
 eliminating the whole race class — and with it the retry poll, the `None`
 return, the hard-error gate, and the Docker hostname-fallback branch in
 `session_setup.py`. The catch (why it's deferred): an explicit subnet trades the
@@ -897,4 +902,3 @@ Note: README's agent table/examples were not re-audited as part of the 2026-07-3
 **Discovered**: 2026-07-31 during docs/ audit (`docs/CONFIGURATION.md`)
 
 Gas City no longer contributes a standalone alias. Its resolved child-agent composition contributes the Claude/Gemini domains when those children are installed.
-

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ implicitly—list every CLI the image should contain.
 
 ### Prerequisites
 
-**Container runtime**: [Podman](https://podman.io/getting-started/installation) or [Docker](https://docs.docker.com/get-docker/), locally or on a remote host reached over SSH.
+**Container runtime**: [Podman 4.0+](https://podman.io/getting-started/installation) or [Docker](https://docs.docker.com/get-docker/), locally or on a remote host reached over SSH. Podman 4.0 introduced the multi-network and per-network static-IP support required for isolated proxy networking.
 
 **Authentication** — set up credentials for your chosen provider:
 
@@ -488,7 +488,7 @@ pip install -e .
 ### Requirements
 
 - Python 3.11+ (for the Python package)
-- [Podman](https://podman.io/getting-started/installation) or [Docker](https://docs.docker.com/get-docker/) (for local backend)
+- [Podman 4.0+](https://podman.io/getting-started/installation) or [Docker](https://docs.docker.com/get-docker/) (for local backend; Podman 4.0+ is required for isolated proxy networking)
 - Auth credentials for your provider (Google Cloud SDK, API key, etc.)
 
 ## Development

--- a/src/paude/backends/podman/proxy.py
+++ b/src/paude/backends/podman/proxy.py
@@ -195,6 +195,7 @@ class PodmanProxyManager:
         if self._runner.container_exists(pname):
             if self._runner.container_running(pname):
                 return
+            self._runner.engine.ensure_supported_networking()
             print(f"Starting proxy {pname}...", file=sys.stderr)
             self._proxy_runner.start_session_proxy(pname)
             return
@@ -205,6 +206,7 @@ class PodmanProxyManager:
             return
 
         # Recreate the missing proxy
+        self._runner.engine.ensure_supported_networking()
         proxy_image, domains, endpoints, otel_ports = proxy_config
         nname = network_name(session_name)
         ca_vol = ca_volume_name(session_name)
@@ -251,6 +253,7 @@ class PodmanProxyManager:
 
     def start_proxy(self, session_name: str) -> None:
         """Start the proxy container for a session."""
+        self._runner.engine.ensure_supported_networking()
         pname = proxy_container_name(session_name)
         self._proxy_runner.start_session_proxy(pname)
 
@@ -351,6 +354,7 @@ class PodmanProxyManager:
         if not proxy_image:
             raise ValueError("proxy_image is required to create a proxy")
 
+        self._runner.engine.ensure_supported_networking()
         nname = network_name(session_name)
         # `disable_dns` is the single fact that decides whether a hostname
         # fallback is viable: with DNS the agent can resolve the proxy by
@@ -490,6 +494,7 @@ class PodmanProxyManager:
         if not running_proxy_image:
             raise ValueError(f"Cannot inspect proxy container: {pname}")
         proxy_image = proxy_image or running_proxy_image
+        self._runner.engine.ensure_supported_networking()
 
         # Preserve OTEL ports from labels across proxy recreate
         proxy_config = self.get_config_from_labels(session_name)

--- a/src/paude/cli/help.py
+++ b/src/paude/cli/help.py
@@ -91,7 +91,8 @@ _SECTIONS: tuple[HelpSection, ...] = (
             " utilities, including rg (ripgrep) for fast code search."
             " The Codex CLI image also includes Node.js for documentation"
             " tooling, using the custom base image's package manager or an"
-            " existing Node.js installation."
+            " existing Node.js installation. Podman 4.0+ or Docker is required"
+            " for isolated proxy networking."
         ),
     ),
     HelpSection(

--- a/src/paude/container/engine.py
+++ b/src/paude/container/engine.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import re
 import subprocess
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -17,6 +19,31 @@ if TYPE_CHECKING:
 # clobbered, short enough that a caller who didn't drain to EOF isn't left
 # hanging.
 _REAP_GRACE_SECONDS = 5.0
+MINIMUM_PODMAN_VERSION = (4, 0)
+
+
+class UnsupportedEngineError(RuntimeError):
+    """Raised when an engine cannot provide required networking semantics."""
+
+
+def _parse_podman_version(output: str) -> tuple[int, ...]:
+    """Parse the effective version from a Podman JSON version report."""
+    report = json.loads(output)
+    if not isinstance(report, dict):
+        raise ValueError("expected a JSON object")
+    server = report.get("Server")
+    source = server if isinstance(server, dict) else report.get("Client")
+    if not isinstance(source, dict):
+        raise ValueError("missing Client and Server version objects")
+    raw_version = source.get("Version")
+    if not isinstance(raw_version, str):
+        raise ValueError("missing Version string")
+    match = re.fullmatch(
+        r"v?(\d+(?:\.\d+)*)(?:[-+][0-9A-Za-z.-]+)?", raw_version
+    )
+    if match is None:
+        raise ValueError(f"invalid Version value {raw_version!r}")
+    return tuple(int(part) for part in match.group(1).split("."))
 
 
 class ContainerEngine:
@@ -40,6 +67,9 @@ class ContainerEngine:
 
             transport = LocalTransport()
         self._transport = transport
+        self._version_checked = False
+        self._version: tuple[int, ...] | None = None
+        self._version_error: str | None = None
 
     def run(
         self,
@@ -154,6 +184,59 @@ class ContainerEngine:
         """Access the underlying transport."""
         return self._transport
 
+    @property
+    def version(self) -> tuple[int, ...] | None:
+        """Return the effective Podman version, probing at most once.
+
+        Remote Podman clients report both client and server versions. The
+        server controls networking behavior, so prefer it when present.
+        Docker does not need this Podman-specific capability probe.
+        """
+        if not self.is_podman:
+            return None
+        if not self._version_checked:
+            self._probe_version()
+        return self._version
+
+    def _probe_version(self) -> None:
+        """Populate the cached Podman version and diagnostic."""
+        self._version_checked = True
+        try:
+            result = self.run("version", "--format", "json", check=False)
+        except Exception as exc:
+            self._version_error = f"command failed: {exc}"
+            return
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "no output").strip()
+            self._version_error = f"exit {result.returncode}: {detail}"
+            return
+        try:
+            self._version = _parse_podman_version(result.stdout)
+        except (json.JSONDecodeError, ValueError) as exc:
+            self._version_error = f"invalid JSON output {result.stdout!r}: {exc}"
+
+    def ensure_supported_networking(self) -> None:
+        """Require Podman networking semantics needed for proxy isolation."""
+        if not self.is_podman:
+            return
+        version = self.version
+        command = f"{self.binary} version --format json"
+        if version is None:
+            raise UnsupportedEngineError(
+                f"Could not determine the Podman version using `{command}` "
+                f"({self._version_error or 'unknown error'}). Paude requires "
+                "Podman 4.0+ for isolated proxy networking."
+            )
+        required = MINIMUM_PODMAN_VERSION
+        comparable = version + (0,) * max(0, len(required) - len(version))
+        if comparable < required:
+            detected = ".".join(str(part) for part in version)
+            raise UnsupportedEngineError(
+                f"Podman {detected} is unsupported; Paude requires Podman "
+                "4.0+ for repeated --network flags and per-network static "
+                "IPs used by isolated proxy networking."
+            )
+
     def _exists(self, resource_type: str, name: str) -> bool:
         """Check if a resource exists.
 
@@ -191,7 +274,7 @@ class ContainerEngine:
     def network_args(self, network: str, network_ip: str | None = None) -> list[str]:
         """Build ``--network`` arguments, embedding a static IP if given.
 
-        Podman embeds the IP in the ``--network`` value (``net:ip=...``);
+        Podman 4.0+ embeds the IP in the ``--network`` value (``net:ip=...``);
         Docker requires the IP as a separate ``--ip`` flag.
         """
         if network_ip and not self.is_podman:
@@ -224,7 +307,7 @@ class ContainerEngine:
     def supports_multi_network_create(self) -> bool:
         """Whether --network net1,net2 works in create/run.
 
-        Podman supports this; Docker requires ``docker network connect``
+        Podman 4.0+ supports this; Docker requires ``docker network connect``
         after container creation.
         """
         return self.binary != "docker"

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -90,7 +90,13 @@ class FakeTransport:
     ) -> None:
         self._is_remote = is_remote
         self._host_label = host_label
-        self._results = results or {}
+        supported_version = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"Client":{"Version":"5.8.4"}}',
+            stderr="",
+        )
+        self._results = {"version --format json": supported_version, **(results or {})}
         self._default = default_result or subprocess.CompletedProcess(
             args=[], returncode=0, stdout="", stderr=""
         )

--- a/tests/test_ci.py
+++ b/tests/test_ci.py
@@ -1,0 +1,15 @@
+"""Tests for continuous-integration workflow guarantees."""
+
+from pathlib import Path
+
+
+def test_podman_integration_requires_supported_engine() -> None:
+    """Podman integration runs on a supported image and checks its version."""
+    workflow = (
+        Path(__file__).parents[1] / ".github" / "workflows" / "ci.yml"
+    ).read_text()
+    job = workflow.split("  podman-integration:\n", maxsplit=1)[1]
+
+    assert "    runs-on: ubuntu-24.04\n" in job
+    assert "podman version --format" in job
+    assert "podman_major < 4" in job

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -865,6 +865,8 @@ def test_help_shows_extra_sections():
     assert "Configuration" in output
     assert "Security" in output
     assert "Agents" in output
+    assert "Podman 4.0+" in output
+    assert "isolated proxy networking" in output
 
 
 @pytest.mark.parametrize(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from paude.container.engine import ContainerEngine
+from paude.container.engine import ContainerEngine, UnsupportedEngineError
 from paude.transport import LocalTransport, SshTransport
-from tests.fakes import FakePopen
+from tests.fakes import FakePopen, FakeTransport, recorded_commands
 
 
 class TestContainerEngineInit:
@@ -44,6 +45,91 @@ class TestContainerEngineProperties:
 
     def test_docker_default_bridge_network(self) -> None:
         assert ContainerEngine("docker").default_bridge_network == "bridge"
+
+
+class TestPodmanVersionSupport:
+    """Tests for the Podman networking capability guard."""
+
+    @staticmethod
+    def _engine(
+        stdout: str, *, returncode: int = 0, stderr: str = ""
+    ) -> ContainerEngine:
+        result = subprocess.CompletedProcess(
+            args=[], returncode=returncode, stdout=stdout, stderr=stderr
+        )
+        transport = FakeTransport(results={"version --format json": result})
+        return ContainerEngine("podman", transport=transport)
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("4.0.0", (4, 0, 0)),
+            ("4.9.3-rc1", (4, 9, 3)),
+            ("v5.8.4-dev", (5, 8, 4)),
+        ],
+    )
+    def test_version_parses_release_strings(
+        self, raw: str, expected: tuple[int, ...]
+    ) -> None:
+        engine = self._engine(json.dumps({"Client": {"Version": raw}}))
+        assert engine.version == expected
+
+    def test_version_prefers_server_and_is_cached(self) -> None:
+        engine = self._engine(
+            json.dumps(
+                {
+                    "Client": {"Version": "5.8.4"},
+                    "Server": {"Version": "4.9.3"},
+                }
+            )
+        )
+        assert engine.version == (4, 9, 3)
+        assert engine.version == (4, 9, 3)
+        assert recorded_commands(engine) == [["podman", "version", "--format", "json"]]
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["not-json", "{}", '{"Client":{}}', '{"Client":{"Version":"4broken"}}'],
+    )
+    def test_version_is_none_for_invalid_output(self, raw: str) -> None:
+        assert self._engine(raw).version is None
+
+    def test_version_is_none_for_failed_command(self) -> None:
+        engine = self._engine("", returncode=125, stderr="podman unavailable")
+        assert engine.version is None
+
+    @pytest.mark.parametrize("raw", ["4.0.0", "4.9.3", "5.8.4"])
+    def test_guard_accepts_supported_podman(self, raw: str) -> None:
+        engine = self._engine(json.dumps({"Client": {"Version": raw}}))
+        engine.ensure_supported_networking()
+
+    def test_guard_rejects_podman_3_with_actionable_message(self) -> None:
+        engine = self._engine(json.dumps({"Client": {"Version": "3.4.4"}}))
+        with pytest.raises(UnsupportedEngineError, match=r"3\.4\.4.*4\.0"):
+            engine.ensure_supported_networking()
+
+    def test_guard_fails_closed_with_command_diagnostic(self) -> None:
+        engine = self._engine("", returncode=125, stderr="connection refused")
+        with pytest.raises(
+            UnsupportedEngineError,
+            match=r"podman version --format json.*exit 125: connection refused",
+        ):
+            engine.ensure_supported_networking()
+
+    def test_guard_wraps_transport_failure(self) -> None:
+        transport = MagicMock()
+        transport.run.side_effect = OSError("podman not found")
+        engine = ContainerEngine("podman", transport=transport)
+        with pytest.raises(
+            UnsupportedEngineError,
+            match=r"podman version --format json.*command failed: podman not found",
+        ):
+            engine.ensure_supported_networking()
+
+    def test_guard_never_probes_docker(self) -> None:
+        engine = ContainerEngine("docker", transport=FakeTransport())
+        engine.ensure_supported_networking()
+        assert recorded_commands(engine) == []
 
 
 class TestContainerEngineRun:

--- a/tests/test_podman_proxy.py
+++ b/tests/test_podman_proxy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -23,7 +24,9 @@ from paude.backends.podman.proxy import (
 )
 from paude.backends.podman.proxy_credentials import PreparedProxyCredentials
 from paude.backends.proxy_config import ProxyCredentials, derive_agent_ip
+from paude.container.engine import UnsupportedEngineError
 from paude.container.proxy_runner import ProxyStartError
+from tests.fakes import FakeTransport, make_engine, make_runner, recorded_commands
 
 
 def _make_mock_runner(engine_binary: str = "podman") -> MagicMock:
@@ -252,6 +255,78 @@ class TestProxyManagerFixedIp:
         net_indices = [i for i, a in enumerate(call_args) if a == "--network"]
         assert len(net_indices) == 2
         assert "ip=172.28.0.2" in call_args[net_indices[0] + 1]
+
+
+class TestPodmanVersionGuard:
+    """Unsupported Podman versions fail before proxy resource mutation."""
+
+    @staticmethod
+    def _runner() -> MagicMock:
+        result = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"Client":{"Version":"3.4.4"}}',
+            stderr="",
+        )
+        transport = FakeTransport(results={"version --format json": result})
+        return make_runner(make_engine("podman", transport=transport))
+
+    def test_create_proxy_refuses_before_mutation(self) -> None:
+        runner = self._runner()
+        network = MagicMock()
+        manager = PodmanProxyManager(runner, network)
+
+        with pytest.raises(UnsupportedEngineError, match="Podman 3.4.4"):
+            manager.create_proxy("test-session", "proxy:latest", ["example.com"])
+
+        network.create_internal_network.assert_not_called()
+        assert recorded_commands(runner.engine) == [
+            ["podman", "version", "--format", "json"]
+        ]
+
+    def test_start_if_needed_refuses_before_start(self) -> None:
+        runner = self._runner()
+        runner.container_exists.return_value = True
+        runner.container_running.return_value = False
+        manager = PodmanProxyManager(runner, MagicMock())
+
+        with pytest.raises(UnsupportedEngineError):
+            manager.start_if_needed("test-session")
+
+        assert recorded_commands(runner.engine) == [
+            ["podman", "version", "--format", "json"]
+        ]
+
+    def test_recreate_refuses_before_network_or_volume_mutation(self) -> None:
+        runner = self._runner()
+        runner.container_exists.return_value = False
+        network = MagicMock()
+        manager = PodmanProxyManager(runner, network)
+
+        with (
+            patch.object(
+                manager,
+                "get_config_from_labels",
+                return_value=("proxy:latest", ["example.com"], [], []),
+            ),
+            pytest.raises(UnsupportedEngineError),
+        ):
+            manager.start_if_needed("test-session")
+
+        network.create_internal_network.assert_not_called()
+
+    def test_update_domains_refuses_before_swap(self) -> None:
+        runner = self._runner()
+        runner.container_exists.return_value = True
+        runner.get_container_image.return_value = "proxy:latest"
+        manager = PodmanProxyManager(runner, MagicMock())
+
+        with pytest.raises(UnsupportedEngineError):
+            manager.update_domains("test-session", ["example.com"])
+
+        assert recorded_commands(runner.engine) == [
+            ["podman", "version", "--format", "json"]
+        ]
 
 
 class TestResolveProxyIpGuard:


### PR DESCRIPTION
Probe and cache the effective Podman server version before proxy resource mutations, failing closed below 4.0 or on unknown output.

Run Podman CI on Ubuntu 24.04 and document and test the supported runtime floor so older CNI engines cannot silently bypass isolation.